### PR TITLE
Add brand-specific hover colors for footer social icons

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -208,9 +208,13 @@ body.nav-open{overflow:hidden}
 .brand--footer{margin:0}
 .brand--footer .brand-logo{height:48px}
 .site-footer .social{margin-left:0}
-.site-footer .icon{transition:background .2s ease,opacity .2s ease,transform .2s ease}
+.site-footer .icon{background:var(--accent-2);transition:background .2s ease,opacity .2s ease,transform .2s ease}
 .site-footer .icon:hover,
-.site-footer .icon:focus-visible{opacity:1;background:var(--accent);transform:translateY(-2px);outline:none}
+.site-footer .icon:focus-visible{opacity:1;transform:translateY(-2px);outline:none}
+.site-footer .icon.fb:hover,
+.site-footer .icon.fb:focus-visible{background:#1877F2}
+.site-footer .icon.ig:hover,
+.site-footer .icon.ig:focus-visible{background:#E4405F}
 .legal-links{font-size:.85rem;opacity:.8;margin-top:8px;text-align:center;width:100%}
 .legal-links a:hover{color:var(--accent)}
 


### PR DESCRIPTION
## Summary
- update the footer social icon styles to use dark neutral default fill
- add Facebook and Instagram brand colors on hover/focus to emphasize the interactive state

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f02de21b408320b498f83ce04bcfde