### PR TITLE
Add legal policy pages and update footer links

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -196,6 +196,8 @@ body.nav-open{overflow:hidden}
 .site-footer .icon{transition:background .2s ease,opacity .2s ease,transform .2s ease}
 .site-footer .icon:hover,
 .site-footer .icon:focus-visible{opacity:1;background:var(--accent);transform:translateY(-2px);outline:none}
+.legal-links{font-size:.85rem;opacity:.8;margin-top:8px}
+.legal-links a:hover{color:var(--accent)}
 
 /* CONTACT WIDGET */
 .contact-widget{position:fixed;right:clamp(16px,3vw,32px);bottom:clamp(16px,3vw,32px);display:flex;flex-direction:column;align-items:flex-end;gap:12px;z-index:140}

--- a/index.html
+++ b/index.html
@@ -427,6 +427,10 @@
         <a href="#" aria-label="Facebook" class="icon fb"></a>
         <a href="#" aria-label="Instagram" class="icon ig"></a>
       </div>
+      <div class="legal-links">
+        <a href="/terms.html">Όροι Χρήσης</a> · 
+        <a href="/privacy-policy.html">Πολιτική Απορρήτου</a>
+      </div>
     </div>
   </footer>
 

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -1,0 +1,163 @@
+<!doctype html>
+<html lang="el">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>FM Renovation – Πολιτική Απορρήτου</title>
+  <meta name="description" content="Πολιτική απορρήτου της FM Renovation σύμφωνα με τον Γενικό Κανονισμό Προστασίας Δεδομένων (GDPR).">
+  <link rel="canonical" href="https://www.anakainisou.gr/privacy-policy.html">
+  <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Roboto:wght@700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="assets/style.css">
+</head>
+<body>
+  <header class="site-header" id="top">
+    <div class="container header-inner">
+      <a class="brand" href="/" aria-label="FM Renovation – Αρχική">
+        <img class="brand-logo" src="images/logo.png" alt="FM Renovation λογότυπο">
+        <span class="brand-tagline"><strong>Ανακαινίσεις</strong></span>
+      </a>
+      <button class="nav-toggle" type="button" data-nav-toggle aria-expanded="false" aria-controls="mobile-menu" aria-label="Άνοιγμα μενού">
+        <span class="nav-toggle-bar"></span>
+        <span class="nav-toggle-bar"></span>
+        <span class="nav-toggle-bar"></span>
+      </button>
+      <nav id="site-nav" class="nav" aria-label="Κύρια πλοήγηση">
+        <ul class="nav__list">
+          <li class="nav__item"><a href="/index.html#about" class="nav__link">Σχετικά</a></li>
+          <li class="nav__item nav-item--has-submenu">
+            <button class="nav__link nav__link--parent" type="button" aria-expanded="false" data-desktop-parent>
+              Υπηρεσίες
+              <span class="nav-caret" aria-hidden="true"></span>
+            </button>
+            <ul class="submenu">
+              <li><a href="/index.html#services" class="submenu__link">Ανακαίνιση Κατοικίας</a></li>
+              <li><a href="/index.html#services" class="submenu__link">Μπάνιο</a></li>
+              <li><a href="/index.html#services" class="submenu__link">Κουζίνα</a></li>
+              <li><a href="/index.html#services" class="submenu__link">Ηλεκτρολογικά – Υ.Δ.Ε.</a></li>
+              <li><a href="/index.html#services" class="submenu__link">Υδραυλικά</a></li>
+              <li><a href="/index.html#services" class="submenu__link">Κουφώματα</a></li>
+            </ul>
+          </li>
+          <li class="nav__item"><a href="/index.html#reasons" class="nav__link">Γιατί εμείς</a></li>
+          <li class="nav__item"><a href="/index.html#process" class="nav__link">Διαδικασία</a></li>
+          <li class="nav__item"><a href="/index.html#gallery" class="nav__link">Gallery</a></li>
+          <li class="nav__item nav__item--cta"><a href="/index.html#contact" class="btn btn--sm nav-cta">Ζητήστε Προσφορά</a></li>
+        </ul>
+      </nav>
+      <div class="social">
+        <a href="#" aria-label="Facebook" class="icon fb"></a>
+        <a href="#" aria-label="Instagram" class="icon ig"></a>
+      </div>
+    </div>
+  </header>
+
+  <div class="nav-backdrop" data-nav-backdrop hidden></div>
+  <div class="nav-overlay" id="mobile-menu" role="dialog" aria-modal="true" aria-labelledby="mobile-menu-title" hidden>
+    <div class="nav-overlay__inner" data-mobile-overlay>
+      <div class="nav-overlay__top">
+        <h2 id="mobile-menu-title" class="nav-overlay__title">Μενού</h2>
+        <button class="nav-close" type="button" data-nav-close aria-label="Κλείσιμο μενού">
+          <span class="nav-close-bar"></span>
+          <span class="nav-close-bar"></span>
+        </button>
+      </div>
+      <nav class="nav-mobile" aria-label="Κύρια πλοήγηση" data-mobile-nav>
+        <ul class="nav-mobile__list">
+          <li class="nav-mobile__item"><a href="/index.html#about" class="nav-mobile__link">Σχετικά</a></li>
+          <li class="nav-mobile__item nav-mobile__item--has-submenu">
+            <button class="nav-mobile__link nav-mobile__link--parent" type="button" aria-expanded="false" data-mobile-parent>
+              Υπηρεσίες
+              <span class="nav-caret" aria-hidden="true"></span>
+            </button>
+            <ul class="nav-mobile__submenu">
+              <li><a href="/index.html#services" class="nav-mobile__sublink">Ανακαίνιση Κατοικίας</a></li>
+              <li><a href="/index.html#services" class="nav-mobile__sublink">Μπάνιο</a></li>
+              <li><a href="/index.html#services" class="nav-mobile__sublink">Κουζίνα</a></li>
+              <li><a href="/index.html#services" class="nav-mobile__sublink">Ηλεκτρολογικά – Υ.Δ.Ε.</a></li>
+              <li><a href="/index.html#services" class="nav-mobile__sublink">Υδραυλικά</a></li>
+              <li><a href="/index.html#services" class="nav-mobile__sublink">Κουφώματα</a></li>
+            </ul>
+          </li>
+          <li class="nav-mobile__item"><a href="/index.html#reasons" class="nav-mobile__link">Γιατί εμείς</a></li>
+          <li class="nav-mobile__item"><a href="/index.html#process" class="nav-mobile__link">Διαδικασία</a></li>
+          <li class="nav-mobile__item"><a href="/index.html#gallery" class="nav-mobile__link">Gallery</a></li>
+          <li class="nav-mobile__item nav-mobile__item--cta"><a href="/index.html#contact" class="btn btn--primary nav-mobile__cta">Ζητήστε Προσφορά</a></li>
+        </ul>
+      </nav>
+      <div class="nav-overlay__social">
+        <a href="#" aria-label="Facebook" class="icon fb"></a>
+        <a href="#" aria-label="Instagram" class="icon ig"></a>
+      </div>
+    </div>
+  </div>
+
+  <main>
+    <section class="section">
+      <div class="container">
+        <h1>Πολιτική Απορρήτου</h1>
+        <p><strong>Τελευταία ενημέρωση:</strong> Οκτώβριος 2025</p>
+        <p>Η FM Renovation σέβεται την ιδιωτικότητα των επισκεπτών της και συμμορφώνεται με τον Γενικό Κανονισμό Προστασίας Δεδομένων (ΕΕ 2016/679).</p>
+        <ol>
+          <li><strong>Ποια δεδομένα συλλέγουμε</strong><br>Μέσω της φόρμας επικοινωνίας συλλέγουμε ονοματεπώνυμο, email, τηλέφωνο και μήνυμα. Χρησιμοποιούνται αποκλειστικά για επικοινωνία με τον πελάτη.</li>
+          <li><strong>Χρήση δεδομένων</strong><br>Τα στοιχεία χρησιμοποιούνται για απάντηση σε αιτήματα, παροχή πληροφοριών ή βελτίωση υπηρεσιών. Δεν κοινοποιούνται σε τρίτους εκτός αν απαιτείται από τον νόμο.</li>
+          <li><strong>Cookies &amp; Analytics</strong><br>Η ιστοσελίδα μπορεί να χρησιμοποιεί cookies και εργαλεία ανάλυσης (π.χ. Google Analytics). Οι επισκέπτες μπορούν να απενεργοποιήσουν τα cookies μέσω του browser τους.</li>
+          <li><strong>Ασφάλεια δεδομένων</strong><br>Η εταιρεία λαμβάνει κατάλληλα τεχνικά και οργανωτικά μέτρα για την προστασία των δεδομένων από μη εξουσιοδοτημένη πρόσβαση ή απώλεια.</li>
+          <li><strong>Δικαιώματα χρηστών</strong><br>Οι χρήστες έχουν δικαίωμα πρόσβασης, διόρθωσης, διαγραφής και εναντίωσης στην επεξεργασία. Για αιτήματα, επικοινωνήστε στο <a href="mailto:info@anakainisou.gr">info@anakainisou.gr</a>.</li>
+          <li><strong>Διατήρηση δεδομένων</strong><br>Τα δεδομένα διατηρούνται μόνο για όσο είναι απαραίτητα και διαγράφονται με ασφάλεια μετά το πέρας του σκοπού συλλογής τους.</li>
+          <li><strong>Τροποποιήσεις</strong><br>Η εταιρεία μπορεί να ενημερώνει την Πολιτική Απορρήτου. Η τελευταία έκδοση θα δημοσιεύεται στη σελίδα anakainisou.gr/privacy-policy.html.</li>
+        </ol>
+        <p><strong>Υπεύθυνος επεξεργασίας:</strong></p>
+        <address>
+          FM Renovation<br>
+          Λ. Κηφισίας 120, Μαρούσι, Αθήνα<br>
+          Τηλ: +30 210 55 44 321<br>
+          Email: <a href="mailto:info@anakainisou.gr">info@anakainisou.gr</a>
+        </address>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container footer-inner">
+      <a class="brand brand--footer" href="/" aria-label="FM Renovation – Αρχική">
+        <img class="brand-logo" src="images/logo.png" alt="FM Renovation λογότυπο">
+      </a>
+      <p>© <span id="year"></span> FM Renovation • <a href="https://anakainisou.gr/">anakainisou.gr</a></p>
+      <div class="social">
+        <a href="#" aria-label="Facebook" class="icon fb"></a>
+        <a href="#" aria-label="Instagram" class="icon ig"></a>
+      </div>
+      <div class="legal-links">
+        <a href="/terms.html">Όροι Χρήσης</a> · 
+        <a href="/privacy-policy.html">Πολιτική Απορρήτου</a>
+      </div>
+    </div>
+  </footer>
+
+  <div class="contact-widget" aria-label="Γρήγορη επικοινωνία">
+    <div id="contactWidgetPanel" class="contact-widget__panel" aria-hidden="true">
+      <a class="contact-widget__link" href="mailto:info@example.com">
+        <span class="contact-widget__icon" aria-hidden="true">
+          <img src="images/icons/email.svg" width="36" height="36" alt="" loading="lazy">
+        </span>
+        <span>Email</span>
+      </a>
+      <a class="contact-widget__link" href="viber://chat?number=+300000000000">
+        <span class="contact-widget__icon" aria-hidden="true">
+          <img src="images/icons/viber.svg" width="36" height="36" alt="" loading="lazy">
+        </span>
+        <span>Viber</span>
+      </a>
+    </div>
+    <button class="contact-widget__toggle" type="button" aria-expanded="false" aria-controls="contactWidgetPanel" aria-label="Άνοιγμα επιλογών επικοινωνίας">
+      <svg aria-hidden="true" width="28" height="28" viewBox="0 0 24 24" fill="none">
+        <path d="M12 3C7.03 3 3 6.58 3 11c0 2.35 1.16 4.47 3 5.96V21l3.07-1.64c.96.27 1.99.42 3.08.42 4.97 0 9-3.58 9-8s-4.03-8-9-8Zm-.14 11.91h-.02c-.31 0-.6-.03-.88-.08-.76.52-1.6.95-2.49 1.26.47-.69.76-1.32.88-1.94-1.11-.74-1.81-1.82-1.81-3.05 0-2.22 2.09-4.02 4.67-4.02s4.67 1.8 4.67 4.02-2.09 4.03-4.66 4.03Z" fill="currentColor"/>
+      </svg>
+      <span class="visually-hidden">Contact</span>
+    </button>
+  </div>
+
+  <script src="assets/app.js" defer></script>
+</body>
+</html>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -5,4 +5,14 @@
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
+  <url>
+    <loc>https://www.anakainisou.gr/terms.html</loc>
+    <changefreq>yearly</changefreq>
+    <priority>0.4</priority>
+  </url>
+  <url>
+    <loc>https://www.anakainisou.gr/privacy-policy.html</loc>
+    <changefreq>yearly</changefreq>
+    <priority>0.4</priority>
+  </url>
 </urlset>

