### PR TITLE
Adjust hero CTA width on mobile

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -117,6 +117,11 @@ img{max-width:100%;height:auto;display:block}
   .cta-group .btn{width:auto}
 }
 
+@media (max-width: 519px){
+  .hero .cta-group{width:auto;align-items:flex-start}
+  .hero .cta-group .btn{width:auto;align-self:flex-start;justify-content:center;padding:12px 16px}
+}
+
 @media (min-width: 640px){
   .brand-logo{height:68px}
   .services{grid-template-columns:repeat(2,minmax(0,1fr))}


### PR DESCRIPTION
## Summary
- shrink hero CTA buttons on small screens so they match their text width
- align the mobile CTA group to the start for a more compact look

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ec4115ee1c8320bbe50a1a52b37fd7