### PR TITLE
Refactor styles to make layout mobile-first

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -15,22 +15,23 @@ html{scroll-behavior:smooth}
 body{margin:0;font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;color:var(--text);background:var(--bg)}
 img{max-width:100%;height:auto;display:block}
 .container{max-width:var(--maxw);margin-inline:auto;padding:0 20px}
-.section{padding:72px 0}
+.section{padding:56px 0}
 .section--muted{background:var(--bg-soft)}
 .section--cta{background:linear-gradient(180deg,#FFFFFF 0%, #F5F7FA 100%)}
 .lead{opacity:.9;font-size:1.125rem}
 
 /* Header */
-.site-header{position:sticky;top:0;z-index:50;background:rgba(245,247,250,.9);backdrop-filter:saturate(150%) blur(8px);border-bottom:1px solid #e9eef5}
-.header-inner{display:flex;align-items:center;gap:16px;padding:12px 0}
+.site-header{position:sticky;top:0;z-index:50;background:rgba(245,247,250,.92);backdrop-filter:saturate(150%) blur(8px);border-bottom:1px solid #e9eef5}
+.header-inner{display:flex;align-items:center;gap:12px;padding:12px 0;flex-wrap:wrap}
 .brand{display:inline-flex;align-items:center;text-decoration:none;color:inherit}
-.brand-logo{height:72px;width:auto;display:block}
-.nav{display:flex;gap:18px;align-items:center;margin-left:auto}
+.brand-logo{height:60px;width:auto;display:block}
+.nav{display:none;position:fixed;inset:72px 16px auto 16px;background:#fff;border:1px solid #e8edf4;border-radius:14px;padding:12px;flex-direction:column;gap:12px;box-shadow:var(--shadow);z-index:60}
 .nav a{color:var(--text);text-decoration:none;opacity:.9;transition:color .2s ease, text-shadow .2s ease, opacity .2s ease}
 .nav a:hover,
 .nav a:focus-visible{opacity:1;color:var(--accent);text-shadow:0 3px 14px rgba(15,23,42,.35)}
-.nav-toggle{display:none;background:none;border:1px solid #d8dee9;color:var(--text);padding:6px 10px;border-radius:10px}
-.social{display:flex;gap:10px;margin-left:12px}
+.nav.open{display:flex}
+.nav-toggle{display:inline-flex;background:none;border:1px solid #d8dee9;color:var(--text);padding:6px 10px;border-radius:10px;align-items:center;justify-content:center}
+.social{display:flex;gap:10px;margin-left:auto}
 .icon{width:28px;height:28px;display:inline-block;background:var(--text);mask-size:cover;-webkit-mask-size:cover;opacity:.85;transition:background .2s ease,opacity .2s ease}
 .icon:hover{opacity:1;background:#f59f0b}
 .fb{mask-image:url('../images/facebooklogo.svg');-webkit-mask-image:url('../images/facebooklogo.svg')}
@@ -46,36 +47,37 @@ img{max-width:100%;height:auto;display:block}
 .under-cta{text-align:center;margin-top:18px}
 
 /* Hero */
-.hero{position:relative;padding:140px 0;min-height:520px;color:#fff;overflow:hidden;background:#0f172a}
+.hero{position:relative;padding:100px 0 96px;min-height:460px;color:#fff;overflow:hidden;background:#0f172a}
 .hero::before{content:"";position:absolute;inset:0;background:linear-gradient(120deg,rgba(15,23,42,.88) 0%,rgba(30,41,59,.6) 52%,rgba(30,64,175,.25) 100%);z-index:1}
 .hero-slider{position:absolute;inset:0;margin:0;z-index:0}
 .hero-slider img{position:absolute;inset:0;width:100%;height:100%;object-fit:cover;opacity:0;transition:opacity .6s ease}
 .hero-slider img.active{opacity:1}
-.hero-inner{position:relative;z-index:2;display:flex;flex-direction:column;align-items:flex-start;gap:20px;max-width:var(--maxw);margin-inline:auto;padding:0 20px}
+.hero-inner{position:relative;z-index:2;display:flex;flex-direction:column;align-items:flex-start;gap:20px;max-width:var(--maxw);margin-inline:auto;padding:0 16px}
 .hero-copy{max-width:560px;display:grid;gap:16px}
-.hero h1{font-size:clamp(30px,3.6vw,50px);line-height:1.05;margin:0}
+.hero h1{font-size:clamp(28px,7vw,48px);line-height:1.05;margin:0}
 .hero .lead{opacity:.92;color:inherit}
-.cta-group{display:flex;flex-wrap:wrap;gap:12px}
+.cta-group{display:flex;flex-direction:column;gap:12px;width:100%}
+.cta-group .btn{width:100%;justify-content:center}
 .hero .btn{border-color:rgba(255,255,255,.35)}
 .hero .btn--ghost{background:rgba(255,255,255,.12);color:#fff}
 
 /* About */
-.about-grid{display:grid;grid-template-columns:1.2fr .8fr;gap:20px}
+.about-grid{display:grid;gap:20px}
 .about-card{background:var(--card);border:1px solid #e8edf4;border-radius:16px;padding:20px;box-shadow:var(--shadow)}
 .bullets{padding-left:18px}
 
 /* Services */
 .grid{display:grid;gap:16px}
-.services{grid-template-columns:repeat(3,1fr)}
+.services{grid-template-columns:minmax(0,1fr)}
 .card{background:var(--card);padding:20px;border:1px solid #e8edf4;border-radius:16px;transition:transform .2s, box-shadow .2s}
 .card:hover,.card:focus-within{transform:translateY(-4px) scale(1.01);box-shadow:0 12px 28px rgba(0,0,0,.08)}
 .card .link{display:inline-block;margin-top:6px;text-decoration:none;color:var(--accent-2)}
 
 /* Reasons & Process */
-.two-col{display:grid;grid-template-columns:1fr 1fr;gap:28px}
+.two-col{display:grid;gap:28px}
 .reasons{list-style:none;padding:0;display:grid;gap:10px}
 .reasons li{background:#fff;border:1px solid #e8edf4;border-radius:12px;padding:12px}
-.process .steps{display:grid;grid-template-columns:repeat(4,1fr);gap:10px;margin-bottom:8px}
+.process .steps{display:grid;grid-template-columns:minmax(0,1fr);gap:10px;margin-bottom:8px}
 .step{background:#fff;border:1px solid #e8edf4;border-radius:12px;padding:12px;cursor:pointer;text-align:left;display:flex;gap:10px;align-items:center}
 .step span{display:inline-grid;place-items:center;width:28px;height:28px;border-radius:50%;background:var(--accent);color:#111;font-weight:700}
 .step[aria-current="true"]{outline:2px solid var(--accent)}
@@ -83,17 +85,17 @@ img{max-width:100%;height:auto;display:block}
 
 /* Carousel */
 .carousel{position:relative}
-.car-track{display:grid;grid-auto-flow:column;grid-auto-columns:80%;gap:12px;overflow-x:auto;scroll-snap-type:x mandatory;padding-bottom:6px}
+.car-track{display:grid;grid-auto-flow:column;grid-auto-columns:88%;gap:12px;overflow-x:auto;scroll-snap-type:x mandatory;padding-bottom:6px}
 .car-track img{scroll-snap-align:center;border-radius:14px;border:1px solid #e8edf4;box-shadow:var(--shadow);height:340px;object-fit:cover}
 .car-btn{position:absolute;top:45%;transform:translateY(-50%);border:none;background:#fff;border:1px solid #e8edf4;border-radius:999px;width:38px;height:38px;cursor:pointer;box-shadow:var(--shadow)}
 .prev{left:-6px}.next{right:-6px}
 
 /* Testimonials */
-.testimonials{display:grid;grid-auto-flow:column;grid-auto-columns:32ch;gap:14px;overflow-x:auto;scroll-snap-type:x mandatory}
+.testimonials{display:grid;grid-auto-flow:column;grid-auto-columns:85%;gap:14px;overflow-x:auto;scroll-snap-type:x mandatory}
 .t-card{scroll-snap-align:start;background:#fff;border:1px solid #e8edf4;border-radius:14px;padding:16px;box-shadow:var(--shadow)}
 
 /* Contact + Map */
-.contact{display:grid;grid-template-columns:1fr 1fr;gap:28px;align-items:start}
+.contact{display:grid;grid-template-columns:minmax(0,1fr);gap:28px;align-items:start}
 .form{display:grid;gap:12px;background:#fff;border:1px solid #e8edf4;border-radius:14px;padding:16px;box-shadow:var(--shadow)}
 .form input,.form textarea{width:100%;padding:12px 14px;border:1px solid #dfe6ef;border-radius:10px}
 .form input:focus,.form textarea:focus{outline:2px solid var(--accent)}
@@ -101,31 +103,49 @@ img{max-width:100%;height:auto;display:block}
 
 /* Footer */
 .site-footer{border-top:1px solid #e8edf4;padding:20px 0;background:#fff}
-.footer-inner{display:flex;align-items:center;gap:12px;flex-wrap:wrap}
+.footer-inner{display:flex;flex-direction:column;align-items:flex-start;gap:14px}
 .brand--footer{margin-right:auto}
-.brand--footer .brand-logo{height:56px}
-.footer-nav{display:flex;gap:14px}
+.brand--footer .brand-logo{height:48px}
+.footer-nav{display:flex;gap:14px;flex-wrap:wrap}
 .footer-nav a{text-decoration:none;color:var(--text);opacity:.9}
 .site-footer .social{margin-left:0}
 
 /* Responsive */
-@media (max-width: 990px){
-  .hero{padding:120px 0}
-  .hero-inner{align-items:flex-start}
-  .about-grid,.two-col,.contact{grid-template-columns:1fr}
-  .services{grid-template-columns:repeat(2,1fr)}
-  .process .steps{grid-template-columns:repeat(2,1fr)}
-  .car-track{grid-auto-columns:88%}
+@media (min-width: 520px){
+  .cta-group{flex-direction:row;flex-wrap:wrap;width:auto}
+  .cta-group .btn{width:auto}
 }
-@media (max-width: 640px){
-  .nav-toggle{display:inline-flex}
-  .nav{position:fixed;inset:60px 12px auto 12px;background:#fff;border:1px solid #e8edf4;border-radius:14px;padding:12px;display:none;flex-direction:column;box-shadow:var(--shadow)}
-  .nav.open{display:flex}
-  .brand-logo{height:60px}
-  .hero{padding:110px 0 100px}
-  .hero-inner{padding:0 16px;align-items:flex-start}
-  .hero h1{font-size:clamp(28px,7vw,42px)}
-  .cta-group{width:100%}
-  .cta-group .btn{flex:1 1 auto;justify-content:center}
-  .footer-inner{flex-direction:column;align-items:flex-start}
+
+@media (min-width: 640px){
+  .brand-logo{height:68px}
+  .services{grid-template-columns:repeat(2,minmax(0,1fr))}
+  .process .steps{grid-template-columns:repeat(2,minmax(0,1fr))}
+  .testimonials{grid-auto-columns:60%}
+}
+
+@media (min-width: 768px){
+  .header-inner{flex-wrap:nowrap}
+  .nav{position:static;display:flex;flex-direction:row;align-items:center;margin-left:auto;padding:0;border:none;box-shadow:none;background:transparent;gap:18px}
+  .nav-toggle{display:none}
+  .cta-group{width:auto}
+  .social{margin-left:12px}
+  .hero{padding:120px 0}
+  .hero-inner{padding:0 20px}
+  .car-track{grid-auto-columns:70%}
+  .testimonials{grid-auto-columns:32ch}
+  .footer-inner{flex-direction:row;align-items:center}
+  .brand--footer .brand-logo{height:56px}
+}
+
+@media (min-width: 900px){
+  .section{padding:72px 0}
+  .two-col{grid-template-columns:1fr 1fr}
+  .process .steps{grid-template-columns:repeat(4,minmax(0,1fr))}
+  .contact{grid-template-columns:1fr 1fr}
+  .car-track{grid-auto-columns:60%}
+}
+
+@media (min-width: 1040px){
+  .services{grid-template-columns:repeat(3,minmax(0,1fr))}
+  .hero{padding:140px 0}
 }


### PR DESCRIPTION
## Summary
- restructure the base styles to prioritize small screens with mobile-first defaults
- update header navigation, hero CTAs, and core grid sections for improved readability on phones
- refresh responsive breakpoints for services, process, testimonials, contact, and footer layouts

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68ec3b39a8e483208576a51f3c14f566