### PR TITLE
Use relative paths for assets on GitHub Pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,11 +17,11 @@
   <meta property="og:image" content="https://anakainisou.gr/images/hero.webp" />
 
   <!-- Favicon -->
-  <link rel="icon" href="/images/favicon.svg" type="image/svg+xml" />
+  <link rel="icon" href="images/favicon.svg" type="image/svg+xml" />
 
   <!-- CSS -->
-  <link rel="preload" href="/assets/style.css" as="style" />
-  <link rel="stylesheet" href="/assets/style.css" />
+  <link rel="preload" href="assets/style.css" as="style" />
+  <link rel="stylesheet" href="assets/style.css" />
 
   <!-- Canonical -->
   <link rel="canonical" href="https://anakainisou.gr/" />
@@ -90,7 +90,7 @@
   <header class="site-header" id="top">
     <div class="container header-inner">
       <a class="brand" href="#top" aria-label="FM Renovation – Αρχική">
-        <img src="/images/logo-fm-renovation.svg" alt="FM Renovation λογότυπο" width="140" height="28">
+        <img src="images/logo-fm-renovation.svg" alt="FM Renovation λογότυπο" width="140" height="28">
       </a>
       <button class="nav-toggle" aria-expanded="false" aria-controls="site-nav" aria-label="Άνοιγμα μενού">☰</button>
       <nav id="site-nav" class="nav">
@@ -117,7 +117,7 @@
           </div>
         </div>
         <figure class="hero-media">
-          <img src="/images/hero.webp" alt="Σύγχρονη ανακαίνιση εσωτερικού χώρου" width="1200" height="800" loading="eager" fetchpriority="high">
+          <img src="images/hero.webp" alt="Σύγχρονη ανακαίνιση εσωτερικού χώρου" width="1200" height="800" loading="eager" fetchpriority="high">
         </figure>
       </div>
     </section>
@@ -203,17 +203,17 @@
       <div class="container">
         <h2>Gallery έργων</h2>
         <div class="grid gallery">
-          <a href="/images/project-1.webp" class="glightbox" data-title="Ανακαίνιση διαμερίσματος – Σαλόνι">
-            <img src="/images/project-1.webp" alt="Ανακαίνιση διαμερίσματος – Σαλόνι" loading="lazy" width="600" height="400" />
+          <a href="images/project-1.webp" class="glightbox" data-title="Ανακαίνιση διαμερίσματος – Σαλόνι">
+            <img src="images/project-1.webp" alt="Ανακαίνιση διαμερίσματος – Σαλόνι" loading="lazy" width="600" height="400" />
           </a>
-          <a href="/images/project-2.webp" class="glightbox" data-title="Ανακαίνιση μπάνιου – Minimal">
-            <img src="/images/project-2.webp" alt="Ανακαίνιση μπάνιου – Minimal" loading="lazy" width="600" height="400" />
+          <a href="images/project-2.webp" class="glightbox" data-title="Ανακαίνιση μπάνιου – Minimal">
+            <img src="images/project-2.webp" alt="Ανακαίνιση μπάνιου – Minimal" loading="lazy" width="600" height="400" />
           </a>
-          <a href="/images/project-3.webp" class="glightbox" data-title="Ανακαίνιση κουζίνας – Λευκή/ξύλο">
-            <img src="/images/project-3.webp" alt="Ανακαίνιση κουζίνας – Λευκή/ξύλο" loading="lazy" width="600" height="400" />
+          <a href="images/project-3.webp" class="glightbox" data-title="Ανακαίνιση κουζίνας – Λευκή/ξύλο">
+            <img src="images/project-3.webp" alt="Ανακαίνιση κουζίνας – Λευκή/ξύλο" loading="lazy" width="600" height="400" />
           </a>
-          <a href="/images/project-4.webp" class="glightbox" data-title="Επαγγελματικός χώρος – Γραφείο">
-            <img src="/images/project-4.webp" alt="Επαγγελματικός χώρος – Γραφείο" loading="lazy" width="600" height="400" />
+          <a href="images/project-4.webp" class="glightbox" data-title="Επαγγελματικός χώρος – Γραφείο">
+            <img src="images/project-4.webp" alt="Επαγγελματικός χώρος – Γραφείο" loading="lazy" width="600" height="400" />
           </a>
         </div>
       </div>
@@ -267,6 +267,6 @@
     </div>
   </footer>
 
-  <script src="/assets/script.js" defer></script>
+  <script src="assets/script.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace root-absolute asset and image URLs in `index.html` with paths relative to the project

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ebe1367f70832095869d1086301dc0