### PR TITLE
Remove redundant legal footer links

### DIFF
--- a/index.html
+++ b/index.html
@@ -465,10 +465,6 @@
           <a href="#" aria-label="Instagram" class="icon ig"></a>
         </div>
       </div>
-      <div class="legal-links">
-        <a href="/terms.html">Όροι Χρήσης</a> · 
-        <a href="/privacy-policy.html">Πολιτική Απορρήτου</a>
-      </div>
     </div>
   </footer>
 

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -128,10 +128,6 @@
         <a href="#" aria-label="Facebook" class="icon fb"></a>
         <a href="#" aria-label="Instagram" class="icon ig"></a>
       </div>
-      <div class="legal-links">
-        <a href="/terms.html">Όροι Χρήσης</a> · 
-        <a href="/privacy-policy.html">Πολιτική Απορρήτου</a>
-      </div>
     </div>
   </footer>
 

--- a/terms.html
+++ b/terms.html
@@ -127,10 +127,6 @@
         <a href="#" aria-label="Facebook" class="icon fb"></a>
         <a href="#" aria-label="Instagram" class="icon ig"></a>
       </div>
-      <div class="legal-links">
-        <a href="/terms.html">Όροι Χρήσης</a> · 
-        <a href="/privacy-policy.html">Πολιτική Απορρήτου</a>
-      </div>
     </div>
   </footer>
 


### PR DESCRIPTION
## Summary
- remove the stray legal links block from the shared footer on the homepage
- align the privacy policy and terms pages with the streamlined footer layout

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f0296ee7948320ac40c36a4dcf3ea1