### PR TITLE
Fix header brand logo rendering

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,7 +35,10 @@ n
   <header class="site-header" id="top">
     <div class="container header-inner">
       <a class="brand" href="#top" aria-label="FM Renovation – Αρχική">
-n
+        <picture>
+          <source srcset="images/logo-fm-renovation.svg" type="image/svg+xml">
+          <img class="brand-logo" src="images/logo.png" alt="FM Renovation">
+        </picture>
       </a>
       <button class="nav-toggle" aria-expanded="false" aria-controls="site-nav" aria-label="Μενού">☰</button>
       <nav id="site-nav" class="nav">


### PR DESCRIPTION
## Summary
- embed the FM Renovation logo inside the header brand link using the existing SVG/PNG assets

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68ec1eb2715883209d7399e893f34ab5