### PR TITLE
Update header and footer logo links to homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -103,7 +103,7 @@
 <body>
   <header class="site-header" id="top">
     <div class="container header-inner">
-      <a class="brand" href="#top" aria-label="FM Renovation – Αρχική">
+      <a class="brand" href="/" aria-label="FM Renovation – Αρχική">
         <img class="brand-logo" src="images/logo.png" alt="FM Renovation λογότυπο">
         <span class="brand-tagline"><strong>Ανακαινίσεις</strong></span>
       </a>
@@ -419,7 +419,7 @@
 
   <footer class="site-footer">
     <div class="container footer-inner">
-      <a class="brand brand--footer" href="#top" aria-label="FM Renovation – Αρχική">
+      <a class="brand brand--footer" href="/" aria-label="FM Renovation – Αρχική">
         <img class="brand-logo" src="images/logo.png" alt="FM Renovation λογότυπο">
       </a>
       <p>© <span id="year"></span> FM Renovation • <a href="https://anakainisou.gr/">anakainisou.gr</a></p>


### PR DESCRIPTION
## Summary
- update the header and footer brand logo links to point to the site root for quick navigation back home

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68f01561b5d083209a64680114909fc6