### PR TITLE
Add responsive overlay navigation menu

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -1,7 +1,87 @@
-// Mobile nav toggle
+const header=document.querySelector('.site-header');
 const toggle=document.querySelector('.nav-toggle');
-const nav=document.getElementById('site-nav');
-if(toggle&&nav){toggle.addEventListener('click',()=>{const open=nav.classList.toggle('open');toggle.setAttribute('aria-expanded',String(open));});}
+const overlay=document.getElementById('mobile-overlay');
+const backdrop=document.querySelector('[data-backdrop]');
+const focusableSel='a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])';
+let lastFocused=null;
+
+// sticky header σκιά
+let lastY=0;
+window.addEventListener('scroll',()=>{
+  const y=window.scrollY||0;
+  if(y>4 && lastY<=4) header?.classList.add('is-scrolled');
+  else if(y<=4 && lastY>4) header?.classList.remove('is-scrolled');
+  lastY=y;
+});
+
+function openMenu(){
+  lastFocused=document.activeElement;
+  toggle.setAttribute('aria-expanded','true');
+  overlay.setAttribute('aria-hidden','false');
+  backdrop.hidden=false;
+  requestAnimationFrame(()=>backdrop.classList.add('is-visible'));
+  document.body.style.overflow='hidden';
+  // focus trap
+  const first=overlay.querySelectorAll(focusableSel)[0];
+  first?.focus();
+}
+
+function closeMenu(){
+  toggle.setAttribute('aria-expanded','false');
+  overlay.setAttribute('aria-hidden','true');
+  backdrop.classList.remove('is-visible');
+  setTimeout(()=>{backdrop.hidden=true;},280);
+  document.body.style.overflow='';
+  lastFocused?.focus();
+}
+
+toggle?.addEventListener('click',()=>{
+  const expanded=toggle.getAttribute('aria-expanded')==='true';
+  expanded?closeMenu():openMenu();
+});
+
+backdrop?.addEventListener('click',closeMenu);
+document.addEventListener('keydown',(e)=>{
+  if(e.key==='Escape' && overlay.getAttribute('aria-hidden')==='false') closeMenu();
+  if(e.key==='Tab' && overlay.getAttribute('aria-hidden')==='false'){
+    const f=[...overlay.querySelectorAll(focusableSel)];
+    if(!f.length) return;
+    const first=f[0], last=f[f.length-1];
+    if(e.shiftKey && document.activeElement===first){ last.focus(); e.preventDefault(); }
+    else if(!e.shiftKey && document.activeElement===last){ first.focus(); e.preventDefault(); }
+  }
+});
+
+// Desktop submenu (Υπηρεσίες): ανοίγει με hover/focus ήδη από CSS. Πρόσθεσε keyboard support:
+document.querySelectorAll('.has-submenu .submenu-toggle')?.forEach(btn=>{
+  const panel=btn.parentElement.querySelector('.submenu');
+  btn.addEventListener('click',(e)=>{ e.preventDefault(); const exp=btn.getAttribute('aria-expanded')==='true'; btn.setAttribute('aria-expanded', String(!exp)); panel.style.display=exp?'':'grid'; });
+  btn.addEventListener('keydown',(e)=>{ if(e.key==='Escape'){ btn.setAttribute('aria-expanded','false'); panel.style.display=''; btn.focus(); }});
+  panel?.addEventListener('mouseleave',()=>{ btn.setAttribute('aria-expanded','false'); panel.style.display=''; });
+  panel?.addEventListener('focusout',(event)=>{
+    if(!panel.contains(event.relatedTarget)){
+      btn.setAttribute('aria-expanded','false');
+      panel.style.display='';
+    }
+  });
+});
+
+// Mobile accordion submenus
+document.querySelectorAll('.overlay-accordion')?.forEach(btn=>{
+  const panel=document.getElementById(btn.getAttribute('aria-controls'));
+  btn.addEventListener('click',()=>{
+    const exp=btn.getAttribute('aria-expanded')==='true';
+    btn.setAttribute('aria-expanded', String(!exp));
+    if(exp){ panel.hidden=true; }
+    else { panel.hidden=false; panel.querySelector(focusableSel)?.focus(); }
+  });
+});
+
+overlay?.querySelectorAll('a').forEach(link=>{
+  link.addEventListener('click',()=>{
+    if(toggle?.getAttribute('aria-expanded')==='true') closeMenu();
+  });
+});
 
 // Footer year
 const y=document.getElementById('year'); if(y) y.textContent=new Date().getFullYear();

