### PR TITLE
Restore original logo asset

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="assets/style.css">
-  <link rel="icon" href="images/logo-fm-renovation.svg" type="image/svg+xml">
+  <link rel="icon" href="logo.png" type="image/png">
   <meta property="og:type" content="website">
   <meta property="og:locale" content="el_GR">
   <meta property="og:title" content="FM Renovation – Ανακαινίσεις">
@@ -23,7 +23,7 @@
     "name":"FM Renovation – Ανακαινίσου.gr",
     "url":"https://anakainisou.gr/",
     "image":"https://images.unsplash.com/photo-1505691723518-36a5ac3b2d55?q=80&w=1600&auto=format&fit=crop",
-    "logo":"https://anakainisou.gr/images/logo-fm-renovation.svg",
+    "logo":"https://anakainisou.gr/logo.png",
     "description":"Ολοκληρωμένες λύσεις ανακαίνισης για κατοικίες & επαγγελματικούς χώρους.",
     "address":{"@type":"PostalAddress","addressLocality":"Αθήνα","addressCountry":"GR"},
     "telephone":"+30 210 0000000",
@@ -35,7 +35,7 @@
   <header class="site-header" id="top">
     <div class="container header-inner">
       <a class="brand" href="#top" aria-label="FM Renovation – Αρχική">
-        <img src="images/logo-fm-renovation.svg" alt="FM Renovation" width="150" height="32">
+        <img src="logo.png" alt="FM Renovation" width="75" height="16">
       </a>
       <button class="nav-toggle" aria-expanded="false" aria-controls="site-nav" aria-label="Μενού">☰</button>
       <nav id="site-nav" class="nav">


### PR DESCRIPTION
## Summary
- restore the original high-resolution `logo.png` asset
- remove the duplicate `images/logo.png` file and update references to use the root logo

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68ebfb8c0c548320a5d5375dc690ed9e