### PR TITLE
Update services section and enhance local SEO metadata

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -115,6 +115,7 @@ body.nav-open{overflow:hidden}
 .hero-inner{position:relative;z-index:2;display:flex;flex-direction:column;align-items:flex-start;gap:20px;max-width:var(--maxw);margin-inline:auto;padding:0 16px}
 .hero-copy{max-width:560px;display:grid;gap:16px}
 .hero h1{font-size:clamp(28px,7vw,48px);line-height:1.05;margin:0}
+.hero h2{font-size:clamp(22px,5.6vw,36px);line-height:1.2;margin:0;font-weight:600;color:inherit}
 .hero .lead{opacity:.92;color:inherit}
 .cta-group{display:flex;flex-direction:column;gap:12px;width:100%}
 .cta-group .btn{width:100%;justify-content:center}

--- a/index.html
+++ b/index.html
@@ -17,16 +17,90 @@
   <meta property="og:image" content="https://images.unsplash.com/photo-1505691723518-36a5ac3b2d55?q=80&w=1600&auto=format&fit=crop">
   <script type="application/ld+json">
   {
-    "@context":"https://schema.org",
-    "@type":"LocalBusiness",
-    "name":"FM Renovation – Ανακαινίσου.gr",
-    "url":"https://anakainisou.gr/",
-    "image":"https://images.unsplash.com/photo-1505691723518-36a5ac3b2d55?q=80&w=1600&auto=format&fit=crop",
-
-    "description":"Ολοκληρωμένες λύσεις ανακαίνισης για κατοικίες & επαγγελματικούς χώρους.",
-    "address":{"@type":"PostalAddress","addressLocality":"Αθήνα","addressCountry":"GR"},
-    "telephone":"+30 210 0000000",
-    "sameAs":["https://www.facebook.com/","https://www.instagram.com/"]
+    "@context": "https://schema.org",
+    "@type": "LocalBusiness",
+    "name": "FM Renovation — Ανακαινίσου.gr",
+    "url": "https://anakainisou.gr/",
+    "image": "https://images.unsplash.com/photo-1505691723518-36a5ac3b2d55?q=80&w=1600&auto=format&fit=crop",
+    "logo": "https://anakainisou.gr/images/logo-fm-renovation.svg",
+    "description": "Ολοκληρωμένες λύσεις ανακαίνισης για κατοικίες & επαγγελματικούς χώρους.",
+    "telephone": "+30 210 0000000",
+    "email": "info@anakainisou.gr",
+    "priceRange": "€€",
+    "address": {
+      "@type": "PostalAddress",
+      "addressLocality": "Αθήνα",
+      "addressRegion": "Αττική",
+      "addressCountry": "GR"
+    },
+    "areaServed": [
+      "Αθήνα",
+      "Αττική",
+      "Πειραιάς",
+      "Βόρεια Προάστια",
+      "Νότια Προάστια",
+      "Δυτική Αττική",
+      "Ανατολική Αττική"
+    ],
+    "serviceArea": {
+      "@type": "AdministrativeArea",
+      "name": "Αττική",
+      "areaServed": [
+        "Αθήνα",
+        "Αττική"
+      ]
+    },
+    "geo": {
+      "@type": "GeoCircle",
+      "geoMidpoint": {
+        "@type": "GeoCoordinates",
+        "addressLocality": "Αθήνα",
+        "addressCountry": "GR"
+      },
+      "geoRadius": 35000
+    },
+    "sameAs": [
+      "https://www.facebook.com/",
+      "https://www.instagram.com/"
+    ],
+    "makesOffer": [
+      {"@type": "Offer", "itemOffered": {"@type": "Service", "name": "Γκρεμίσματα – αποξηλώσεις – απομάκρυνση παλαιών υλικών με κάδο"}},
+      {"@type": "Offer", "itemOffered": {"@type": "Service", "name": "Χτισίματα – σοβατίσματα – ελαιοχρωματισμοί τοιχοποιίας"}},
+      {"@type": "Offer", "itemOffered": {"@type": "Service", "name": "Υδραυλικές εργασίες"}},
+      {"@type": "Offer", "itemOffered": {"@type": "Service", "name": "Ηλεκτρολογικές εργασίες – Έκδοση Υ.Δ.Ε."}},
+      {"@type": "Offer", "itemOffered": {"@type": "Service", "name": "Κουφώματα αλουμινίου – PVC"}},
+      {"@type": "Offer", "itemOffered": {"@type": "Service", "name": "Τοποθέτηση πλακιδίων τοίχου – δαπέδου"}},
+      {"@type": "Offer", "itemOffered": {"@type": "Service", "name": "Τοποθέτηση πατωμάτων laminate – αποκατάσταση ξύλινων πατωμάτων"}},
+      {"@type": "Offer", "itemOffered": {"@type": "Service", "name": "Τρίψιμο – γυάλισμα μωσαϊκών δαπέδων"}},
+      {"@type": "Offer", "itemOffered": {"@type": "Service", "name": "Κατασκευή – τοποθέτηση ντουλαπιών κουζίνας"}},
+      {"@type": "Offer", "itemOffered": {"@type": "Service", "name": "Κατασκευή – τοποθέτηση ντουλαπών"}},
+      {"@type": "Offer", "itemOffered": {"@type": "Service", "name": "Πόρτες εισόδου (ασφαλείας) – εσωτερικές πόρτες"}},
+      {"@type": "Offer", "itemOffered": {"@type": "Service", "name": "Μεταλλικές κατασκευές"}},
+      {"@type": "Offer", "itemOffered": {"@type": "Service", "name": "Μονώσεις παντός τύπου"}},
+      {"@type": "Offer", "itemOffered": {"@type": "Service", "name": "Έκδοση οικοδομικών αδειών"}},
+      {"@type": "Offer", "itemOffered": {"@type": "Service", "name": "Αποκατάσταση προσόψεων (στηθαία) σε πολυκατοικίες με χρήση σκαλωσιάς"}}
+    ],
+    "hasOfferCatalog": {
+      "@type": "OfferCatalog",
+      "name": "Υπηρεσίες Ανακαινίσεων",
+      "itemListElement": [
+        {"@type": "Offer", "itemOffered": {"@type": "Service", "name": "Γκρεμίσματα – αποξηλώσεις – απομάκρυνση παλαιών υλικών με κάδο"}},
+        {"@type": "Offer", "itemOffered": {"@type": "Service", "name": "Χτισίματα – σοβατίσματα – ελαιοχρωματισμοί τοιχοποιίας"}},
+        {"@type": "Offer", "itemOffered": {"@type": "Service", "name": "Υδραυλικές εργασίες"}},
+        {"@type": "Offer", "itemOffered": {"@type": "Service", "name": "Ηλεκτρολογικές εργασίες – Έκδοση Υ.Δ.Ε."}},
+        {"@type": "Offer", "itemOffered": {"@type": "Service", "name": "Κουφώματα αλουμινίου – PVC"}},
+        {"@type": "Offer", "itemOffered": {"@type": "Service", "name": "Τοποθέτηση πλακιδίων τοίχου – δαπέδου"}},
+        {"@type": "Offer", "itemOffered": {"@type": "Service", "name": "Τοποθέτηση πατωμάτων laminate – αποκατάσταση ξύλινων πατωμάτων"}},
+        {"@type": "Offer", "itemOffered": {"@type": "Service", "name": "Τρίψιμο – γυάλισμα μωσαϊκών δαπέδων"}},
+        {"@type": "Offer", "itemOffered": {"@type": "Service", "name": "Κατασκευή – τοποθέτηση ντουλαπιών κουζίνας"}},
+        {"@type": "Offer", "itemOffered": {"@type": "Service", "name": "Κατασκευή – τοποθέτηση ντουλαπών"}},
+        {"@type": "Offer", "itemOffered": {"@type": "Service", "name": "Πόρτες εισόδου (ασφαλείας) – εσωτερικές πόρτες"}},
+        {"@type": "Offer", "itemOffered": {"@type": "Service", "name": "Μεταλλικές κατασκευές"}},
+        {"@type": "Offer", "itemOffered": {"@type": "Service", "name": "Μονώσεις παντός τύπου"}},
+        {"@type": "Offer", "itemOffered": {"@type": "Service", "name": "Έκδοση οικοδομικών αδειών"}},
+        {"@type": "Offer", "itemOffered": {"@type": "Service", "name": "Αποκατάσταση προσόψεων (στηθαία) σε πολυκατοικίες με χρήση σκαλωσιάς"}}
+      ]
+    }
   }
   </script>
 </head>
