### PR TITLE
Adjust CTA button colors

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -100,8 +100,9 @@ body.nav-open{overflow:hidden}
 /* Buttons */
 .btn{display:inline-flex;align-items:center;justify-content:center;gap:8px;padding:12px 18px;border-radius:999px;text-decoration:none;border:1px solid #e0e6ee;transition:.2s transform,.2s box-shadow,.2s background}
 .nav .btn{border-width:2px;border-color:var(--accent)}
-.btn--primary{background:var(--accent);color:#111;box-shadow:0 6px 16px rgba(245,158,11,.35)}
-.btn--primary:hover{transform:translateY(-1px);box-shadow:var(--shadow)}
+.btn--primary{background:var(--accent);color:#fff;border-color:var(--accent);box-shadow:0 6px 16px rgba(245,158,11,.35)}
+.btn--primary:hover,
+.btn--primary:focus-visible{background:var(--bg);color:var(--text);border-color:var(--accent-2);transform:translateY(-1px);box-shadow:var(--shadow);outline:none}
 .btn--ghost{background:#fff;color:var(--text)}
 .btn--sm{padding:8px 12px}
 .under-cta{text-align:center;margin-top:18px}


### PR DESCRIPTION
## Summary
- update primary CTA button styling to use the new amber and slate palette
- ensure hover and focus states swap to the light background with dark outline and text

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68eed28dc7ec83209a2bc57eae58d415