### PR TITLE
Center header logo and adjust mobile nav toggle

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -22,16 +22,17 @@ img{max-width:100%;height:auto;display:block}
 
 /* Header */
 .site-header{position:sticky;top:0;z-index:50;background:rgba(245,247,250,.92);backdrop-filter:saturate(150%) blur(8px);border-bottom:1px solid #e9eef5}
-.header-inner{display:flex;align-items:center;gap:12px;padding:12px 0;flex-wrap:wrap}
-.brand{display:inline-flex;align-items:center;text-decoration:none;color:inherit}
+.header-inner{display:grid;align-items:center;gap:12px;padding:12px 0;grid-template-columns:auto 1fr auto}
+.brand{display:inline-flex;align-items:center;text-decoration:none;color:inherit;justify-self:center}
 .brand-logo{height:60px;width:auto;display:block}
+.header-right{display:flex;align-items:center;gap:12px;justify-self:end}
 .nav{display:none;position:fixed;inset:72px 16px auto 16px;background:#fff;border:1px solid #e8edf4;border-radius:14px;padding:12px;flex-direction:column;gap:12px;box-shadow:var(--shadow);z-index:60}
 .nav a{color:var(--text);text-decoration:none;opacity:.9;transition:color .2s ease, text-shadow .2s ease, opacity .2s ease}
 .nav a:hover,
 .nav a:focus-visible{opacity:1;color:var(--accent);text-shadow:0 3px 14px rgba(15,23,42,.35)}
 .nav.open{display:flex}
 .nav-toggle{display:inline-flex;background:none;border:1px solid #d8dee9;color:var(--text);padding:6px 10px;border-radius:10px;align-items:center;justify-content:center}
-.social{display:flex;gap:10px;margin-left:auto}
+.social{display:flex;gap:10px}
 .icon{width:28px;height:28px;display:inline-block;background:var(--text);mask-size:cover;-webkit-mask-size:cover;opacity:.85;transition:background .2s ease,opacity .2s ease}
 .icon:hover{opacity:1;background:#f59f0b}
 .fb{mask-image:url('../images/facebooklogo.svg');-webkit-mask-image:url('../images/facebooklogo.svg')}
@@ -124,8 +125,8 @@ img{max-width:100%;height:auto;display:block}
 }
 
 @media (min-width: 768px){
-  .header-inner{flex-wrap:nowrap}
-  .nav{position:static;display:flex;flex-direction:row;align-items:center;margin-left:auto;padding:0;border:none;box-shadow:none;background:transparent;gap:18px}
+  .header-inner{grid-template-columns:auto 1fr auto}
+  .nav{position:static;display:flex;flex-direction:row;align-items:center;padding:0;border:none;box-shadow:none;background:transparent;gap:18px}
   .nav-toggle{display:none}
   .cta-group{width:auto}
   .social{margin-left:12px}

--- a/index.html
+++ b/index.html
@@ -33,22 +33,24 @@
 <body>
   <header class="site-header" id="top">
     <div class="container header-inner">
+      <button class="nav-toggle" aria-expanded="false" aria-controls="site-nav" aria-label="Μενού">☰</button>
       <a class="brand" href="#top" aria-label="FM Renovation – Αρχική">
         <img class="brand-logo" src="images/logo.png" alt="FM Renovation λογότυπο">
       </a>
-      <button class="nav-toggle" aria-expanded="false" aria-controls="site-nav" aria-label="Μενού">☰</button>
-      <nav id="site-nav" class="nav">
-        <a href="#about">Η Εταιρεία</a>
-        <a href="#services">Υπηρεσίες</a>
-        <a href="#reasons">Γιατί εμείς</a>
-        <a href="#process">Διαδικασία</a>
-        <a href="#gallery">Έργα</a>
-        <a href="#reviews">Μαρτυρίες</a>
-        <a href="#contact" class="btn btn--sm">Ζητήστε Προσφορά</a>
-      </nav>
-      <div class="social">
-        <a href="#" aria-label="Facebook" class="icon fb"></a>
-        <a href="#" aria-label="Instagram" class="icon ig"></a>
+      <div class="header-right">
+        <nav id="site-nav" class="nav">
+          <a href="#about">Η Εταιρεία</a>
+          <a href="#services">Υπηρεσίες</a>
+          <a href="#reasons">Γιατί εμείς</a>
+          <a href="#process">Διαδικασία</a>
+          <a href="#gallery">Έργα</a>
+          <a href="#reviews">Μαρτυρίες</a>
+          <a href="#contact" class="btn btn--sm">Ζητήστε Προσφορά</a>
+        </nav>
+        <div class="social">
+          <a href="#" aria-label="Facebook" class="icon fb"></a>
+          <a href="#" aria-label="Instagram" class="icon ig"></a>
+        </div>
       </div>
     </div>
   </header>


### PR DESCRIPTION
## Summary
- center the site logo in the header while keeping the mobile menu button on the left
- update header layout styles to use a grid wrapper and consolidate navigation and social controls on the right

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ec3e58e67483208a480c91ec64fe09