### PR TITLE
Add hover text shadow for navigation menu links

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -27,7 +27,8 @@ img{max-width:100%;height:auto;display:block}
 .brand-logo{height:72px;width:auto;display:block}
 .nav{display:flex;gap:18px;align-items:center;margin-left:auto}
 .nav a{color:var(--text);text-decoration:none;opacity:.9;transition:color .2s ease, text-shadow .2s ease, opacity .2s ease}
-.nav a:hover{opacity:1;color:var(--accent);text-shadow:0 2px 12px rgba(245,158,11,.35)}
+.nav a:hover,
+.nav a:focus-visible{opacity:1;color:var(--accent);text-shadow:0 3px 14px rgba(15,23,42,.35)}
 .nav-toggle{display:none;background:none;border:1px solid #d8dee9;color:var(--text);padding:6px 10px;border-radius:10px}
 .social{display:flex;gap:10px;margin-left:12px}
 .icon{width:28px;height:28px;display:inline-block;background:var(--text);mask-size:cover;-webkit-mask-size:cover;opacity:.85}


### PR DESCRIPTION
## Summary
- enhance navigation link hover styling with a darker text shadow for better legibility
- extend the hover styling to focus-visible state for improved accessibility

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68ec2f2af38c83208d6baf35df54fcfb