### PR TITLE
Remove testimonials link from navigation menus

### DIFF
--- a/index.html
+++ b/index.html
@@ -136,7 +136,6 @@
           <li class="nav__item"><a href="#reasons" class="nav__link">Γιατί εμείς</a></li>
           <li class="nav__item"><a href="#process" class="nav__link">Διαδικασία</a></li>
           <li class="nav__item"><a href="#gallery" class="nav__link">Gallery</a></li>
-          <li class="nav__item"><a href="#reviews" class="nav__link">Μαρτυρίες</a></li>
           <li class="nav__item nav__item--cta"><a href="#contact" class="btn btn--sm nav-cta">Ζητήστε Προσφορά</a></li>
         </ul>
       </nav>
@@ -177,7 +176,6 @@
           <li class="nav-mobile__item"><a href="#reasons" class="nav-mobile__link">Γιατί εμείς</a></li>
           <li class="nav-mobile__item"><a href="#process" class="nav-mobile__link">Διαδικασία</a></li>
           <li class="nav-mobile__item"><a href="#gallery" class="nav-mobile__link">Gallery</a></li>
-          <li class="nav-mobile__item"><a href="#reviews" class="nav-mobile__link">Μαρτυρίες</a></li>
           <li class="nav-mobile__item nav-mobile__item--cta"><a href="#contact" class="btn btn--primary nav-mobile__cta">Ζητήστε Προσφορά</a></li>
         </ul>
       </nav>


### PR DESCRIPTION
## Summary
- remove the testimonials link from the primary desktop navigation
- remove the testimonials link from the mobile navigation menu

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68eedd56992c8320875bb9271d86c4f6