### PR TITLE
Update navigation labels for about and gallery

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,11 +39,11 @@ n
       </a>
       <button class="nav-toggle" aria-expanded="false" aria-controls="site-nav" aria-label="Μενού">☰</button>
       <nav id="site-nav" class="nav">
-        <a href="#about">Σχετικά</a>
+        <a href="#about">Η Εταιρεία</a>
         <a href="#services">Υπηρεσίες</a>
         <a href="#reasons">Γιατί εμείς</a>
         <a href="#process">Διαδικασία</a>
-        <a href="#gallery">Gallery</a>
+        <a href="#gallery">Έργα</a>
         <a href="#reviews">Μαρτυρίες</a>
         <a href="#contact" class="btn btn--sm">Ζητήστε Προσφορά</a>
       </nav>


### PR DESCRIPTION
## Summary
- update the header navigation link to refer to the about section as "Η Εταιρεία"
- rename the gallery navigation entry to "Έργα"

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ec36df5ef083208848953a79a63e83