### PR TITLE
Add floating contact widget with smart visibility and triggers

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -287,3 +287,320 @@ document.querySelectorAll('[data-carousel]').forEach(car=>{
 // Dummy form handler
 const form=document.querySelector('form.form');
 if(form){form.addEventListener('submit',e=>{e.preventDefault();alert('Ευχαριστούμε! Θα επικοινωνήσουμε σύντομα.');form.reset();});}
+
+// Contact widget interactions
+(function(){
+  const widget=document.querySelector('[data-contact-widget]');
+  if(!widget){return;}
+  const fab=widget.querySelector('[data-contact-toggle]');
+  const panel=widget.querySelector('[data-contact-panel]');
+  const closeBtn=widget.querySelector('[data-contact-close]');
+  const backdrop=document.querySelector('[data-contact-backdrop]');
+  if(!fab||!panel||!closeBtn||!backdrop){return;}
+  const path=(window.location&&window.location.pathname)||'';
+  if(/\/(privacy|terms)/.test(path)){
+    widget.setAttribute('hidden','');
+    widget.classList.add('contact-widget--hidden');
+    backdrop.classList.remove('is-active');
+    backdrop.setAttribute('hidden','');
+    return;
+  }
+  const sessionKey='fmWidgetOpened';
+  const dismissKey='fmWidgetDismissed';
+  const mobileBreakpoint=1024;
+  let widgetOpen=false;
+  let hiddenByContact=false;
+  let hiddenByMenu=false;
+  let servicesTimer=null;
+  let autoOpenPending=false;
+  let idleTimer=null;
+  let exitIntentBound=false;
+  let lastMouseMove=0;
+  let autoOpenDone=false;
+  let autoSuppressed=false;
+  try{autoOpenDone=sessionStorage.getItem(sessionKey)==='1';autoSuppressed=sessionStorage.getItem(dismissKey)==='1';}catch(error){autoOpenDone=false;autoSuppressed=false;}
+
+  const isForceHidden=function(){return hiddenByContact||hiddenByMenu;};
+  const getFocusable=function(){
+    return Array.from(panel.querySelectorAll(focusableSelectors)).filter(function(el){
+      return el.tabIndex>=0&&!el.hasAttribute('disabled');
+    });
+  };
+
+  const trapWidgetFocus=function(event){
+    if(!widgetOpen||event.key!=='Tab'){return;}
+    const focusable=getFocusable();
+    if(!focusable.length){return;}
+    const first=focusable[0];
+    const last=focusable[focusable.length-1];
+    if(event.shiftKey){
+      if(document.activeElement===first){
+        event.preventDefault();
+        last.focus({preventScroll:true});
+      }
+    }else if(document.activeElement===last){
+      event.preventDefault();
+      first.focus({preventScroll:true});
+    }
+  };
+
+  const handleWidgetEsc=function(event){
+    if(event.key==='Escape'&&widgetOpen){
+      event.preventDefault();
+      closeWidget({userTriggered:true});
+    }
+  };
+
+  const finalizeClose=function(){
+    panel.setAttribute('hidden','');
+    panel.setAttribute('aria-hidden','true');
+    backdrop.hidden=true;
+  };
+
+  const openWidget=function(options){
+    options=options||{};
+    if(widgetOpen||isForceHidden()){return;}
+    widgetOpen=true;
+    panel.removeAttribute('hidden');
+    panel.setAttribute('aria-hidden','false');
+    backdrop.hidden=false;
+    widget.classList.add('contact-widget--open');
+    panel.classList.add('is-active');
+    backdrop.classList.add('is-active');
+    fab.setAttribute('aria-expanded','true');
+    document.addEventListener('keydown',handleWidgetEsc);
+    panel.addEventListener('keydown',trapWidgetFocus);
+    setTimeout(function(){
+      const focusTarget=panel.querySelector('[data-contact-focus]')||getFocusable()[0]||closeBtn;
+      if(focusTarget){focusTarget.focus({preventScroll:true});}
+    },40);
+    if(options.auto){
+      autoOpenDone=true;
+      try{sessionStorage.setItem(sessionKey,'1');}catch(error){}
+      updateAutoOpenBindings();
+    }
+  };
+
+  const disableAutoOpen=function(){
+    if(autoSuppressed){return;}
+    autoSuppressed=true;
+    try{sessionStorage.setItem(dismissKey,'1');}catch(error){}
+    updateAutoOpenBindings();
+  };
+
+  const closeWidget=function(options){
+    options=options||{};
+    const returnFocus=options.returnFocus!==false;
+    const userTriggered=options.userTriggered===true;
+    if(!widgetOpen){
+      if(userTriggered){disableAutoOpen();}
+      return;
+    }
+    widgetOpen=false;
+    widget.classList.remove('contact-widget--open');
+    panel.classList.remove('is-active');
+    backdrop.classList.remove('is-active');
+    fab.setAttribute('aria-expanded','false');
+    document.removeEventListener('keydown',handleWidgetEsc);
+    panel.removeEventListener('keydown',trapWidgetFocus);
+    panel.setAttribute('aria-hidden','true');
+    if(prefersReducedMotion.matches){
+      finalizeClose();
+    }else{
+      const timer=setTimeout(finalizeClose,320);
+      panel.addEventListener('transitionend',function handler(){
+        finalizeClose();
+        clearTimeout(timer);
+        panel.removeEventListener('transitionend',handler);
+      });
+    }
+    if(returnFocus&&fab.offsetParent!==null){
+      setTimeout(function(){fab.focus({preventScroll:true});},40);
+    }
+    if(userTriggered){disableAutoOpen();}
+  };
+
+  const updateVisibility=function(){
+    const shouldHide=isForceHidden();
+    widget.classList.toggle('contact-widget--hidden',shouldHide);
+    widget.setAttribute('aria-hidden',shouldHide?'true':'false');
+    if(shouldHide&&widgetOpen){closeWidget({returnFocus:false});}
+  };
+
+  const shouldAutoOpen=function(){
+    if(widgetOpen||autoOpenDone||autoSuppressed||autoOpenPending||isForceHidden()){return false;}
+    return true;
+  };
+
+  const attemptAutoOpen=function(){
+    if(!shouldAutoOpen()){return;}
+    autoOpenPending=true;
+    const trigger=function(){
+      autoOpenPending=false;
+      if(shouldAutoOpen()){
+        openWidget({auto:true});
+      }
+    };
+    if(prefersReducedMotion.matches){
+      trigger();
+    }else{
+      fab.classList.add('pulse');
+      setTimeout(function(){
+        fab.classList.remove('pulse');
+        trigger();
+      },600);
+    }
+  };
+
+  fab.addEventListener('click',function(){
+    if(widgetOpen){closeWidget({userTriggered:true});}
+    else{openWidget();}
+  });
+
+  closeBtn.addEventListener('click',function(){closeWidget({userTriggered:true});});
+  backdrop.addEventListener('click',function(){closeWidget({userTriggered:true});});
+
+  const clearIdleTimer=function(){
+    if(idleTimer){clearTimeout(idleTimer);idleTimer=null;}
+  };
+
+  const scheduleIdleTimer=function(){
+    clearIdleTimer();
+    if(window.innerWidth>=mobileBreakpoint||autoOpenDone||autoSuppressed){return;}
+    idleTimer=setTimeout(function(){
+      idleTimer=null;
+      if(!hiddenByContact){attemptAutoOpen();}
+    },25000);
+  };
+
+  const exitIntentHandler=function(event){
+    const now=Date.now();
+    if(now-lastMouseMove<200){return;}
+    lastMouseMove=now;
+    if(event.clientY<=8&&event.clientY>=0){
+      attemptAutoOpen();
+      if(autoOpenDone||autoSuppressed){unbindExitIntent();}
+    }
+  };
+
+  const bindExitIntent=function(){
+    if(exitIntentBound||autoOpenDone||autoSuppressed){return;}
+    if(window.innerWidth>=mobileBreakpoint){
+      window.addEventListener('mousemove',exitIntentHandler);
+      exitIntentBound=true;
+    }
+  };
+
+  const unbindExitIntent=function(){
+    if(!exitIntentBound){return;}
+    window.removeEventListener('mousemove',exitIntentHandler);
+    exitIntentBound=false;
+  };
+
+  const updateAutoOpenBindings=function(){
+    if(autoOpenDone||autoSuppressed){
+      clearIdleTimer();
+      unbindExitIntent();
+      return;
+    }
+    if(window.innerWidth>=mobileBreakpoint){
+      clearIdleTimer();
+      bindExitIntent();
+    }else{
+      unbindExitIntent();
+      scheduleIdleTimer();
+    }
+  };
+
+  window.addEventListener('resize',function(){updateAutoOpenBindings();});
+
+  const contactSection=document.getElementById('contact');
+  if(contactSection&&'IntersectionObserver' in window){
+    const contactObserver=new IntersectionObserver(function(entries){
+      entries.forEach(function(entry){
+        const inView=entry.isIntersecting&&entry.intersectionRatio>=0.6;
+        if(inView!==hiddenByContact){
+          hiddenByContact=inView;
+          updateVisibility();
+        }
+      });
+    },{threshold:[0,0.6,1]});
+    contactObserver.observe(contactSection);
+  }else if(contactSection){
+    const checkContact=function(){
+      const rect=contactSection.getBoundingClientRect();
+      const viewport=window.innerHeight||document.documentElement.clientHeight||0;
+      const visible=Math.max(0,Math.min(rect.bottom,viewport)-Math.max(rect.top,0));
+      const ratio=rect.height>0?visible/rect.height:0;
+      const inView=ratio>=0.6;
+      if(inView!==hiddenByContact){
+        hiddenByContact=inView;
+        updateVisibility();
+      }
+    };
+    window.addEventListener('scroll',checkContact,{passive:true});
+    window.addEventListener('resize',checkContact);
+    checkContact();
+  }
+
+  const servicesSection=document.getElementById('services');
+  if(servicesSection&&'IntersectionObserver' in window){
+    const servicesObserver=new IntersectionObserver(function(entries){
+      entries.forEach(function(entry){
+        if(entry.isIntersecting&&entry.intersectionRatio>=0.6){
+          if(servicesTimer){clearTimeout(servicesTimer);}
+          servicesTimer=setTimeout(function(){servicesTimer=null;if(shouldAutoOpen()){attemptAutoOpen();}},2000);
+        }else if(servicesTimer){
+          clearTimeout(servicesTimer);
+          servicesTimer=null;
+        }
+      });
+    },{threshold:[0.6]});
+    servicesObserver.observe(servicesSection);
+  }else if(servicesSection){
+    const checkServices=function(){
+      const rect=servicesSection.getBoundingClientRect();
+      const viewport=window.innerHeight||document.documentElement.clientHeight||0;
+      const visible=Math.max(0,Math.min(rect.bottom,viewport)-Math.max(rect.top,0));
+      const ratio=rect.height>0?visible/rect.height:0;
+      if(ratio>=0.6){
+        if(servicesTimer){clearTimeout(servicesTimer);}
+        servicesTimer=setTimeout(function(){servicesTimer=null;if(shouldAutoOpen()){attemptAutoOpen();}},2000);
+      }else if(servicesTimer){
+        clearTimeout(servicesTimer);
+        servicesTimer=null;
+      }
+    };
+    window.addEventListener('scroll',checkServices,{passive:true});
+    window.addEventListener('resize',checkServices);
+    checkServices();
+  }
+
+  const idleEvents=['touchstart','pointerdown','keydown'];
+  idleEvents.forEach(function(evt){
+    document.addEventListener(evt,function(){
+      if(window.innerWidth<mobileBreakpoint&&!autoOpenDone&&!autoSuppressed){scheduleIdleTimer();}
+      else{clearIdleTimer();}
+    },{passive:true});
+  });
+  window.addEventListener('scroll',function(){
+    if(window.innerWidth<mobileBreakpoint&&!autoOpenDone&&!autoSuppressed){scheduleIdleTimer();}
+    else{clearIdleTimer();}
+  },{passive:true});
+
+  const menuObserver=new MutationObserver(function(mutations){
+    mutations.forEach(function(mutation){
+      if(mutation.attributeName==='class'){
+        const menuOpenNow=body.classList.contains('nav-open');
+        if(menuOpenNow!==hiddenByMenu){
+          hiddenByMenu=menuOpenNow;
+          updateVisibility();
+        }
+      }
+    });
+  });
+  menuObserver.observe(body,{attributes:true});
+
+  updateVisibility();
+  updateAutoOpenBindings();
+})();

--- a/assets/style.css
+++ b/assets/style.css
@@ -180,6 +180,46 @@ body.nav-open{overflow:hidden}
 .footer-nav a{text-decoration:none;color:var(--text);opacity:.9}
 .site-footer .social{margin-left:0}
 
+/* CONTACT WIDGET */
+.contact-widget{position:fixed;right:calc(16px + env(safe-area-inset-right,0px));bottom:calc(16px + env(safe-area-inset-bottom,0px));z-index:140;display:flex;flex-direction:column;align-items:flex-end;gap:12px;transition:opacity .3s ease,transform .3s ease;transform:translateY(0)}
+.contact-widget[hidden]{display:none}
+.contact-widget--hidden{opacity:0;pointer-events:none;transform:translateY(24px)}
+.contact-widget--open .contact-widget__panel{opacity:1;transform:translateY(0) scale(1);pointer-events:auto}
+.contact-widget__fab{width:64px;height:64px;border-radius:999px;border:none;background:#F59E0B;color:#0F172A;display:grid;place-items:center;box-shadow:0 14px 34px rgba(245,158,11,.45);cursor:pointer;transition:transform .25s ease,box-shadow .25s ease,background .25s ease;position:relative}
+.contact-widget__fab:hover,.contact-widget__fab:focus-visible{transform:translateY(-2px) scale(1.02);box-shadow:0 18px 40px rgba(245,158,11,.5);outline:none}
+.contact-widget__fab:focus-visible{box-shadow:0 0 0 4px rgba(245,158,11,.35),0 18px 40px rgba(245,158,11,.5)}
+.contact-widget__fab:active{transform:scale(.97)}
+.contact-widget__fab-icon{width:26px;height:26px;background:currentColor;mask-image:url('../images/icons/phone.svg');-webkit-mask-image:url('../images/icons/phone.svg');mask-size:contain;-webkit-mask-size:contain;mask-repeat:no-repeat;-webkit-mask-repeat:no-repeat;mask-position:center;-webkit-mask-position:center}
+.contact-widget__panel{position:relative;width:clamp(260px,30vw,320px);background:#fff;color:#0F172A;border:1px solid #e8edf4;border-radius:18px;box-shadow:0 20px 45px rgba(15,23,42,.18);padding:16px;opacity:0;transform:translateY(12px) scale(.98);pointer-events:none;transition:opacity .28s ease,transform .28s ease}
+.contact-widget__header{display:flex;align-items:center;justify-content:space-between;gap:12px;margin-bottom:10px}
+.contact-widget__title{margin:0;font-size:1rem;font-weight:600;color:#0F172A}
+.contact-widget__close{width:40px;height:40px;border-radius:12px;border:1px solid #d8dee9;background:#f8fafc;color:#0F172A;display:grid;place-items:center;cursor:pointer;transition:background .2s ease,border-color .2s ease,transform .2s ease}
+.contact-widget__close span{width:18px;height:18px;display:block;position:relative}
+.contact-widget__close span::before,.contact-widget__close span::after{content:"";position:absolute;left:0;top:50%;width:100%;height:2px;background:currentColor;border-radius:999px}
+.contact-widget__close span::before{transform:translateY(-50%) rotate(45deg)}
+.contact-widget__close span::after{transform:translateY(-50%) rotate(-45deg)}
+.contact-widget__close:hover,.contact-widget__close:focus-visible{background:#fff;border-color:#cbd4e2;transform:scale(1.02);outline:none}
+.contact-widget__actions{list-style:none;margin:0;padding:0;display:grid;gap:8px}
+.contact-widget__action{display:flex;align-items:center;gap:12px;padding:12px 14px;border-radius:14px;border:1px solid #e8edf4;text-decoration:none;color:#0F172A;font-weight:600;min-height:44px;transition:background .2s ease,border-color .2s ease,color .2s ease,transform .2s ease}
+.contact-widget__action:hover,.contact-widget__action:focus-visible{background:#F5F7FA;border-color:#d5dce8;transform:translateY(-1px);outline:none}
+.contact-widget__action-icon{width:24px;height:24px;background:currentColor;mask-size:contain;-webkit-mask-size:contain;mask-repeat:no-repeat;-webkit-mask-repeat:no-repeat;mask-position:center;-webkit-mask-position:center;color:#1E293B;flex-shrink:0}
+.contact-widget__action-icon--viber{mask-image:url('../images/icons/viber.svg');-webkit-mask-image:url('../images/icons/viber.svg')}
+.contact-widget__action-icon--email{mask-image:url('../images/icons/email.svg');-webkit-mask-image:url('../images/icons/email.svg')}
+.contact-widget__action-icon--phone{mask-image:url('../images/icons/phone.svg');-webkit-mask-image:url('../images/icons/phone.svg')}
+.contact-widget__backdrop{position:fixed;inset:0;background:rgba(15,23,42,.45);opacity:0;pointer-events:none;transition:opacity .28s ease;z-index:130}
+.contact-widget__backdrop.is-active{opacity:1;pointer-events:auto}
+.contact-widget__fab.pulse{animation:contact-widget-pulse .9s ease}
+@keyframes contact-widget-pulse{0%,100%{transform:scale(1)}50%{transform:scale(1.08)}}
+
+@media (max-width: 600px){
+  .contact-widget__panel{width:min(90vw,320px)}
+}
+
+@media (prefers-reduced-motion: reduce){
+  .contact-widget,.contact-widget__fab,.contact-widget__panel,.contact-widget__backdrop,.contact-widget__action,.contact-widget__close{transition:none !important}
+  .contact-widget__fab.pulse{animation:none}
+}
+
 /* Responsive */
 @media (min-width: 520px){
   .cta-group{flex-direction:row;flex-wrap:wrap;width:auto}

--- a/index.html
+++ b/index.html
@@ -409,6 +409,41 @@
     </div>
   </footer>
 
+  <div class="contact-widget" data-contact-widget>
+    <button class="contact-widget__fab" type="button" aria-controls="contact-widget-panel" aria-expanded="false" aria-label="Γρήγορη επικοινωνία" data-contact-toggle>
+      <span class="contact-widget__fab-icon" aria-hidden="true"></span>
+    </button>
+    <div class="contact-widget__panel" id="contact-widget-panel" role="dialog" aria-modal="true" aria-labelledby="contact-widget-title" data-contact-panel hidden>
+      <div class="contact-widget__header">
+        <h2 class="contact-widget__title" id="contact-widget-title">Επικοινωνία</h2>
+        <button class="contact-widget__close" type="button" aria-label="Κλείσιμο επιλογών επικοινωνίας" data-contact-close>
+          <span aria-hidden="true"></span>
+        </button>
+      </div>
+      <ul class="contact-widget__actions">
+        <li>
+          <a class="contact-widget__action" href="viber://chat?number=%2B30XXXXXXXXXX" data-contact-focus>
+            <span class="contact-widget__action-icon contact-widget__action-icon--viber" aria-hidden="true"></span>
+            <span class="contact-widget__action-label">Viber</span>
+          </a>
+        </li>
+        <li>
+          <a class="contact-widget__action" href="mailto:info@anakainisou.gr?subject=%CE%95%CE%BD%CE%B4%CE%B9%CE%B1%CF%86%CE%AD%CF%81%CE%BF%CE%BD%20%CE%B3%CE%B9%CE%B1%20%CE%B1%CE%BD%CE%B1%CE%BA%CE%B1%CE%AF%CE%BD%CE%B9%CF%83%CE%B7">
+            <span class="contact-widget__action-icon contact-widget__action-icon--email" aria-hidden="true"></span>
+            <span class="contact-widget__action-label">Email</span>
+          </a>
+        </li>
+        <li>
+          <a class="contact-widget__action" href="tel:+30210XXXXXXX">
+            <span class="contact-widget__action-icon contact-widget__action-icon--phone" aria-hidden="true"></span>
+            <span class="contact-widget__action-label">Τηλέφωνο</span>
+          </a>
+        </li>
+      </ul>
+    </div>
+  </div>
+  <div class="contact-widget__backdrop" data-contact-backdrop hidden aria-hidden="true"></div>
+
   <script src="assets/app.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add floating contact widget markup with Viber, Email, and Τηλέφωνο actions and accessible dialog structure
- style the contact widget, backdrop, and animations while respecting safe areas and focus states
- implement widget toggle logic, focus management, visibility rules, and auto-open triggers tied to services, exit intent, and idle states

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68eee43409448320980b75f6cdae71bd