### PR TITLE
Hide mobile header social icons

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -55,7 +55,7 @@ img{max-width:100%;height:auto;display:block}
 .nav-item--has-submenu.is-open .submenu,
 .nav-item--has-submenu:hover .submenu,
 .nav-item--has-submenu:focus-within .submenu{opacity:1;visibility:visible;pointer-events:auto;transform:translate(-50%,0)}
-.social{display:flex;gap:10px;margin-left:auto}
+.social{display:flex;gap:10px}
 .icon{width:28px;height:28px;display:inline-block;background:var(--text);mask-size:cover;-webkit-mask-size:cover;opacity:.85;transition:background .2s ease,opacity .2s ease}
 .icon:hover,.icon:focus-visible{opacity:1;background:#f59f0b;outline:none}
 .fb{mask-image:url('../images/facebooklogo.svg');-webkit-mask-image:url('../images/facebooklogo.svg')}
@@ -186,6 +186,12 @@ body.nav-open{overflow:hidden}
   .services{grid-template-columns:repeat(2,minmax(0,1fr))}
   .process .steps{grid-template-columns:repeat(2,minmax(0,1fr))}
   .testimonials{grid-auto-columns:60%}
+}
+
+@media (max-width: 767px){
+  .header-inner{flex-wrap:nowrap}
+  .nav-toggle{margin-left:auto}
+  .site-header .social{display:none}
 }
 
 @media (min-width: 768px){


### PR DESCRIPTION
## Summary
- hide the header social icons on small screens while keeping the menu toggle aligned right

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ed754ef3088320bb242f12d2f31aa5