@@ -52,10 +126,11 @@
             </button>
             <ul class="submenu">
               <li><a href="#services" class="submenu__link">Ανακαίνιση Κατοικίας</a></li>
-              <li><a href="#services" class="submenu__link">Ανακαίνιση Μπάνιου</a></li>
-              <li><a href="#services" class="submenu__link">Ανακαίνιση Κουζίνας</a></li>
-              <li><a href="#services" class="submenu__link">Επαγγελματικοί Χώροι</a></li>
-              <li><a href="#services" class="submenu__link">Ενεργειακή Αναβάθμιση</a></li>
+              <li><a href="#services" class="submenu__link">Μπάνιο</a></li>
+              <li><a href="#services" class="submenu__link">Κουζίνα</a></li>
+              <li><a href="#services" class="submenu__link">Ηλεκτρολογικά – Υ.Δ.Ε.</a></li>
+              <li><a href="#services" class="submenu__link">Υδραυλικά</a></li>
+              <li><a href="#services" class="submenu__link">Κουφώματα</a></li>
             </ul>
           </li>
           <li class="nav__item"><a href="#reasons" class="nav__link">Γιατί εμείς</a></li>
@@ -92,10 +167,11 @@
             </button>
             <ul class="nav-mobile__submenu" data-mobile-submenu>
               <li><a href="#services" class="nav-mobile__sublink">Ανακαίνιση Κατοικίας</a></li>
