### PR TITLE
Fix header logo dimensions

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -26,6 +26,7 @@ img{max-width:100%;height:auto;display:block}
 .site-header.is-scrolled{box-shadow:0 12px 30px rgba(15,23,42,.12);border-bottom-color:rgba(15,23,42,.08)}
 .header-inner{display:flex;align-items:center;gap:12px;padding:12px 0;flex-wrap:wrap}
 .brand{display:inline-flex;flex-direction:column;align-items:center;gap:4px;text-decoration:none;color:inherit;cursor:pointer}
+.brand-logo{height:52px;width:auto}
 
 
 .nav-toggle{display:inline-flex;flex-direction:column;align-items:center;justify-content:center;gap:6px;width:46px;height:46px;border:1px solid #d8dee9;border-radius:12px;background:rgba(255,255,255,.72);cursor:pointer;transition:background .2s ease,border-color .2s ease}


### PR DESCRIPTION
## Summary
- set a default height for the header brand logo so it renders at the intended size on small screens

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f03080f6648320b9058dced816d0d1