--- a/assets/style.css
+++ b/assets/style.css
@@ -149,3 +149,62 @@ img{max-width:100%;height:auto;display:block}
   .services{grid-template-columns:repeat(3,minmax(0,1fr))}
   .hero{padding:140px 0}
 }
+/* NAV (overlay) */
+.site-header{position:sticky;top:0;z-index:50;background:rgba(255,255,255,.9);backdrop-filter:saturate(140%) blur(8px);border-bottom:1px solid #e9eef5;transition:box-shadow .2s}
+.site-header.is-scrolled{box-shadow:0 6px 18px rgba(0,0,0,.06)}
+.header-inner{display:flex;align-items:center;gap:16px;padding:12px 0}
+.brand{display:inline-flex;align-items:center;text-decoration:none;color:inherit}
+.nav{display:flex;gap:18px;align-items:center;margin-left:auto}
+.nav a{text-decoration:none;color:#0F172A;opacity:.9}
+.nav a:hover{opacity:1}
+
+/* Submenu (desktop) */
+.has-submenu{position:relative}
+.submenu-toggle{display:inline-flex;align-items:center;gap:6px;background:transparent;border:0;color:#0F172A;cursor:pointer;opacity:.9}
+.submenu-toggle:hover{opacity:1}
+.submenu{position:absolute;top:calc(100% + 8px);left:0;background:#fff;border:1px solid #e8edf4;border-radius:12px;box-shadow:0 12px 28px rgba(0,0,0,.08);padding:8px;min-width:240px;display:none}
+.has-submenu:focus-within .submenu,
+.has-submenu:hover .submenu{display:grid}
+.submenu a{padding:10px 12px;border-radius:10px;text-decoration:none;color:#0F172A}
+.submenu a:hover{background:#F5F7FA}
+.chev{font-size:.9em}
+
+/* Hamburger button */
+.nav-toggle{display:none;position:relative;width:44px;height:44px;border:1px solid #e0e6ee;border-radius:12px;background:#fff;cursor:pointer;margin-left:auto}
+.nav-toggle .bar{position:absolute;left:10px;right:10px;height:2px;background:#0F172A;transition:transform .25s ease, opacity .2s}
+.nav-toggle .bar:nth-child(1){top:14px}
+.nav-toggle .bar:nth-child(2){top:21px}
+.nav-toggle .bar:nth-child(3){top:28px}
+.nav-toggle[aria-expanded="true"] .bar:nth-child(1){transform:translateY(7px) rotate(45deg)}
+.nav-toggle[aria-expanded="true"] .bar:nth-child(2){opacity:0}
+.nav-toggle[aria-expanded="true"] .bar:nth-child(3){transform:translateY(-7px) rotate(-45deg)}
+
+/* Overlay (mobile) */
+.overlay{position:fixed;inset:0;min-height:100dvh;background:#fff;transform:translateY(-100%);opacity:0;transition:transform .28s ease, opacity .28s ease;z-index:60;display:flex}
+.overlay[aria-hidden="false"]{transform:translateY(0);opacity:1}
+.overlay-nav{display:flex;flex-direction:column;gap:10px;width:min(92vw,560px);margin:72px auto 16px;padding:0 16px}
+.overlay-nav a{text-decoration:none;color:#0F172A;padding:12px 10px;border-radius:12px;border:1px solid #e8edf4;background:#fff}
+.overlay-nav a:hover{background:#F5F7FA}
+.overlay-nav .btn.btn--primary{background:#F59E0B;color:#111;border-color:#f3c46b}
+
+/* Mobile submenu (accordion) */
+.overlay-group{display:block}
+.overlay-accordion{width:100%;display:flex;align-items:center;justify-content:space-between;gap:8px;background:#fff;border:1px solid #e8edf4;border-radius:12px;padding:12px 10px;color:#0F172A;cursor:pointer}
+.overlay-sub{display:grid;gap:8px;margin:6px 0 0 0}
+.overlay-sub a{margin-left:8px}
+
+/* Backdrop */
+.backdrop{position:fixed;inset:0;background:rgba(0,0,0,.45);z-index:55;opacity:0;transition:opacity .28s ease}
+.backdrop.is-visible{opacity:1}
+[hidden]{display:none !important}
+
+/* Responsive */
+@media (max-width:768px){
+  .nav{display:none}
+  .nav-toggle{display:inline-block}
+}
+
+/* reduced motion */
+@media (prefers-reduced-motion: reduce){
+  .overlay, .backdrop, .nav-toggle .bar{transition:none}
+}

--- a/index.html
+++ b/index.html
@@ -34,24 +34,70 @@
   <header class="site-header" id="top">
     <div class="container header-inner">
       <a class="brand" href="#top" aria-label="FM Renovation – Αρχική">
-        <img class="brand-logo" src="images/logo.png" alt="FM Renovation λογότυπο">
+        <img src="images/logo.png" alt="FM Renovation" width="150" height="32">
       </a>
-      <button class="nav-toggle" aria-expanded="false" aria-controls="site-nav" aria-label="Μενού">☰</button>
-      <nav id="site-nav" class="nav">
-        <a href="#about">Η Εταιρεία</a>
-        <a href="#services">Υπηρεσίες</a>
+
+      <!-- Desktop nav -->
+      <nav id="site-nav" class="nav" aria-label="Κύρια πλοήγηση">
+        <a href="#about">Σχετικά</a>
+
+        <!-- Υπηρεσίες με submenu -->
+        <div class="has-submenu">
+          <button class="submenu-toggle" aria-expanded="false" aria-controls="submenu-services">
+            Υπηρεσίες
+            <span class="chev" aria-hidden="true">▾</span>
+          </button>
+          <div id="submenu-services" class="submenu" role="menu">
+            <a role="menuitem" href="#services">Ανακαίνιση Κατοικίας</a>
+            <a role="menuitem" href="#services">Ανακαίνιση Μπάνιου</a>
+            <a role="menuitem" href="#services">Ανακαίνιση Κουζίνας</a>
+            <a role="menuitem" href="#services">Επαγγελματικοί Χώροι</a>
+            <a role="menuitem" href="#services">Ενεργειακή Αναβάθμιση</a>
+          </div>
+        </div>
+
         <a href="#reasons">Γιατί εμείς</a>
         <a href="#process">Διαδικασία</a>
-        <a href="#gallery">Έργα</a>
+        <a href="#gallery">Gallery</a>
         <a href="#reviews">Μαρτυρίες</a>
-        <a href="#contact" class="btn btn--sm">Ζητήστε Προσφορά</a>
+        <a href="#contact" class="btn btn--sm btn--primary">Ζητήστε Προσφορά</a>
       </nav>
-      <div class="social">
-        <a href="#" aria-label="Facebook" class="icon fb"></a>
-        <a href="#" aria-label="Instagram" class="icon ig"></a>
-      </div>
+
+      <!-- Hamburger button (mobile) -->
+      <button class="nav-toggle" aria-expanded="false" aria-controls="mobile-overlay" aria-label="Άνοιγμα μενού">
+        <span class="bar"></span><span class="bar"></span><span class="bar"></span>
+      </button>
     </div>
   </header>
+
+  <!-- Overlay menu (mobile) -->
+  <aside id="mobile-overlay" class="overlay" role="dialog" aria-modal="true" aria-hidden="true">
+    <nav class="overlay-nav" aria-label="Mobile πλοήγηση">
+      <a href="#about">Σχετικά</a>
+
+      <!-- Submenu ως accordion στο mobile -->
+      <div class="overlay-group">
+        <button class="overlay-accordion" aria-expanded="false" aria-controls="m-sub-services">
+          Υπηρεσίες
+          <span class="chev" aria-hidden="true">▾</span>
+        </button>
+        <div id="m-sub-services" class="overlay-sub" hidden>
+          <a href="#services">Ανακαίνιση Κατοικίας</a>
+          <a href="#services">Ανακαίνιση Μπάνιου</a>
+          <a href="#services">Ανακαίνιση Κουζίνας</a>
+          <a href="#services">Επαγγελματικοί Χώροι</a>
+          <a href="#services">Ενεργειακή Αναβάθμιση</a>
+        </div>
+      </div>
+
+      <a href="#reasons">Γιατί εμείς</a>
+      <a href="#process">Διαδικασία</a>
+      <a href="#gallery">Gallery</a>
+      <a href="#reviews">Μαρτυρίες</a>
+      <a href="#contact" class="btn btn--primary">Ζητήστε Προσφορά</a>
+    </nav>
+  </aside>
+  <div class="backdrop" data-backdrop hidden></div>
 
   <main>
     <!-- HERO: slider 5 εικόνες + CTA -->


### PR DESCRIPTION
## Summary
- replace the site header with a responsive navigation that supports desktop submenus and a mobile overlay
- style the sticky header, dropdown overlay, backdrop, and hamburger button with responsive breakpoints and reduced-motion support
- implement JavaScript for the hamburger toggle, focus trapping, scroll lock, escape handling, and submenu/accordion interactions

## Testing
- Manual: Verified the mobile overlay navigation opens, traps focus, and closes via backdrop and ESC while serving the site locally

------
https://chatgpt.com/codex/tasks/task_e_68ec3e0c8cf08320ad9ed5af95804dc2