-              <li><a href="#services" class="nav-mobile__sublink">Ανακαίνιση Μπάνιου</a></li>
-              <li><a href="#services" class="nav-mobile__sublink">Ανακαίνιση Κουζίνας</a></li>
-              <li><a href="#services" class="nav-mobile__sublink">Επαγγελματικοί Χώροι</a></li>
-              <li><a href="#services" class="nav-mobile__sublink">Ενεργειακή Αναβάθμιση</a></li>
+              <li><a href="#services" class="nav-mobile__sublink">Μπάνιο</a></li>
+              <li><a href="#services" class="nav-mobile__sublink">Κουζίνα</a></li>
+              <li><a href="#services" class="nav-mobile__sublink">Ηλεκτρολογικά – Υ.Δ.Ε.</a></li>
+              <li><a href="#services" class="nav-mobile__sublink">Υδραυλικά</a></li>
+              <li><a href="#services" class="nav-mobile__sublink">Κουφώματα</a></li>
             </ul>
           </li>
           <li class="nav-mobile__item"><a href="#reasons" class="nav-mobile__link">Γιατί εμείς</a></li>
@@ -117,15 +193,16 @@
     <section class="hero">
       <figure class="hero-slider" aria-label="Προβολή έργων">
         <!-- Χρησιμοποιούμε καθαρές εικόνες από Unsplash για άμεση προεπισκόπηση -->
