### PR TITLE
Adjust mobile menu overlay to respect header height

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -4,10 +4,22 @@ const navToggle=document.querySelector('[data-nav-toggle]');
 const navOverlay=document.getElementById('mobile-menu');
 const navBackdrop=document.querySelector('[data-nav-backdrop]');
 const navClose=document.querySelector('[data-nav-close]');
+const siteHeader=document.querySelector('.site-header');
 const desktopMedia=window.matchMedia('(min-width: 768px)');
 const prefersReducedMotion=window.matchMedia('(prefers-reduced-motion: reduce)');
 const focusableSelectors="a[href]:not([tabindex='-1']), button:not([disabled]):not([tabindex='-1']), [tabindex]:not([tabindex='-1'])";
 let menuOpen=false;
+
+function updateHeaderHeight(){
+  if(!siteHeader){return;}
+  const headerHeight=siteHeader.offsetHeight;
+  document.documentElement.style.setProperty('--header-h', headerHeight+'px');
+}
+
+updateHeaderHeight();
+window.addEventListener('load',updateHeaderHeight);
+window.addEventListener('resize',updateHeaderHeight);
+window.addEventListener('orientationchange',updateHeaderHeight);
 
 const mobileParent=document.querySelector('[data-mobile-parent]');
 const mobileItem=mobileParent?mobileParent.closest('.nav-mobile__item'):null;
@@ -56,6 +68,7 @@ function handleOverlayEsc(event){
 
 function openMenu(){
   if(!navToggle||!navOverlay||!navBackdrop||menuOpen){return;}
+  updateHeaderHeight();
   menuOpen=true;
   setMobileSubmenu(false);
   navOverlay.hidden=false;

--- a/assets/style.css
+++ b/assets/style.css
@@ -9,6 +9,7 @@
   --radius:16px;
   --shadow:0 10px 25px rgba(15,23,42,.08);
   --maxw:1200px;
+  --header-h:0px;
 }
 *{box-sizing:border-box}
 html{scroll-behavior:smooth}
@@ -61,11 +62,11 @@ img{max-width:100%;height:auto;display:block}
 .fb{mask-image:url('../images/facebooklogo.svg');-webkit-mask-image:url('../images/facebooklogo.svg')}
 .ig{mask-image:url('../images/instagramlogo.svg');-webkit-mask-image:url('../images/instagramlogo.svg')}
 
-.nav-backdrop{position:fixed;inset:0;background:rgba(0,0,0,.45);opacity:0;pointer-events:none;transition:opacity .3s ease;z-index:70}
+.nav-backdrop{position:fixed;left:0;right:0;bottom:0;top:var(--header-h);top:calc(var(--header-h) + env(safe-area-inset-top,0px));background:rgba(0,0,0,.45);opacity:0;pointer-events:none;transition:opacity .3s ease;z-index:70}
 .nav-backdrop.is-active{opacity:1;pointer-events:auto}
-.nav-overlay{position:fixed;inset:0;display:flex;justify-content:center;align-items:flex-start;opacity:0;pointer-events:none;transition:opacity .3s ease;z-index:90}
+.nav-overlay{position:fixed;left:0;right:0;top:var(--header-h);top:calc(var(--header-h) + env(safe-area-inset-top,0px));height:calc(100dvh - var(--header-h));height:calc(100dvh - (var(--header-h) + env(safe-area-inset-top,0px)));display:flex;justify-content:center;align-items:flex-start;opacity:0;pointer-events:none;transition:opacity .3s ease;z-index:90}
 .nav-overlay.is-active{opacity:1;pointer-events:auto}
-.nav-overlay__inner{background:#fff;color:var(--text);width:100%;height:100dvh;display:flex;flex-direction:column;padding:calc(24px + env(safe-area-inset-top,0px)) 20px calc(28px + env(safe-area-inset-bottom,0px));gap:12px;transform:translateY(-8%);transition:transform .35s ease,opacity .35s ease;opacity:0}
+.nav-overlay__inner{background:#fff;color:var(--text);width:100%;height:100%;display:flex;flex-direction:column;padding:calc(24px + env(safe-area-inset-top,0px)) 20px calc(28px + env(safe-area-inset-bottom,0px));gap:12px;transform:translateY(-8%);transition:transform .35s ease,opacity .35s ease;opacity:0}
 .nav-overlay.is-active .nav-overlay__inner{transform:translateY(0);opacity:1}
 .nav-overlay__top{display:flex;align-items:center;justify-content:space-between;gap:12px}
 .nav-overlay__title{margin:0;font-size:1rem;font-weight:600;color:var(--text)}


### PR DESCRIPTION
## Summary
- add a CSS custom property for the sticky header height and apply it to the mobile nav overlay/backdrop
- update the overlay layout so it begins below the header and fills the remaining viewport with safe-area fallbacks
- compute and update the header height in JavaScript on load, resize, and when opening the mobile menu

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68ed7e07a4b0832083e4acbbe13490f8