--- a/terms.html
+++ b/terms.html
@@ -1,0 +1,162 @@
+<!doctype html>
+<html lang="el">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>FM Renovation – Όροι Χρήσης</title>
+  <meta name="description" content="Όροι και προϋποθέσεις χρήσης του ιστότοπου anakainisou.gr της εταιρείας FM Renovation.">
+  <link rel="canonical" href="https://www.anakainisou.gr/terms.html">
+  <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Roboto:wght@700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="assets/style.css">
+</head>
+<body>
+  <header class="site-header" id="top">
+    <div class="container header-inner">
+      <a class="brand" href="/" aria-label="FM Renovation – Αρχική">
+        <img class="brand-logo" src="images/logo.png" alt="FM Renovation λογότυπο">
+        <span class="brand-tagline"><strong>Ανακαινίσεις</strong></span>
+      </a>
+      <button class="nav-toggle" type="button" data-nav-toggle aria-expanded="false" aria-controls="mobile-menu" aria-label="Άνοιγμα μενού">
+        <span class="nav-toggle-bar"></span>
+        <span class="nav-toggle-bar"></span>
+        <span class="nav-toggle-bar"></span>
+      </button>
+      <nav id="site-nav" class="nav" aria-label="Κύρια πλοήγηση">
+        <ul class="nav__list">
+          <li class="nav__item"><a href="/index.html#about" class="nav__link">Σχετικά</a></li>
+          <li class="nav__item nav-item--has-submenu">
+            <button class="nav__link nav__link--parent" type="button" aria-expanded="false" data-desktop-parent>
+              Υπηρεσίες
+              <span class="nav-caret" aria-hidden="true"></span>
+            </button>
+            <ul class="submenu">
+              <li><a href="/index.html#services" class="submenu__link">Ανακαίνιση Κατοικίας</a></li>
+              <li><a href="/index.html#services" class="submenu__link">Μπάνιο</a></li>
+              <li><a href="/index.html#services" class="submenu__link">Κουζίνα</a></li>
+              <li><a href="/index.html#services" class="submenu__link">Ηλεκτρολογικά – Υ.Δ.Ε.</a></li>
+              <li><a href="/index.html#services" class="submenu__link">Υδραυλικά</a></li>
+              <li><a href="/index.html#services" class="submenu__link">Κουφώματα</a></li>
+            </ul>
+          </li>
+          <li class="nav__item"><a href="/index.html#reasons" class="nav__link">Γιατί εμείς</a></li>
+          <li class="nav__item"><a href="/index.html#process" class="nav__link">Διαδικασία</a></li>
+          <li class="nav__item"><a href="/index.html#gallery" class="nav__link">Gallery</a></li>
+          <li class="nav__item nav__item--cta"><a href="/index.html#contact" class="btn btn--sm nav-cta">Ζητήστε Προσφορά</a></li>
+        </ul>
+      </nav>
+      <div class="social">
+        <a href="#" aria-label="Facebook" class="icon fb"></a>
+        <a href="#" aria-label="Instagram" class="icon ig"></a>
+      </div>
+    </div>
+  </header>
+
+  <div class="nav-backdrop" data-nav-backdrop hidden></div>
+  <div class="nav-overlay" id="mobile-menu" role="dialog" aria-modal="true" aria-labelledby="mobile-menu-title" hidden>
+    <div class="nav-overlay__inner" data-mobile-overlay>
+      <div class="nav-overlay__top">
+        <h2 id="mobile-menu-title" class="nav-overlay__title">Μενού</h2>
+        <button class="nav-close" type="button" data-nav-close aria-label="Κλείσιμο μενού">
+          <span class="nav-close-bar"></span>
+          <span class="nav-close-bar"></span>
+        </button>
+      </div>
+      <nav class="nav-mobile" aria-label="Κύρια πλοήγηση" data-mobile-nav>
+        <ul class="nav-mobile__list">
+          <li class="nav-mobile__item"><a href="/index.html#about" class="nav-mobile__link">Σχετικά</a></li>
+          <li class="nav-mobile__item nav-mobile__item--has-submenu">
+            <button class="nav-mobile__link nav-mobile__link--parent" type="button" aria-expanded="false" data-mobile-parent>
+              Υπηρεσίες
+              <span class="nav-caret" aria-hidden="true"></span>
+            </button>
+            <ul class="nav-mobile__submenu">
+              <li><a href="/index.html#services" class="nav-mobile__sublink">Ανακαίνιση Κατοικίας</a></li>
+              <li><a href="/index.html#services" class="nav-mobile__sublink">Μπάνιο</a></li>
+              <li><a href="/index.html#services" class="nav-mobile__sublink">Κουζίνα</a></li>
+              <li><a href="/index.html#services" class="nav-mobile__sublink">Ηλεκτρολογικά – Υ.Δ.Ε.</a></li>
+              <li><a href="/index.html#services" class="nav-mobile__sublink">Υδραυλικά</a></li>
+              <li><a href="/index.html#services" class="nav-mobile__sublink">Κουφώματα</a></li>
+            </ul>
+          </li>
+          <li class="nav-mobile__item"><a href="/index.html#reasons" class="nav-mobile__link">Γιατί εμείς</a></li>
+          <li class="nav-mobile__item"><a href="/index.html#process" class="nav-mobile__link">Διαδικασία</a></li>
+          <li class="nav-mobile__item"><a href="/index.html#gallery" class="nav-mobile__link">Gallery</a></li>
+          <li class="nav-mobile__item nav-mobile__item--cta"><a href="/index.html#contact" class="btn btn--primary nav-mobile__cta">Ζητήστε Προσφορά</a></li>
+        </ul>
+      </nav>
+      <div class="nav-overlay__social">
+        <a href="#" aria-label="Facebook" class="icon fb"></a>
+        <a href="#" aria-label="Instagram" class="icon ig"></a>
+      </div>
+    </div>
+  </div>
+
+  <main>
+    <section class="section">
+      <div class="container">
+        <h1>Όροι Χρήσης</h1>
+        <p><strong>Τελευταία ενημέρωση:</strong> Οκτώβριος 2025</p>
+        <p>Καλώς ήρθατε στο anakainisou.gr, την επίσημη ιστοσελίδα της εταιρείας FM Renovation, που δραστηριοποιείται στον τομέα των ανακαινίσεων οικιών και επαγγελματικών χώρων. Η πρόσβαση και χρήση του παρόντος ιστότοπου προϋποθέτει την πλήρη αποδοχή των παρακάτω όρων.</p>
+        <ol>
+          <li><strong>Ιδιοκτησία &amp; Περιεχόμενο</strong><br>Ο ιστότοπος, το λογότυπο, τα κείμενα, οι φωτογραφίες και κάθε άλλο περιεχόμενο αποτελούν πνευματική ιδιοκτησία της FM Renovation και προστατεύονται από την ελληνική και ευρωπαϊκή νομοθεσία. Απαγορεύεται η αναπαραγωγή, αντιγραφή ή εκμετάλλευση περιεχομένου χωρίς έγγραφη άδεια.</li>
+          <li><strong>Παρεχόμενες Πληροφορίες</strong><br>Η εταιρεία καταβάλλει κάθε δυνατή προσπάθεια ώστε οι πληροφορίες να είναι ακριβείς και ενημερωμένες, χωρίς ευθύνη για λάθη ή παραλείψεις.</li>
+          <li><strong>Ευθύνη Χρήστη</strong><br>Ο χρήστης οφείλει να κάνει χρήση του ιστότοπου σύμφωνα με τη νομοθεσία και τα χρηστά ήθη. Απαγορεύεται η αποστολή παράνομου ή προσβλητικού περιεχομένου.</li>
+          <li><strong>Εξωτερικοί Σύνδεσμοι</strong><br>Ο ιστότοπος μπορεί να περιέχει συνδέσμους προς άλλους ιστότοπους, για το περιεχόμενο των οποίων η FM Renovation δεν φέρει ευθύνη.</li>
+          <li><strong>Τροποποιήσεις</strong><br>Η εταιρεία διατηρεί το δικαίωμα να τροποποιεί ή να ενημερώνει τους παρόντες όρους χωρίς προειδοποίηση.</li>
+          <li><strong>Εφαρμοστέο Δίκαιο</strong><br>Οι παρόντες όροι διέπονται από το Ελληνικό Δίκαιο και αρμόδια είναι τα Δικαστήρια Αθηνών.</li>
+        </ol>
+        <p><strong>Επικοινωνία:</strong></p>
+        <address>
+          FM Renovation<br>
+          Λ. Κηφισίας 120, Μαρούσι, Αθήνα<br>
+          Τηλ: +30 2114 044 496<br>
+          Email: <a href="mailto:info@anakainisou.gr">info@anakainisou.gr</a>
+        </address>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container footer-inner">
+      <a class="brand brand--footer" href="/" aria-label="FM Renovation – Αρχική">
+        <img class="brand-logo" src="images/logo.png" alt="FM Renovation λογότυπο">
+      </a>
+      <p>© <span id="year"></span> FM Renovation • <a href="https://anakainisou.gr/">anakainisou.gr</a></p>
+      <div class="social">
+        <a href="#" aria-label="Facebook" class="icon fb"></a>
+        <a href="#" aria-label="Instagram" class="icon ig"></a>
+      </div>
+      <div class="legal-links">
+        <a href="/terms.html">Όροι Χρήσης</a> · 
+        <a href="/privacy-policy.html">Πολιτική Απορρήτου</a>
+      </div>
+    </div>
+  </footer>
+
+  <div class="contact-widget" aria-label="Γρήγορη επικοινωνία">
+    <div id="contactWidgetPanel" class="contact-widget__panel" aria-hidden="true">
+      <a class="contact-widget__link" href="mailto:info@example.com">
+        <span class="contact-widget__icon" aria-hidden="true">
+          <img src="images/icons/email.svg" width="36" height="36" alt="" loading="lazy">
+        </span>
+        <span>Email</span>
+      </a>
+      <a class="contact-widget__link" href="viber://chat?number=+300000000000">
+        <span class="contact-widget__icon" aria-hidden="true">
+          <img src="images/icons/viber.svg" width="36" height="36" alt="" loading="lazy">
+        </span>
+        <span>Viber</span>
+      </a>
+    </div>
+    <button class="contact-widget__toggle" type="button" aria-expanded="false" aria-controls="contactWidgetPanel" aria-label="Άνοιγμα επιλογών επικοινωνίας">
+      <svg aria-hidden="true" width="28" height="28" viewBox="0 0 24 24" fill="none">
+        <path d="M12 3C7.03 3 3 6.58 3 11c0 2.35 1.16 4.47 3 5.96V21l3.07-1.64c.96.27 1.99.42 3.08.42 4.97 0 9-3.58 9-8s-4.03-8-9-8Zm-.14 11.91h-.02c-.31 0-.6-.03-.88-.08-.76.52-1.6.95-2.49 1.26.47-.69.76-1.32.88-1.94-1.11-.74-1.81-1.82-1.81-3.05 0-2.22 2.09-4.02 4.67-4.02s4.67 1.8 4.67 4.02-2.09 4.03-4.66 4.03Z" fill="currentColor"/>
+      </svg>
+      <span class="visually-hidden">Contact</span>
+    </button>
+  </div>
+
+  <script src="assets/app.js" defer></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add dedicated Greek-language terms of use and privacy policy pages with canonical metadata
- link the new legal pages from the footer and apply light styling for the links
- extend the sitemap to include the legal pages for SEO

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68f021b44fb08320b6b208eb2823b516