-        <img data-hero src="https://images.unsplash.com/photo-1505691938895-1758d7feb511?q=80&w=1600&auto=format&fit=crop" alt="Σύγχρονη ανακαίνιση σαλονιού">
-        <img data-hero src="https://images.unsplash.com/photo-1501045661006-fcebe0257c3f?q=80&w=1600&auto=format&fit=crop" alt="Κουζίνα με ξύλο και λευκό">
-        <img data-hero src="https://images.unsplash.com/photo-1505691723518-36a5ac3b2d55?q=80&w=1600&auto=format&fit=crop" alt="Επαγγελματικός χώρος γραφείου">
-        <img data-hero src="https://images.unsplash.com/photo-1484154218962-a197022b5858?q=80&w=1600&auto=format&fit=crop" alt="Μπάνιο minimal">
-        <img data-hero src="https://images.unsplash.com/photo-1494526585095-c41746248156?q=80&w=1600&auto=format&fit=crop" alt="Υπνοδωμάτιο μοντέρνο">
+        <img data-hero src="https://images.unsplash.com/photo-1505691938895-1758d7feb511?q=80&w=1600&auto=format&fit=crop" alt="Ανακαίνιση σαλονιού στην Αθήνα από FM Renovation">
+        <img data-hero src="https://images.unsplash.com/photo-1501045661006-fcebe0257c3f?q=80&w=1600&auto=format&fit=crop" alt="Ανακαίνιση κουζίνας στην Αθήνα από FM Renovation">
+        <img data-hero src="https://images.unsplash.com/photo-1505691723518-36a5ac3b2d55?q=80&w=1600&auto=format&fit=crop" alt="Ανακαίνιση επαγγελματικού χώρου στην Αττική – FM Renovation">
+        <img data-hero src="https://images.unsplash.com/photo-1484154218962-a197022b5858?q=80&w=1600&auto=format&fit=crop" alt="Ανακαίνιση μπάνιου στην Αθήνα από FM Renovation">
+        <img data-hero src="https://images.unsplash.com/photo-1494526585095-c41746248156?q=80&w=1600&auto=format&fit=crop" alt="Ανακαίνιση υπνοδωματίου στην Αττική – FM Renovation">
       </figure>
       <div class="container hero-inner">
         <div class="hero-copy">
-          <h1>Ανακαίνισε το σπίτι ή τον επαγγελματικό σου χώρο με την<br>FM Renovation.</h1>
+          <h1>Ανακαινίσεις</h1>
+          <h2>Ολική ή μερική ανακαίνιση οικίας και επαγγελματικού χώρου</h2>
           <p class="lead">Ολοκληρωμένες ανακαινίσεις με τεχνική ακρίβεια, συνέπεια και διαφάνεια.</p>
           <div class="cta-group">
             <a href="#contact" class="btn btn--primary">Ζητήστε Προσφορά</a>
@@ -159,12 +236,81 @@
       <div class="container">
         <h2>Υπηρεσίες</h2>
         <div class="grid services">
