### PR TITLE
Update header and footer logos to point to external site

### DIFF
--- a/index.html
+++ b/index.html
@@ -103,7 +103,7 @@
 <body>
   <header class="site-header" id="top">
     <div class="container header-inner">
-      <a class="brand" href="/index.html" aria-label="FM Renovation – Αρχική">
+      <a class="brand" href="https://mastereat.github.io/anakainisou.gr/" aria-label="FM Renovation – Αρχική">
         <img class="brand-logo" src="images/logo.png" alt="FM Renovation λογότυπο">
         <span class="brand-tagline"><strong>Ανακαινίσεις</strong></span>
       </a>
@@ -449,7 +449,7 @@
         </ul>
       </div>
       <div class="footer-brand">
-        <a class="brand brand--footer" href="/index.html" aria-label="FM Renovation – Αρχική">
+        <a class="brand brand--footer" href="https://mastereat.github.io/anakainisou.gr/" aria-label="FM Renovation – Αρχική">
           <img class="brand-logo" src="images/logo.png" alt="FM Renovation λογότυπο">
         </a>
         <nav class="footer-links" aria-label="Χρήσιμες σύνδεσμοι">

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -13,7 +13,7 @@
 <body>
   <header class="site-header" id="top">
     <div class="container header-inner">
-      <a class="brand" href="/index.html" aria-label="FM Renovation – Αρχική">
+      <a class="brand" href="https://mastereat.github.io/anakainisou.gr/" aria-label="FM Renovation – Αρχική">
         <img class="brand-logo" src="images/logo.png" alt="FM Renovation λογότυπο">
         <span class="brand-tagline"><strong>Ανακαινίσεις</strong></span>
       </a>
@@ -120,7 +120,7 @@
 
   <footer class="site-footer">
     <div class="container footer-inner">
-      <a class="brand brand--footer" href="/index.html" aria-label="FM Renovation – Αρχική">
+      <a class="brand brand--footer" href="https://mastereat.github.io/anakainisou.gr/" aria-label="FM Renovation – Αρχική">
         <img class="brand-logo" src="images/logo.png" alt="FM Renovation λογότυπο">
       </a>
       <p>© <span id="year"></span> FM Renovation • <a href="https://anakainisou.gr/">anakainisou.gr</a></p>

--- a/terms.html
+++ b/terms.html
@@ -13,7 +13,7 @@
 <body>
   <header class="site-header" id="top">
     <div class="container header-inner">
-      <a class="brand" href="/index.html" aria-label="FM Renovation – Αρχική">
+      <a class="brand" href="https://mastereat.github.io/anakainisou.gr/" aria-label="FM Renovation – Αρχική">
         <img class="brand-logo" src="images/logo.png" alt="FM Renovation λογότυπο">
         <span class="brand-tagline"><strong>Ανακαινίσεις</strong></span>
       </a>
@@ -119,7 +119,7 @@
 
   <footer class="site-footer">
     <div class="container footer-inner">
-      <a class="brand brand--footer" href="/index.html" aria-label="FM Renovation – Αρχική">
+      <a class="brand brand--footer" href="https://mastereat.github.io/anakainisou.gr/" aria-label="FM Renovation – Αρχική">
         <img class="brand-logo" src="images/logo.png" alt="FM Renovation λογότυπο">
       </a>
       <p>© <span id="year"></span> FM Renovation • <a href="https://anakainisou.gr/">anakainisou.gr</a></p>


### PR DESCRIPTION
## Summary
- point the header logo to https://mastereat.github.io/anakainisou.gr/ across site pages
- update footer logo links to use the same external destination

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f03267bbd8832097e4ee05e093e766