### PR TITLE
Ensure brand logos refresh homepage

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -345,3 +345,16 @@ if(form){form.addEventListener('submit',e=>{e.preventDefault();alert('Ευχαρ
     }
   });
 })();
+
+// Force homepage refresh when clicking on brand logos
+document.querySelectorAll('a.brand').forEach(function(link){
+  link.addEventListener('click',function(event){
+    const targetUrl=new URL(link.href,window.location.href);
+    const currentUrl=new URL(window.location.href);
+    if(targetUrl.pathname===currentUrl.pathname&&targetUrl.search===currentUrl.search){
+      event.preventDefault();
+      window.location.href=targetUrl.href;
+      window.location.reload();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- ensure clicking the header and footer brand logos refreshes the homepage when already on it by forcing a reload

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68f02223738c8320b17eec2fc1cfa0d2