-          <article class="card service"><h3>Ανακαίνιση Κατοικίας</h3><p>Ολική/μερική ανακαίνιση με έμφαση στη λειτουργικότητα.</p><a href="#contact" class="link">Ζητήστε Προσφορά</a></article>
-          <article class="card service"><h3>Ανακαίνιση Μπάνιου</h3><p>Υλικά αντοχής & άψογα φινιρίσματα.</p><a href="#contact" class="link">Ζητήστε Προσφορά</a></article>
-          <article class="card service"><h3>Ανακαίνιση Κουζίνας</h3><p>Εργονομικός σχεδιασμός & σύγχρονοι μηχανισμοί.</p><a href="#contact" class="link">Ζητήστε Προσφορά</a></article>
-          <article class="card service"><h3>Επαγγελματικοί Χώροι</h3><p>Γραφεία, καταστήματα, HORECA με ελεγχόμενο downtime.</p><a href="#contact" class="link">Ζητήστε Προσφορά</a></article>
-          <article class="card service"><h3>Ενεργειακή Αναβάθμιση</h3><p>Θερμομόνωση, κουφώματα, φωτισμός LED.</p><a href="#contact" class="link">Ζητήστε Προσφορά</a></article>
-          <article class="card service"><h3>Μικροεργασίες</h3><p>Βαψίματα, ηλεκτρολογικά, επιδιορθώσεις.</p><a href="#contact" class="link">Ζητήστε Προσφορά</a></article>
+          <article class="card service">
+            <h3>Γκρεμίσματα – αποξηλώσεις – απομάκρυνση παλαιών υλικών με κάδο</h3>
+            <p>Εξειδικευμένο συνεργείο, ασφαλείς πρακτικές και καθαρή απομάκρυνση μπαζών.</p>
+            <a href="#contact" class="link">Ζητήστε Προσφορά</a>
+          </article>
+          <article class="card service">
+            <h3>Χτισίματα – σοβατίσματα – ελαιοχρωματισμοί τοιχοποιίας</h3>
+            <p>Ποιοτικές επιφάνειες, σωστές στρώσεις και άψογες λεπτομέρειες.</p>
+            <a href="#contact" class="link">Ζητήστε Προσφορά</a>
+          </article>
+          <article class="card service">
+            <h3>Υδραυλικές εργασίες</h3>
+            <p>Σωστές συνδέσεις, υλικά αντοχής και εγγυημένη λειτουργία.</p>
+            <a href="#contact" class="link">Ζητήστε Προσφορά</a>
+          </article>
+          <article class="card service">
+            <h3>Ηλεκτρολογικές εργασίες – Έκδοση Υ.Δ.Ε.</h3>
+            <p>Συμμόρφωση με πρότυπα, πιστοποιήσεις και υπεύθυνη έκδοση Υ.Δ.Ε.</p>
+            <a href="#contact" class="link">Ζητήστε Προσφορά</a>
+          </article>
+          <article class="card service">
+            <h3>Κουφώματα αλουμινίου – PVC</h3>
+            <p>Κουφώματα με θερμοδιακοπή (αλουμίνιο/PVC) για θερμομόνωση &amp; ασφάλεια.</p>
+            <a href="#contact" class="link">Ζητήστε Προσφορά</a>
+          </article>
+          <article class="card service">
+            <h3>Τοποθέτηση πλακιδίων τοίχου – δαπέδου</h3>
+            <p>Ακριβής τοποθέτηση πλακιδίων με σωστή ευθυγράμμιση και αρμολόγηση.</p>
+            <a href="#contact" class="link">Ζητήστε Προσφορά</a>
+          </article>
+          <article class="card service">
+            <h3>Τοποθέτηση πατωμάτων laminate – αποκατάσταση ξύλινων πατωμάτων</h3>
+            <p>Άψογη εφαρμογή laminate και αποκατάσταση ξύλινων πατωμάτων.</p>
+            <a href="#contact" class="link">Ζητήστε Προσφορά</a>
+          </article>
+          <article class="card service">
+            <h3>Τρίψιμο – γυάλισμα μωσαϊκών δαπέδων</h3>
+            <p>Επαγγελματικό τρίψιμο και γυάλισμα μωσαϊκών για ομοιόμορφο φινίρισμα.</p>
+            <a href="#contact" class="link">Ζητήστε Προσφορά</a>
+          </article>
+          <article class="card service">
+            <h3>Κατασκευή – τοποθέτηση ντουλαπιών κουζίνας</h3>
+            <p>Σχεδίαση–τοποθέτηση ντουλαπιών κουζίνας με εργονομία και αντοχές.</p>
+            <a href="#contact" class="link">Ζητήστε Προσφορά</a>
+          </article>
+          <article class="card service">
+            <h3>Κατασκευή – τοποθέτηση ντουλαπών</h3>
+            <p>Κατασκευή–τοποθέτηση ντουλαπών με μηχανισμούς ομαλής κύλισης.</p>
+            <a href="#contact" class="link">Ζητήστε Προσφορά</a>
+          </article>
+          <article class="card service">
+            <h3>Πόρτες εισόδου (ασφαλείας) – εσωτερικές πόρτες</h3>
+            <p>Πόρτες ασφαλείας/εσωτερικές με πιστοποιήσεις και σωστή τοποθέτηση.</p>
+            <a href="#contact" class="link">Ζητήστε Προσφορά</a>
+          </article>
+          <article class="card service">
+            <h3>Μεταλλικές κατασκευές</h3>
+            <p>Μελέτη και κατασκευή μεταλλικών στοιχείων με ακρίβεια.</p>
+            <a href="#contact" class="link">Ζητήστε Προσφορά</a>
+          </article>
+          <article class="card service">
+            <h3>Μονώσεις παντός τύπου</h3>
+            <p>Θερμομόνωση/υγρομόνωση και λύσεις εξοικονόμησης ενέργειας.</p>
+            <a href="#contact" class="link">Ζητήστε Προσφορά</a>
+          </article>
+          <article class="card service">
+            <h3>Έκδοση οικοδομικών αδειών</h3>
+            <p>Ανάληψη διαδικασιών και έκδοση οικοδομικών αδειών.</p>
+            <a href="#contact" class="link">Ζητήστε Προσφορά</a>
+          </article>
+          <article class="card service">
+            <h3>Αποκατάσταση προσόψεων (στηθαία) σε πολυκατοικίες με χρήση σκαλωσιάς</h3>
+            <p>Σκαλωσιές, επισκευές στηθαίων και αποκατάσταση όψεων με ασφάλεια.</p>
+            <a href="#contact" class="link">Ζητήστε Προσφορά</a>
+          </article>
         </div>
         <div class="under-cta"><a href="#contact" class="btn btn--primary">Θέλω Προσφορά για Υπηρεσία</a></div>
       </div>
