### PR TITLE
Remove stray character from header

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,6 @@
   <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="assets/style.css">
-n
   <meta property="og:type" content="website">
   <meta property="og:locale" content="el_GR">
   <meta property="og:title" content="FM Renovation – Ανακαινίσεις">


### PR DESCRIPTION
## Summary
- remove stray character from the document head that appeared in the site header

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ec38f8e7fc8320bcc08169ed5fc293