@@ -203,11 +349,11 @@
         <div class="carousel" data-carousel>
           <button class="car-btn prev" aria-label="Προηγούμενη">‹</button>
           <div class="car-track" data-track>
-            <img src="https://images.unsplash.com/photo-1493666438817-866a91353ca9?q=80&w=1400&auto=format&fit=crop" alt="Σαλόνι">
-            <img src="https://images.unsplash.com/photo-1501183638710-841dd1904471?q=80&w=1400&auto=format&fit=crop" alt="Κουζίνα">
-            <img src="https://images.unsplash.com/photo-1497366216548-37526070297c?q=80&w=1400&auto=format&fit=crop" alt="Γραφείο">
-            <img src="https://images.unsplash.com/photo-1501045661006-fcebe0257c3f?q=80&w=1400&auto=format&fit=crop" alt="Μπάνιο">
-            <img src="https://images.unsplash.com/photo-1494526585095-c41746248156?q=80&w=1400&auto=format&fit=crop" alt="Υπνοδωμάτιο">
+            <img src="https://images.unsplash.com/photo-1493666438817-866a91353ca9?q=80&w=1400&auto=format&fit=crop" alt="Διαμόρφωση σαλονιού – δείγμα έργου FM Renovation στην Αθήνα">
+            <img src="https://images.unsplash.com/photo-1501183638710-841dd1904471?q=80&w=1400&auto=format&fit=crop" alt="Ανακαίνιση κουζίνας – FM Renovation, Αττική">
+            <img src="https://images.unsplash.com/photo-1497366216548-37526070297c?q=80&w=1400&auto=format&fit=crop" alt="Ανακαίνιση γραφείου – FM Renovation, Αθήνα">
+            <img src="https://images.unsplash.com/photo-1501045661006-fcebe0257c3f?q=80&w=1400&auto=format&fit=crop" alt="Ανακαίνιση μπάνιου – FM Renovation, Αττική">
+            <img src="https://images.unsplash.com/photo-1494526585095-c41746248156?q=80&w=1400&auto=format&fit=crop" alt="Ανακαίνιση υπνοδωματίου – FM Renovation στην Αθήνα">
           </div>
           <button class="car-btn next" aria-label="Επόμενη">›</button>
         </div>


### PR DESCRIPTION
## Summary
- update the hero headlines to reflect the new branding copy
- replace the services grid with fifteen detailed offerings and refresh the submenu links
- enrich image alt text and LocalBusiness JSON-LD for Athens/Attica SEO coverage

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68eec4b15b8c83208c416e9e48fcdab2