### PR TITLE
Implement 3D rotating services carousel

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -271,273 +271,215 @@ if('IntersectionObserver'in window&&servicesSection&&servicesNavLinks.length){
 
 (function(){
   if(!servicesSection){return;}
-  const grid=servicesSection.querySelector('[data-services-grid]');
-  if(!grid){return;}
-  const cards=Array.from(grid.querySelectorAll('.service'));
-  if(!cards.length){return;}
-  const cardMap=new Map(cards.map(card=>[card.id,card]));
-  const controls=servicesSection.querySelector('[data-services-controls]');
-  const chipButtons=controls?Array.from(controls.querySelectorAll('[data-services-chip]')):[];
-  const searchInput=controls?controls.querySelector('[data-services-search]'):null;
-  const actions=servicesSection.querySelector('.services__actions');
-  const moreButton=actions?actions.querySelector('[data-services-more]'):null;
-  const emptyState=servicesSection.querySelector('[data-services-empty]');
-  const mobileMedia=window.matchMedia('(max-width: 767px)');
-  const header=document.querySelector('.site-header');
-  const step=6;
-  const openCards=new Set();
-  let lastFiltered=cards.slice();
-  const state={category:'all',search:'',visibleCount:step};
+  const carousel=servicesSection.querySelector('[data-services-carousel]');
+  if(!carousel){return;}
+  const ring=carousel.querySelector('[data-carousel-ring]');
+  const cards=ring?Array.from(ring.querySelectorAll('.service')):[];
+  if(!ring||!cards.length){return;}
+  const prevBtn=carousel.querySelector('[data-carousel-prev]');
+  const nextBtn=carousel.querySelector('[data-carousel-next]');
+  const viewport=carousel.querySelector('[data-carousel-viewport]')||carousel;
+  const reducedMotion=window.matchMedia('(prefers-reduced-motion: reduce)');
+  const flatMedia=window.matchMedia('(max-width: 479px)');
+  const compactMedia=window.matchMedia('(max-width: 767px)');
+  const total=cards.length;
+  const stepAngle=360/total;
+  let currentIndex=0;
+  let currentRotation=0;
+  let animationId=null;
+  let isAnimating=false;
+  let isVisible=true;
+  let touchStartX=null;
+  let touchStartY=null;
+  let touchDiffX=0;
 
-  const getSearchText=card=>{
-    const fromAttr=card.getAttribute('data-search')||'';
-    const title=card.querySelector('.service__title');
-    return `${fromAttr} ${title?title.textContent:''}`;
-  };
+  const easeInOutCubic=t=>t<0.5?4*t*t*t:1-Math.pow(-2*t+2,3)/2;
+  const clampIndex=index=>{const mod=index%total;return mod<0?mod+total:mod;};
+  const isFlat=()=>carousel.classList.contains('is-flat');
 
-  const matchesCategory=card=>{
-    if(state.category==='all'){return true;}
-    const cat=(card.dataset.cat||'').split(/\s+/).filter(Boolean);
-    return cat.includes(state.category);
-  };
-
-  const matchesSearch=card=>{
-    if(!state.search){return true;}
-    return getSearchText(card).toLowerCase().includes(state.search.toLowerCase());
-  };
-
-  const getFilteredCards=()=>cards.filter(card=>matchesCategory(card)&&matchesSearch(card));
-
-  const renderCard=(card,open,{updateStore=true}={})=>{
-    const toggle=card.querySelector('.service__toggle');
-    const panel=card.querySelector('.service__panel');
-    if(!toggle||!panel){return;}
-    if(updateStore){
-      if(open){openCards.add(card.id);}else{openCards.delete(card.id);}
-    }
-    toggle.setAttribute('aria-expanded',String(open));
-    card.classList.toggle('is-open',open);
-    if(mobileMedia.matches){
-      panel.style.maxHeight=open?`${panel.scrollHeight}px`:'0px';
-    }else{
-      panel.style.maxHeight='';
-    }
-  };
-
-  const syncAccordions=()=>{
-    cards.forEach(card=>{
-      const toggle=card.querySelector('.service__toggle');
-      if(!toggle){return;}
-      if(mobileMedia.matches){
-        toggle.disabled=false;
-        renderCard(card,openCards.has(card.id),{updateStore:false});
-      }else{
-        toggle.disabled=true;
-        renderCard(card,true,{updateStore:false});
-      }
-    });
-  };
-
-  const refreshOpenPanels=()=>{
-    if(!mobileMedia.matches){return;}
-    openCards.forEach(id=>{
-      const card=cardMap.get(id);
-      if(!card||card.hidden){return;}
-      const panel=card.querySelector('.service__panel');
-      if(panel){panel.style.maxHeight=`${panel.scrollHeight}px`;}
-    });
-  };
-
-  const setVisibleCount=count=>{
-    state.visibleCount=Math.max(step,count);
-  };
-
-  const applyState=()=>{
-    const isMobile=mobileMedia.matches;
-    const filtered=getFilteredCards();
-    lastFiltered=filtered.slice();
-    const total=filtered.length;
-
-    if(!isMobile){
-      cards.forEach(card=>{card.hidden=false;});
-      if(emptyState){emptyState.hidden=true;}
-      if(actions){actions.hidden=true;}
-      syncAccordions();
+  const applyAngles=()=>{
+    if(isFlat()){
+      cards.forEach(card=>{
+        card.style.removeProperty('--angle');
+        card.style.removeProperty('--radius');
+      });
       return;
     }
-
-    setVisibleCount(state.visibleCount);
-    cards.forEach(card=>{card.hidden=true;});
-    const limit=total===0?0:Math.min(state.visibleCount,total);
-    filtered.forEach((card,index)=>{
-      card.hidden=index>=limit;
-    });
-
-    if(emptyState){emptyState.hidden=total!==0;}
-    if(actions){
-      const shouldShowMore=total>step;
-      actions.hidden=!shouldShowMore;
-      if(moreButton){
-        if(shouldShowMore){
-          const showingAll=limit>=total&&total>step;
-          moreButton.textContent=showingAll?'Σύμπτυξη':'Εμφάνιση περισσότερων';
-          moreButton.setAttribute('aria-expanded',showingAll?'true':'false');
-        }else{
-          moreButton.textContent='Εμφάνιση περισσότερων';
-          moreButton.setAttribute('aria-expanded','false');
-        }
-      }
-    }
-    syncAccordions();
-    refreshOpenPanels();
-  };
-
-  const updateChipState=()=>{
-    chipButtons.forEach(btn=>{
-      const isActive=(btn.dataset.filter||'all')===state.category;
-      btn.classList.toggle('is-active',isActive);
-      btn.setAttribute('aria-selected',String(isActive));
+    const radius=compactMedia.matches?240:360;
+    cards.forEach((card,i)=>{
+      card.style.setProperty('--angle',`${i*stepAngle}deg`);
+      card.style.setProperty('--radius',`${radius}px`);
     });
   };
 
-  const debounce=(fn,delay)=>{
-    let timer;
-    return (...args)=>{
-      clearTimeout(timer);
-      timer=setTimeout(()=>fn(...args),delay);
-    };
-  };
-
-  if(chipButtons.length){
-    chipButtons.forEach((btn,index)=>{
-      btn.addEventListener('click',()=>{
-        const value=btn.dataset.filter||'all';
-        if(state.category===value){return;}
-        state.category=value;
-        setVisibleCount(step);
-        updateChipState();
-        applyState();
-      });
-      btn.addEventListener('keydown',event=>{
-        if(event.key!=='ArrowRight'&&event.key!=='ArrowLeft'){return;}
-        event.preventDefault();
-        if(!chipButtons.length){return;}
-        const dir=event.key==='ArrowRight'?1:-1;
-        const next=(index+dir+chipButtons.length)%chipButtons.length;
-        chipButtons[next].focus();
-      });
-    });
-  }
-
-  if(searchInput){
-    const handleSearch=debounce(()=>{
-      state.search=searchInput.value.trim();
-      setVisibleCount(step);
-      applyState();
-    },200);
-    searchInput.addEventListener('input',handleSearch);
-  }
-
-  if(moreButton){
-    moreButton.addEventListener('click',()=>{
-      const total=lastFiltered.length;
-      if(!total){return;}
-      if(state.visibleCount>=total){
-        setVisibleCount(step);
+  const setActiveCard=index=>{
+    cards.forEach((card,i)=>{
+      const isActive=i===index;
+      card.classList.toggle('is-active',isActive);
+      if(isActive){
+        card.removeAttribute('aria-hidden');
       }else{
-        setVisibleCount(state.visibleCount+step);
+        card.setAttribute('aria-hidden','true');
       }
-      applyState();
     });
-  }
+  };
 
-  cards.forEach(card=>{
-    const toggle=card.querySelector('.service__toggle');
-    if(!toggle){return;}
-    toggle.addEventListener('click',()=>{
-      if(!mobileMedia.matches){return;}
-      const isOpen=openCards.has(card.id);
-      renderCard(card,!isOpen);
-    });
+  const updateRotation=value=>{
+    ring.style.setProperty('--rotation',`${value}deg`);
+  };
+
+  const cancelAnimation=()=>{
+    if(animationId){cancelAnimationFrame(animationId);}
+    animationId=null;
+    isAnimating=false;
+  };
+
+  const scrollToCard=(index,{instant=false}={})=>{
+    if(!isFlat()){return;}
+    const target=cards[index];
+    if(!target){return;}
+    const behavior=instant||reducedMotion.matches?'auto':'smooth';
+    target.scrollIntoView({behavior,block:'nearest',inline:'center'});
+  };
+
+  const syncTransforms=(instant=false)=>{
+    cancelAnimation();
+    if(isFlat()){
+      scrollToCard(currentIndex,{instant});
+      return;
+    }
+    currentRotation=-currentIndex*stepAngle;
+    updateRotation(currentRotation);
+  };
+
+  const goTo=index=>{
+    const targetIndex=clampIndex(index);
+    if(targetIndex===currentIndex&&isAnimating===false){
+      return;
+    }
+    const startRotation=-currentIndex*stepAngle;
+    const endRotation=-targetIndex*stepAngle;
+    setActiveCard(targetIndex);
+    if(isFlat()){
+      currentIndex=targetIndex;
+      scrollToCard(currentIndex,{instant:false});
+      return;
+    }
+    cancelAnimation();
+    if(reducedMotion.matches||!isVisible){
+      currentIndex=targetIndex;
+      currentRotation=endRotation;
+      updateRotation(currentRotation);
+      return;
+    }
+    const duration=600;
+    const startTime=performance.now();
+    currentIndex=targetIndex;
+    isAnimating=true;
+    const step=now=>{
+      const progress=Math.min((now-startTime)/duration,1);
+      const eased=easeInOutCubic(progress);
+      const value=startRotation+(endRotation-startRotation)*eased;
+      currentRotation=value;
+      updateRotation(value);
+      if(progress<1&&isVisible){
+        animationId=requestAnimationFrame(step);
+      }else{
+        currentRotation=endRotation;
+        updateRotation(endRotation);
+        cancelAnimation();
+      }
+    };
+    animationId=requestAnimationFrame(step);
+  };
+
+  const rotateBy=delta=>{goTo(currentIndex+delta);};
+
+  const handleFlatChange=()=>{
+    if(flatMedia.matches){carousel.classList.add('is-flat');}else{carousel.classList.remove('is-flat');}
+    applyAngles();
+    syncTransforms(true);
+  };
+
+  const handleCompactChange=()=>{
+    applyAngles();
+    syncTransforms(true);
+  };
+
+  handleFlatChange();
+  setActiveCard(currentIndex);
+
+  const debouncedResize=(()=>{
+    let timer=null;
+    return ()=>{
+      if(timer){clearTimeout(timer);} 
+      timer=setTimeout(()=>{
+        applyAngles();
+        syncTransforms(true);
+      },120);
+    };
+  })();
+
+  window.addEventListener('resize',debouncedResize);
+
+  const addMediaListener=(media,listener)=>{
+    if(typeof media.addEventListener==='function'){media.addEventListener('change',listener);}else if(typeof media.addListener==='function'){media.addListener(listener);} 
+  };
+
+  addMediaListener(flatMedia,handleFlatChange);
+  addMediaListener(compactMedia,handleCompactChange);
+  addMediaListener(reducedMotion,()=>{if(reducedMotion.matches){cancelAnimation();syncTransforms(true);}});
+
+  if(prevBtn){prevBtn.addEventListener('click',()=>rotateBy(-1));}
+  if(nextBtn){nextBtn.addEventListener('click',()=>rotateBy(1));}
+
+  carousel.addEventListener('keydown',event=>{
+    if(event.key==='ArrowRight'){event.preventDefault();rotateBy(1);}else if(event.key==='ArrowLeft'){event.preventDefault();rotateBy(-1);}
   });
 
-  const updateStickyState=()=>{
-    if(!controls){return;}
-    if(!mobileMedia.matches){
-      controls.classList.remove('is-stuck');
-      return;
-    }
-    const sectionTop=servicesSection.getBoundingClientRect().top+window.scrollY;
-    const headerHeight=header?header.offsetHeight:0;
-    const isStuck=window.scrollY+headerHeight>=sectionTop;
-    controls.classList.toggle('is-stuck',isStuck);
-  };
-
-  let ticking=false;
-  window.addEventListener('scroll',()=>{
-    if(ticking){return;}
-    ticking=true;
-    requestAnimationFrame(()=>{
-      updateStickyState();
-      ticking=false;
-    });
+  const SWIPE_THRESHOLD=60;
+  viewport.addEventListener('touchstart',event=>{
+    if(event.touches.length!==1){return;}
+    touchStartX=event.touches[0].clientX;
+    touchStartY=event.touches[0].clientY;
+    touchDiffX=0;
   },{passive:true});
 
-  const handleMediaChange=()=>{
-    syncAccordions();
-    applyState();
-    updateStickyState();
-  };
+  viewport.addEventListener('touchmove',event=>{
+    if(touchStartX===null){return;}
+    const touch=event.touches[0];
+    const dx=touch.clientX-touchStartX;
+    const dy=touch.clientY-touchStartY;
+    if(Math.abs(dx)>Math.abs(dy)){event.preventDefault();}
+    touchDiffX=dx;
+  },{passive:false});
 
-  if(typeof mobileMedia.addEventListener==='function'){
-    mobileMedia.addEventListener('change',handleMediaChange);
-  }else if(typeof mobileMedia.addListener==='function'){
-    mobileMedia.addListener(handleMediaChange);
-  }
+  const resetTouch=()=>{touchStartX=null;touchStartY=null;touchDiffX=0;};
 
-  window.addEventListener('resize',debounce(()=>{
-    refreshOpenPanels();
-    updateStickyState();
-  },150));
-
-  let initialTarget=null;
-  if(window.location.hash){
-    const raw=decodeURIComponent(window.location.hash);
-    const parts=raw.replace(/^#/, '').split('#').filter(Boolean);
-    for(let i=parts.length-1;i>=0;i-=1){
-      const part=parts[i];
-      if(!part){continue;}
-      const exact=document.getElementById(part);
-      if(exact&&cards.includes(exact)){initialTarget=exact;break;}
-      const prefixed=document.getElementById(`service-${part}`);
-      if(prefixed&&cards.includes(prefixed)){initialTarget=prefixed;break;}
+  viewport.addEventListener('touchend',()=>{
+    if(touchStartX===null){return;}
+    if(Math.abs(touchDiffX)>=SWIPE_THRESHOLD){
+      rotateBy(touchDiffX<0?1:-1);
     }
-    if(!initialTarget&&parts.length){
-      const slug=parts[parts.length-1].toLowerCase();
-      initialTarget=cards.find(card=>{
-        const keywords=(card.getAttribute('data-search')||'').toLowerCase();
-        return keywords.split(/\s+/).includes(slug);
-      })||null;
-    }
-  }
+    resetTouch();
+  });
 
-  if(initialTarget){
-    openCards.add(initialTarget.id);
-    const index=cards.indexOf(initialTarget);
-    if(index>-1){setVisibleCount(Math.max(step,index+1));}
-  }
+  viewport.addEventListener('touchcancel',resetTouch);
 
-  updateChipState();
-  applyState();
-  updateStickyState();
-  if(initialTarget){
-    renderCard(initialTarget,true);
-    setTimeout(()=>{
-      const behavior=prefersReducedMotion.matches?'auto':'smooth';
-      initialTarget.scrollIntoView({behavior,block:'start'});
-      refreshOpenPanels();
-    },200);
+  if('IntersectionObserver'in window){
+    const observer=new IntersectionObserver(entries=>{
+      entries.forEach(entry=>{
+        isVisible=entry.isIntersecting;
+        if(!isVisible){
+          cancelAnimation();
+          syncTransforms(true);
+        }
+      });
+    },{threshold:0.1});
+    observer.observe(carousel);
   }
+})();
+
 })();
 
 // Footer year

--- a/assets/style.css
+++ b/assets/style.css
@@ -142,49 +142,69 @@ body.nav-open{overflow:hidden}
 .about-card{background:var(--card);border:1px solid #e8edf4;border-radius:16px;padding:20px;box-shadow:var(--shadow)}
 .bullets{padding-left:18px}
 
+
 /* Services */
 .grid{display:grid;gap:16px}
-.services{grid-template-columns:minmax(0,1fr)}
-.card{background:var(--card);padding:clamp(20px,4vw,26px);border:1px solid #e8edf4;border-radius:16px;transition:transform .2s, box-shadow .2s;min-height:100%}
+
+.card{background:var(--card);padding:clamp(20px,4vw,26px);border:1px solid #e8edf4;border-radius:16px;transition:transform .2s,box-shadow .2s;min-height:100%}
 .card:hover,.card:focus-within{transform:scale(1.01);box-shadow:0 14px 32px rgba(15,23,42,.14)}
 .card .link{display:inline-flex;align-items:center;gap:6px;margin-top:6px;text-decoration:underline;font-weight:600;color:var(--accent-2);transition:color .2s ease}
 .card .link:hover,.card .link:focus-visible{color:var(--accent);outline:none}
-.service{display:flex;flex-direction:column;gap:12px;min-height:320px}
-.service__heading{margin:0}
-.service__toggle{width:100%;display:flex;align-items:center;justify-content:space-between;gap:12px;padding:0;border:0;background:none;color:inherit;font:inherit;text-align:left;cursor:pointer;min-height:48px}
-.service__title{display:-webkit-box;font-size:1.08rem;line-height:1.35;font-weight:600;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden}
-.service__chevron{flex-shrink:0;width:16px;height:16px;border-right:2px solid currentColor;border-bottom:2px solid currentColor;transform:rotate(45deg);transition:transform .24s ease}
-.service__panel{display:flex;flex-direction:column;gap:18px}
-.service__panel-inner{display:flex;flex-direction:column;gap:12px;flex:1}
-.service__content{display:flex;flex-direction:column;gap:12px;flex:1}
-.service p{margin:0;line-height:1.6;color:rgba(15,23,42,.9)}
-.service__cta{margin-top:auto;justify-content:flex-start}
-.service.is-open .service__chevron{transform:rotate(-135deg)}
-.service.is-open .service__title{color:var(--accent);text-decoration:underline;text-decoration-thickness:2px;text-decoration-color:var(--accent)}
 
-.services-mobile-controls{display:none}
-.services-chips{display:flex;gap:8px}
-.services-chip{appearance:none;border:1px solid rgba(15,23,42,.18);background:#fff;color:var(--text);border-radius:999px;padding:10px 16px;font-weight:600;font-size:.95rem;line-height:1;display:inline-flex;align-items:center;justify-content:center;gap:8px;min-height:44px;cursor:pointer;transition:background .2s ease,border-color .2s ease,color .2s ease}
-.services-chip.is-active,.services-chip[aria-selected="true"]{background:rgba(245,158,11,.14);border-color:var(--accent);color:#b45309}
-.services-chip:focus-visible{outline:0;box-shadow:0 0 0 3px var(--ring)}
-.services-search{display:none}
-.services-search input{width:100%;border:1px solid rgba(15,23,42,.18);border-radius:999px;padding:10px 16px;font:inherit;color:inherit;background:#fff}
-.services-search input:focus{outline:0;box-shadow:0 0 0 3px var(--ring)}
-.services__actions{display:none}
-.services__more{width:100%;max-width:320px;font-weight:600}
-.services__actions[hidden],.services-empty[hidden]{display:none !important}
-.services-empty{font-weight:600;margin:12px 0 0;opacity:.85}
+.services-carousel{position:relative;margin-top:32px}
+.services-carousel__viewport{position:relative;overflow:visible}
+.services-carousel__stage{position:relative;min-height:clamp(360px,60vw,480px);perspective:1000px;transform-style:preserve-3d}
+.services-carousel__ring{position:absolute;top:50%;left:50%;width:100%;height:100%;transform:translate(-50%,-50%) rotateY(var(--rotation,0deg));transform-style:preserve-3d}
+.services-carousel .card.service{position:absolute;top:50%;left:50%;width:min(280px,70vw);padding:0;background:transparent;border:none;min-height:0;transform:translate(-50%,-50%) rotateY(var(--angle,0deg)) translateZ(var(--radius,0px));transform-style:preserve-3d;backface-visibility:hidden;pointer-events:none;--service-scale:.9;--service-opacity:.45}
+.services-carousel .card.service.is-active{z-index:10;--service-scale:1.1;--service-opacity:1}
+.services-carousel .card.service .service__inner{display:flex;flex-direction:column;align-items:flex-start;gap:14px;width:100%;background:#fff;border-radius:18px;padding:24px;box-shadow:0 2px 10px rgba(0,0,0,.1);transform:scale(var(--service-scale));opacity:var(--service-opacity);transition:transform .5s ease,opacity .5s ease,box-shadow .5s ease,border-top-color .5s ease;pointer-events:none;border-top:3px solid transparent}
+.services-carousel .card.service.is-active .service__inner{box-shadow:0 6px 20px rgba(0,0,0,.25);border-top-color:#F59E0B;pointer-events:auto}
+.services-carousel .service__title{margin:0;font-size:1.08rem;line-height:1.35;font-weight:600;color:#F59E0B}
+.services-carousel .service__description{margin:0;font-size:1rem;line-height:1.6;color:rgba(15,23,42,.9)}
+.service__cta-button{display:inline-flex;align-items:center;justify-content:center;padding:10px 18px;border-radius:999px;background:#F59E0B;color:#0F172A;font-weight:600;font-size:.95rem;text-decoration:none;transition:background .3s ease,color .3s ease,transform .3s ease}
+.service__cta-button:hover,.service__cta-button:focus-visible{background:#0F172A;color:#F59E0B;outline:none;transform:translateY(-2px)}
 
-.service__toggle:focus-visible{outline:0;box-shadow:0 0 0 3px var(--ring);border-radius:12px}
-.service__toggle[disabled]{cursor:default}
-.service__chevron{color:var(--accent)}
-.service.is-open .service__chevron{color:var(--accent)}
-.service__internal{color:var(--accent);font-weight:600;text-decoration:underline;text-decoration-thickness:2px;text-decoration-color:rgba(245,158,11,.45);transition:color .2s ease,text-decoration-color .2s ease}
-.service__internal:hover,.service__internal:focus-visible{color:#b45309;text-decoration-color:#b45309;outline:none}
-.service:hover .service__title,.service:focus-within .service__title{color:var(--accent);text-decoration:underline;text-decoration-thickness:2px;text-decoration-color:var(--accent)}
+.carousel-btn{position:absolute;top:50%;transform:translateY(-50%);width:48px;height:48px;border:none;border-radius:999px;background:#F59E0B;color:#0F172A;font-size:2rem;line-height:1;display:grid;place-items:center;cursor:pointer;box-shadow:0 12px 24px rgba(15,23,42,.18);transition:background .3s ease,color .3s ease,transform .3s ease;z-index:20}
+.carousel-btn.prev{left:2%}
+.carousel-btn.next{right:2%}
+.carousel-btn:hover,.carousel-btn:focus-visible{background:#0F172A;color:#F59E0B;outline:none;transform:translateY(-50%) scale(1.05)}
+
+.services-carousel.is-flat{perspective:none}
+.services-carousel.is-flat .services-carousel__stage{min-height:auto}
+.services-carousel.is-flat .services-carousel__viewport{overflow-x:auto;scroll-snap-type:x mandatory;-webkit-overflow-scrolling:touch;padding-bottom:18px}
+.services-carousel.is-flat .services-carousel__ring{position:relative;top:auto;left:auto;transform:none !important;display:flex;gap:16px;padding:0 4px}
+.services-carousel.is-flat .card.service{position:relative;top:auto;left:auto;flex:0 0 82%;max-width:82%;transform:none !important;pointer-events:none;scroll-snap-align:center}
+.services-carousel.is-flat .card.service .service__inner{transform:scale(.9);opacity:.45;pointer-events:none}
+.services-carousel.is-flat .card.service.is-active .service__inner{transform:scale(1.1);opacity:1;pointer-events:auto}
+
+@media (hover:hover) and (pointer:fine){
+  .services-carousel .card.service.is-active .service__inner:hover{transform:scale(calc(var(--service-scale) * 1.05));outline:2px solid #F59E0B;outline-offset:4px}
+}
+
+@media (max-width: 900px){
+  .services-carousel .card.service{width:min(260px,78vw)}
+  .carousel-btn{width:44px;height:44px;font-size:1.85rem}
+}
+
+@media (max-width: 767px){
+  .services-carousel{margin-top:24px}
+  .services-carousel__stage{min-height:clamp(320px,80vw,420px)}
+  .services-carousel .card.service{width:min(240px,82vw)}
+  .carousel-btn{width:42px;height:42px;font-size:1.7rem}
+}
+
+@media (max-width: 639px){
+  .services-carousel__stage{min-height:clamp(300px,90vw,380px)}
+  .carousel-btn.prev{left:4%}
+  .carousel-btn.next{right:4%}
+}
+
+@media (max-width: 479px){
+  .carousel-btn{width:38px;height:38px;font-size:1.6rem}
+}
+
 .under-cta .btn{font-weight:700}
 .under-cta .btn:hover,.under-cta .btn:focus-visible{color:var(--accent-2)}
-
 /* Reasons & Process */
 .two-col{display:grid;gap:28px}
 .reasons{list-style:none;padding:0;display:grid;gap:10px}
@@ -288,13 +308,8 @@ body.nav-open{overflow:hidden}
 
 @media (min-width: 640px){
   .brand-logo{height:68px}
-  .services{grid-template-columns:repeat(2,minmax(0,1fr))}
   .process .steps{grid-template-columns:repeat(2,minmax(0,1fr))}
   .testimonials{grid-auto-columns:60%}
-}
-
-@media (max-width: 639px){
-  .service{min-height:340px}
 }
 
 @media (max-width: 520px){
@@ -305,22 +320,6 @@ body.nav-open{overflow:hidden}
   .header-inner{flex-wrap:nowrap}
   .nav-toggle{margin-left:auto}
   .site-header .social{display:none}
-  .services-mobile-controls{display:grid;position:sticky;top:calc(64px + env(safe-area-inset-top,0px));z-index:60;background:var(--bg-soft);margin:0 -20px 16px;padding:12px 20px 14px;border-bottom:1px solid rgba(15,23,42,.08);box-shadow:0 0 0 rgba(15,23,42,.0);transition:box-shadow .25s ease}
-  .services-mobile-controls.is-stuck{box-shadow:0 12px 24px rgba(15,23,42,.18)}
-  .services-chips{overflow-x:auto;padding-bottom:4px;scrollbar-width:none;-webkit-overflow-scrolling:touch}
-  .services-chips::-webkit-scrollbar{display:none}
-  .services-chip{flex:0 0 auto}
-  .services-search{display:block}
-  .services-search input{min-height:44px}
-  .services__actions{display:flex;justify-content:center;margin-top:16px}
-  .services-empty{text-align:center}
-  .service{min-height:auto;gap:0}
-  .service__toggle{padding:12px 0;border-bottom:1px solid rgba(15,23,42,.12);border-radius:0}
-  .service__chevron{margin-left:12px}
-  .service__panel{max-height:0;opacity:0;overflow:hidden;transition:max-height .3s ease,opacity .3s ease}
-  .service__panel-inner{padding-top:0;transition:padding .3s ease}
-  .service.is-open .service__panel{opacity:1}
-  .service.is-open .service__panel-inner{padding-top:12px}
 }
 
 @media (max-width: 768px){
@@ -347,11 +346,6 @@ body.nav-open{overflow:hidden}
   .footer-social{align-items:flex-end}
   .footer-social .social{justify-content:flex-end}
   .brand--footer .brand-logo{height:56px}
-  .service{gap:18px}
-  .service__toggle{cursor:default;padding:0;border-bottom:none;min-height:auto}
-  .service__chevron{display:none}
-  .service__panel{max-height:none !important;opacity:1 !important;overflow:visible;transition:none}
-  .service__panel-inner{padding-top:0;transition:none}
 }
 
 @media (min-width: 900px){
@@ -363,7 +357,6 @@ body.nav-open{overflow:hidden}
 }
 
 @media (min-width: 1040px){
-  .services{grid-template-columns:repeat(3,minmax(0,1fr))}
   .hero{padding:140px 0}
 }
 
@@ -371,9 +364,12 @@ body.nav-open{overflow:hidden}
 .nav-mobile__link.nav__link--active,.nav-mobile__link.nav-mobile__link--active{color:var(--accent);font-weight:700;text-decoration:underline}
 .submenu__link.nav__link--active{color:var(--accent);text-decoration:underline}
 
+
 @media (prefers-reduced-motion: reduce){
   .card{transition:none !important;transform:none !important}
   .card:hover,.card:focus-within{transform:none !important;box-shadow:0 10px 25px rgba(15,23,42,.08)}
-  .service__internal{transition:none !important}
-  .services-chip,.services-mobile-controls,.service__toggle,.service__panel,.service__panel-inner{transition:none !important}
+  .services-carousel__ring,
+  .services-carousel .card.service .service__inner,
+  .carousel-btn{transition:none !important}
+  .services-carousel .card.service.is-active .service__inner:hover{transform:scale(var(--service-scale))}
 }

--- a/index.html
+++ b/index.html
@@ -229,266 +229,127 @@
     <section id="services" class="section section--muted">
       <div class="container">
         <h2>Υπηρεσίες</h2>
-        <div class="services-mobile-controls" data-services-controls>
-          <div class="services-chips" role="tablist" aria-label="Κατηγορίες υπηρεσιών">
-            <button class="services-chip is-active" type="button" role="tab" aria-selected="true" data-services-chip data-filter="all">Όλα</button>
-            <button class="services-chip" type="button" role="tab" aria-selected="false" data-services-chip data-filter="basics">Βασικές εργασίες</button>
-            <button class="services-chip" type="button" role="tab" aria-selected="false" data-services-chip data-filter="installations">Εγκαταστάσεις</button>
-            <button class="services-chip" type="button" role="tab" aria-selected="false" data-services-chip data-filter="openings">Κουφώματα &amp; πόρτες</button>
-            <button class="services-chip" type="button" role="tab" aria-selected="false" data-services-chip data-filter="surfaces">Δάπεδα &amp; επιφάνειες</button>
-            <button class="services-chip" type="button" role="tab" aria-selected="false" data-services-chip data-filter="carpentry">Ξυλουργικά</button>
-            <button class="services-chip" type="button" role="tab" aria-selected="false" data-services-chip data-filter="permits">Άδειες &amp; όψεις</button>
+        <div id="services-carousel" class="services-carousel" role="region" aria-label="Υπηρεσίες Ανακαίνισης" tabindex="0" data-services-carousel>
+          <div class="services-carousel__viewport" data-carousel-viewport>
+            <div class="services-carousel__stage">
+              <div class="services-carousel__ring" data-carousel-ring>
+                <div class="card service" id="service-demolition">
+                  <div class="service__inner">
+                    <h3 class="service__title">Γκρεμίσματα – αποξηλώσεις – απομάκρυνση παλαιών υλικών με κάδο</h3>
+                    <p class="service__description">Οργανώνουμε γκρεμίσματα και αποξηλώσεις με ασφαλή απομάκρυνση μπαζών και προστασία κοινόχρηστων χώρων.</p>
+                    <a href="#contact" class="service__cta-button">Ζητήστε Προσφορά</a>
+                  </div>
+                </div>
+                <div class="card service" id="service-masonry">
+                  <div class="service__inner">
+                    <h3 class="service__title">Χτισίματα – σοβατίσματα – ελαιοχρωματισμοί τοιχοποιίας</h3>
+                    <p class="service__description">Εφαρμόζουμε επιμελημένα χτισίματα και σοβατίσματα με ομοιόμορφους ελαιοχρωματισμούς για ανθεκτικό αποτέλεσμα.</p>
+                    <a href="#contact" class="service__cta-button">Ζητήστε Προσφορά</a>
+                  </div>
+                </div>
+                <div class="card service" id="service-plumbing">
+                  <div class="service__inner">
+                    <h3 class="service__title">Υδραυλικές εργασίες</h3>
+                    <p class="service__description">Οι τεχνικοί μας εγκαθιστούν δίκτυα υδραυλικών με ελέγχους διαρροών και σταθερή παροχή νερού.</p>
+                    <a href="#contact" class="service__cta-button">Ζητήστε Προσφορά</a>
+                  </div>
+                </div>
+                <div class="card service" id="service-electrical">
+                  <div class="service__inner">
+                    <h3 class="service__title">Ηλεκτρολογικές εργασίες – Έκδοση Υ.Δ.Ε.</h3>
+                    <p class="service__description">Σχεδιάζουμε ηλεκτρολογικές εγκαταστάσεις με μελέτες φορτίων, αναβαθμισμένους πίνακες και υπεύθυνη έκδοση Υ.Δ.Ε.</p>
+                    <a href="#contact" class="service__cta-button">Ζητήστε Προσφορά</a>
+                  </div>
+                </div>
+                <div class="card service" id="service-frames">
+                  <div class="service__inner">
+                    <h3 class="service__title">Κουφώματα αλουμινίου – PVC</h3>
+                    <p class="service__description">Τοποθετούμε κουφώματα αλουμινίου και PVC με θερμοδιακοπή και ασφαλή στεγανότητα για άνεση και αισθητική.</p>
+                    <a href="#contact" class="service__cta-button">Ζητήστε Προσφορά</a>
+                  </div>
+                </div>
+                <div class="card service" id="service-tiles">
+                  <div class="service__inner">
+                    <h3 class="service__title">Τοποθέτηση πλακιδίων τοίχου – δαπέδου</h3>
+                    <p class="service__description">Αναλαμβάνουμε τοποθέτηση πλακιδίων με ευθυγράμμιση ακριβείας και προσεγμένο αρμολόγημα για χώρους που ξεχωρίζουν.</p>
+                    <a href="#contact" class="service__cta-button">Ζητήστε Προσφορά</a>
+                  </div>
+                </div>
+                <div class="card service" id="service-flooring">
+                  <div class="service__inner">
+                    <h3 class="service__title">Τοποθέτηση πατωμάτων laminate – αποκατάσταση ξύλινων πατωμάτων</h3>
+                    <p class="service__description">Τοποθετούμε πατώματα laminate και αποκαθιστούμε ξύλινες επιφάνειες με ανθεκτικές επιστρώσεις.</p>
+                    <a href="#contact" class="service__cta-button">Ζητήστε Προσφορά</a>
+                  </div>
+                </div>
+                <div class="card service" id="service-mosaic">
+                  <div class="service__inner">
+                    <h3 class="service__title">Τρίψιμο – γυάλισμα μωσαϊκών δαπέδων</h3>
+                    <p class="service__description">Προσφέρουμε τρίψιμο και γυάλισμα μωσαϊκών για να επαναφέρουμε λάμψη και ομοιομορφία σε κάθε χώρο.</p>
+                    <a href="#contact" class="service__cta-button">Ζητήστε Προσφορά</a>
+                  </div>
+                </div>
+                <div class="card service" id="service-kitchen-cabinets">
+                  <div class="service__inner">
+                    <h3 class="service__title">Κατασκευή – τοποθέτηση ντουλαπιών κουζίνας</h3>
+                    <p class="service__description">Σχεδιάζουμε ντουλάπια κουζίνας στα μέτρα σας με εργονομική οργάνωση και ανθεκτικά φινιρίσματα.</p>
+                    <a href="#contact" class="service__cta-button">Ζητήστε Προσφορά</a>
+                  </div>
+                </div>
+                <div class="card service" id="service-wardrobes">
+                  <div class="service__inner">
+                    <h3 class="service__title">Κατασκευή – τοποθέτηση ντουλαπών</h3>
+                    <p class="service__description">Κατασκευάζουμε ντουλάπες υπνοδωματίου με λειτουργική εσωτερική διαρρύθμιση και αξιόπιστους μηχανισμούς.</p>
+                    <a href="#contact" class="service__cta-button">Ζητήστε Προσφορά</a>
+                  </div>
+                </div>
+                <div class="card service" id="service-doors">
+                  <div class="service__inner">
+                    <h3 class="service__title">Πόρτες εισόδου (ασφαλείας) – εσωτερικές πόρτες</h3>
+                    <p class="service__description">Παρέχουμε πόρτες ασφαλείας και εσωτερικές πόρτες με πιστοποιήσεις, ηχομονωτικές λύσεις και ακριβή τοποθέτηση.</p>
+                    <a href="#contact" class="service__cta-button">Ζητήστε Προσφορά</a>
+                  </div>
+                </div>
+                <div class="card service" id="service-metal">
+                  <div class="service__inner">
+                    <h3 class="service__title">Μεταλλικές κατασκευές</h3>
+                    <p class="service__description">Μελετάμε μεταλλικές κατασκευές μικρής και μεγάλης κλίμακας με στατική επάρκεια και προστασία από διάβρωση.</p>
+                    <a href="#contact" class="service__cta-button">Ζητήστε Προσφορά</a>
+                  </div>
+                </div>
+                <div class="card service" id="service-insulation">
+                  <div class="service__inner">
+                    <h3 class="service__title">Μονώσεις παντός τύπου</h3>
+                    <p class="service__description">Υλοποιούμε μονώσεις παντός τύπου με θερμοπρόσοψη, υγρομόνωση και λύσεις εξοικονόμησης ενέργειας.</p>
+                    <a href="#contact" class="service__cta-button">Ζητήστε Προσφορά</a>
+                  </div>
+                </div>
+                <div class="card service" id="service-permits">
+                  <div class="service__inner">
+                    <h3 class="service__title">Έκδοση οικοδομικών αδειών</h3>
+                    <p class="service__description">Αναλαμβάνουμε έκδοση οικοδομικών αδειών με πλήρη φάκελο μελετών και συντονισμό με τις αρμόδιες υπηρεσίες.</p>
+                    <a href="#contact" class="service__cta-button">Ζητήστε Προσφορά</a>
+                  </div>
+                </div>
+                <div class="card service" id="service-facade">
+                  <div class="service__inner">
+                    <h3 class="service__title">Αποκατάσταση προσόψεων σε πολυκατοικίες</h3>
+                    <p class="service__description">Οργανώνουμε αποκατάσταση προσόψεων με ασφαλή σκαλωσιά, επισκευή στηθαίων και εφαρμογή νέων επιστρώσεων.</p>
+                    <a href="#contact" class="service__cta-button">Ζητήστε Προσφορά</a>
+                  </div>
+                </div>
+                <div class="card service" id="service-gypsum">
+                  <div class="service__inner">
+                    <h3 class="service__title">Γυψοσανίδες – Ψευδοροφές</h3>
+                    <p class="service__description">Κατασκευάζουμε γυψοσανίδες και ψευδοροφές για κατοικίες και επαγγελματικούς χώρους με άριστο φινίρισμα.</p>
+                    <a href="#contact" class="service__cta-button">Ζητήστε Προσφορά</a>
+                  </div>
+                </div>
+              </div>
+            </div>
           </div>
-          <label class="services-search">
-            <span class="visually-hidden">Αναζήτηση υπηρεσιών</span>
-            <input type="search" placeholder="Αναζήτηση υπηρεσίας…" aria-label="Αναζήτηση υπηρεσιών" data-services-search>
-          </label>
-        </div>
-        <div class="grid services" data-services-grid>
-          <article class="card service" id="service-demolition" data-cat="basics" data-search="γκρεμίσματα αποξηλώσεις απομάκρυνση κάδος ανακαίνιση βασικές εργασίες demolition demo removal debris">
-            <h3 class="service__heading">
-              <button class="service__toggle" type="button" aria-expanded="false" aria-controls="service-demolition-panel" aria-labelledby="service-demolition-label">
-                <span class="service__title" id="service-demolition-label">Γκρεμίσματα – αποξηλώσεις – απομάκρυνση παλαιών υλικών με κάδο</span>
-                <span class="service__chevron" aria-hidden="true"></span>
-              </button>
-            </h3>
-            <div class="service__panel" id="service-demolition-panel" role="region" aria-labelledby="service-demolition-label">
-              <div class="service__panel-inner">
-                <div class="service__content">
-                  <p>Οργανώνουμε <a href="#service-demolition" class="service__internal">γκρεμίσματα και αποξηλώσεις</a> με ασφαλιστική κάλυψη, καθαρή απομάκρυνση μπαζών και προστασία κοινόχρηστων χώρων σε όλη την Αττική.</p>
-                </div>
-                <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
-              </div>
-            </div>
-          </article>
-          <article class="card service" id="service-masonry" data-cat="basics" data-search="χτισίματα σοβατίσματα ελαιοχρωματισμοί τοιχοποιία βασικές εργασίες masonry plaster painting walls">
-            <h3 class="service__heading">
-              <button class="service__toggle" type="button" aria-expanded="false" aria-controls="service-masonry-panel" aria-labelledby="service-masonry-label">
-                <span class="service__title" id="service-masonry-label">Χτισίματα – σοβατίσματα – ελαιοχρωματισμοί τοιχοποιίας</span>
-                <span class="service__chevron" aria-hidden="true"></span>
-              </button>
-            </h3>
-            <div class="service__panel" id="service-masonry-panel" role="region" aria-labelledby="service-masonry-label">
-              <div class="service__panel-inner">
-                <div class="service__content">
-                  <p>Εφαρμόζουμε επιμελημένα χτισίματα και σοβατίσματα, ενώ οι <a href="#service-masonry" class="service__internal">ελαιοχρωματισμοί τοιχοποιίας</a> προσφέρουν ομοιομορφία και αντοχή στον χρόνο.</p>
-                </div>
-                <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
-              </div>
-            </div>
-          </article>
-          <article class="card service" id="service-plumbing" data-cat="installations" data-search="υδραυλικά εγκαταστάσεις δίκτυα νερό συντήρηση hydraulika plumbing pipes water">
-            <h3 class="service__heading">
-              <button class="service__toggle" type="button" aria-expanded="false" aria-controls="service-plumbing-panel" aria-labelledby="service-plumbing-label">
-                <span class="service__title" id="service-plumbing-label">Υδραυλικές εργασίες</span>
-                <span class="service__chevron" aria-hidden="true"></span>
-              </button>
-            </h3>
-            <div class="service__panel" id="service-plumbing-panel" role="region" aria-labelledby="service-plumbing-label">
-              <div class="service__panel-inner">
-                <div class="service__content">
-                  <p>Οι τεχνικοί μας για <a href="#service-plumbing" class="service__internal">υδραυλικές εργασίες</a> εγκαθιστούν δίκτυα με ανθεκτικά υλικά, ελέγχουν διαρροές και εξασφαλίζουν σταθερή παροχή νερού.</p>
-                </div>
-                <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
-              </div>
-            </div>
-          </article>
-          <article class="card service" id="service-electrical" data-cat="installations" data-search="ηλεκτρολογικά υδε πίνακας εγκαταστάσεις ρεύμα ilektrologika electrical ude power">
-            <h3 class="service__heading">
-              <button class="service__toggle" type="button" aria-expanded="false" aria-controls="service-electrical-panel" aria-labelledby="service-electrical-label">
-                <span class="service__title" id="service-electrical-label">Ηλεκτρολογικές εργασίες – Έκδοση Υ.Δ.Ε.</span>
-                <span class="service__chevron" aria-hidden="true"></span>
-              </button>
-            </h3>
-            <div class="service__panel" id="service-electrical-panel" role="region" aria-labelledby="service-electrical-label">
-              <div class="service__panel-inner">
-                <div class="service__content">
-                  <p>Σχεδιάζουμε <a href="#service-electrical" class="service__internal">ηλεκτρολογικές εργασίες</a> με μελέτες φορτίων, αναβαθμισμένους πίνακες και υπεύθυνη έκδοση Υ.Δ.Ε. για έργα στην Αθήνα.</p>
-                </div>
-                <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
-              </div>
-            </div>
-          </article>
-          <article class="card service" id="service-frames" data-cat="openings" data-search="κουφώματα αλουμίνιο pvc ενεργειακά παράθυρα πόρτες koufomata frames aluminum windows doors">
-            <h3 class="service__heading">
-              <button class="service__toggle" type="button" aria-expanded="false" aria-controls="service-frames-panel" aria-labelledby="service-frames-label">
-                <span class="service__title" id="service-frames-label">Κουφώματα αλουμινίου – PVC</span>
-                <span class="service__chevron" aria-hidden="true"></span>
-              </button>
-            </h3>
-            <div class="service__panel" id="service-frames-panel" role="region" aria-labelledby="service-frames-label">
-              <div class="service__panel-inner">
-                <div class="service__content">
-                  <p>Τοποθετούμε <a href="#service-frames" class="service__internal">κουφώματα αλουμινίου και PVC</a> με θερμοδιακοπή και ασφαλή στεγανότητα για άνεση και αισθητική σε κάθε χώρο.</p>
-                </div>
-                <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
-              </div>
-            </div>
-          </article>
-          <article class="card service" id="service-tiles" data-cat="surfaces" data-search="πλακίδια τοποθέτηση δάπεδο επένδυση μπάνιο κουζίνα plakidia tiles tiling floor wall">
-            <h3 class="service__heading">
-              <button class="service__toggle" type="button" aria-expanded="false" aria-controls="service-tiles-panel" aria-labelledby="service-tiles-label">
-                <span class="service__title" id="service-tiles-label">Τοποθέτηση πλακιδίων τοίχου – δαπέδου</span>
-                <span class="service__chevron" aria-hidden="true"></span>
-              </button>
-            </h3>
-            <div class="service__panel" id="service-tiles-panel" role="region" aria-labelledby="service-tiles-label">
-              <div class="service__panel-inner">
-                <div class="service__content">
-                  <p>Αναλαμβάνουμε <a href="#service-tiles" class="service__internal">τοποθέτηση πλακιδίων</a> με ευθυγράμμιση ακριβείας, προσεγμένο αρμολόγημα και ανθεκτικά υλικά για χώρους που ξεχωρίζουν.</p>
-                </div>
-                <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
-              </div>
-            </div>
-          </article>
-          <article class="card service" id="service-flooring" data-cat="surfaces" data-search="laminate πάτωμα ξύλινα πατώματα αποκατάσταση flooring floors wood refinishing">
-            <h3 class="service__heading">
-              <button class="service__toggle" type="button" aria-expanded="false" aria-controls="service-flooring-panel" aria-labelledby="service-flooring-label">
-                <span class="service__title" id="service-flooring-label">Τοποθέτηση πατωμάτων laminate – αποκατάσταση ξύλινων πατωμάτων</span>
-                <span class="service__chevron" aria-hidden="true"></span>
-              </button>
-            </h3>
-            <div class="service__panel" id="service-flooring-panel" role="region" aria-labelledby="service-flooring-label">
-              <div class="service__panel-inner">
-                <div class="service__content">
-                  <p>Εξειδικευόμαστε σε <a href="#service-flooring" class="service__internal">τοποθέτηση πατωμάτων laminate</a> και αναζωογόνηση ξύλινων επιφανειών με ελεγχόμενες λειάνσεις και ανθεκτικές επιστρώσεις.</p>
-                </div>
-                <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
-              </div>
-            </div>
-          </article>
-          <article class="card service" id="service-mosaic" data-cat="surfaces" data-search="μωσαϊκό τρίψιμο γυάλισμα επιφάνειες mosaiko terrazzo polishing grinding">
-            <h3 class="service__heading">
-              <button class="service__toggle" type="button" aria-expanded="false" aria-controls="service-mosaic-panel" aria-labelledby="service-mosaic-label">
-                <span class="service__title" id="service-mosaic-label">Τρίψιμο – γυάλισμα μωσαϊκών δαπέδων</span>
-                <span class="service__chevron" aria-hidden="true"></span>
-              </button>
-            </h3>
-            <div class="service__panel" id="service-mosaic-panel" role="region" aria-labelledby="service-mosaic-label">
-              <div class="service__panel-inner">
-                <div class="service__content">
-                  <p>Το συνεργείο μωσαϊκών προσφέρει <a href="#service-mosaic" class="service__internal">τρίψιμο και γυάλισμα</a> με σταδιακό φινίρισμα, επαναφέροντας λάμψη και ομοιομορφία σε κάθε χώρο.</p>
-                </div>
-                <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
-              </div>
-            </div>
-          </article>
-          <article class="card service" id="service-kitchen-cabinets" data-cat="carpentry" data-search="ντουλάπια κουζίνας ξυλουργός κατασκευή custom kitchen cabinets joinery cabinetry">
-            <h3 class="service__heading">
-              <button class="service__toggle" type="button" aria-expanded="false" aria-controls="service-kitchen-cabinets-panel" aria-labelledby="service-kitchen-cabinets-label">
-                <span class="service__title" id="service-kitchen-cabinets-label">Κατασκευή – τοποθέτηση ντουλαπιών κουζίνας</span>
-                <span class="service__chevron" aria-hidden="true"></span>
-              </button>
-            </h3>
-            <div class="service__panel" id="service-kitchen-cabinets-panel" role="region" aria-labelledby="service-kitchen-cabinets-label">
-              <div class="service__panel-inner">
-                <div class="service__content">
-                  <p>Σχεδιάζουμε <a href="#service-kitchen-cabinets" class="service__internal">ντουλάπια κουζίνας</a> στα μέτρα σας, με μηχανισμούς soft-close, εργονομικές ζώνες αποθήκευσης και φινίρισμα υψηλής αντοχής.</p>
-                </div>
-                <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
-              </div>
-            </div>
-          </article>
-          <article class="card service" id="service-wardrobes" data-cat="carpentry" data-search="ντουλάπες ξυλουργικά συρόμενες ντουλάπες αποθήκευση wardrobes closets storage joinery">
-            <h3 class="service__heading">
-              <button class="service__toggle" type="button" aria-expanded="false" aria-controls="service-wardrobes-panel" aria-labelledby="service-wardrobes-label">
-                <span class="service__title" id="service-wardrobes-label">Κατασκευή – τοποθέτηση ντουλαπών</span>
-                <span class="service__chevron" aria-hidden="true"></span>
-              </button>
-            </h3>
-            <div class="service__panel" id="service-wardrobes-panel" role="region" aria-labelledby="service-wardrobes-label">
-              <div class="service__panel-inner">
-                <div class="service__content">
-                  <p>Κατασκευάζουμε <a href="#service-wardrobes" class="service__internal">ντουλάπες υπνοδωματίου</a> με λειτουργική εσωτερική διαρρύθμιση, ανθεκτικούς μηχανισμούς και αισθητικές επιλογές για κάθε χώρο.</p>
-                </div>
-                <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
-              </div>
-            </div>
-          </article>
-          <article class="card service" id="service-doors" data-cat="openings" data-search="πόρτες ασφαλείας εσωτερικές θυρόφυλλα κουφώματα doors security interior entries">
-            <h3 class="service__heading">
-              <button class="service__toggle" type="button" aria-expanded="false" aria-controls="service-doors-panel" aria-labelledby="service-doors-label">
-                <span class="service__title" id="service-doors-label">Πόρτες εισόδου (ασφαλείας) – εσωτερικές πόρτες</span>
-                <span class="service__chevron" aria-hidden="true"></span>
-              </button>
-            </h3>
-            <div class="service__panel" id="service-doors-panel" role="region" aria-labelledby="service-doors-label">
-              <div class="service__panel-inner">
-                <div class="service__content">
-                  <p>Παρέχουμε <a href="#service-doors" class="service__internal">πόρτες ασφαλείας και εσωτερικές πόρτες</a> με πιστοποιήσεις, ηχομονωτικές λύσεις και ακριβή τοποθέτηση για μέγιστη λειτουργικότητα.</p>
-                </div>
-                <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
-              </div>
-            </div>
-          </article>
-          <article class="card service" id="service-metal" data-cat="basics" data-search="μεταλλικές κατασκευές κιγκλιδώματα στέγες στατικά metal constructions steel structures">
-            <h3 class="service__heading">
-              <button class="service__toggle" type="button" aria-expanded="false" aria-controls="service-metal-panel" aria-labelledby="service-metal-label">
-                <span class="service__title" id="service-metal-label">Μεταλλικές κατασκευές</span>
-                <span class="service__chevron" aria-hidden="true"></span>
-              </button>
-            </h3>
-            <div class="service__panel" id="service-metal-panel" role="region" aria-labelledby="service-metal-label">
-              <div class="service__panel-inner">
-                <div class="service__content">
-                  <p>Μελετάμε <a href="#service-metal" class="service__internal">μεταλλικές κατασκευές</a> μικρής και μεγάλης κλίμακας, εξασφαλίζοντας στατική επάρκεια, προστασία από διάβρωση και άψογη εφαρμογή.</p>
-                </div>
-                <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
-              </div>
-            </div>
-          </article>
-          <article class="card service" id="service-insulation" data-cat="permits" data-search="μονώσεις θερμομόνωση υγρομόνωση ταράτσα όψεις monoseis insulation waterproofing facade">
-            <h3 class="service__heading">
-              <button class="service__toggle" type="button" aria-expanded="false" aria-controls="service-insulation-panel" aria-labelledby="service-insulation-label">
-                <span class="service__title" id="service-insulation-label">Μονώσεις παντός τύπου</span>
-                <span class="service__chevron" aria-hidden="true"></span>
-              </button>
-            </h3>
-            <div class="service__panel" id="service-insulation-panel" role="region" aria-labelledby="service-insulation-label">
-              <div class="service__panel-inner">
-                <div class="service__content">
-                  <p>Προτείνουμε <a href="#service-insulation" class="service__internal">μονώσεις παντός τύπου</a> με θερμοπρόσοψη, υγρομόνωση και λύσεις εξοικονόμησης που βελτιώνουν την ενεργειακή απόδοση στην Αττική.</p>
-                </div>
-                <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
-              </div>
-            </div>
-          </article>
-          <article class="card service" id="service-permits" data-cat="permits" data-search="οικοδομικές άδειες μελέτη πολεοδομία adeies permits building licensing">
-            <h3 class="service__heading">
-              <button class="service__toggle" type="button" aria-expanded="false" aria-controls="service-permits-panel" aria-labelledby="service-permits-label">
-                <span class="service__title" id="service-permits-label">Έκδοση οικοδομικών αδειών</span>
-                <span class="service__chevron" aria-hidden="true"></span>
-              </button>
-            </h3>
-            <div class="service__panel" id="service-permits-panel" role="region" aria-labelledby="service-permits-label">
-              <div class="service__panel-inner">
-                <div class="service__content">
-                  <p>Αναλαμβάνουμε <a href="#service-permits" class="service__internal">έκδοση οικοδομικών αδειών</a> με πλήρη φάκελο μελετών, συντονισμό με υπηρεσίες και συνεχή ενημέρωση για κάθε στάδιο.</p>
-                </div>
-                <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
-              </div>
-            </div>
-          </article>
-          <article class="card service" id="service-facade" data-cat="permits" data-search="προσόψεις στηθαία ανακαίνιση όψης αποκατάσταση facade restoration balconies prosopseis">
-            <h3 class="service__heading">
-              <button class="service__toggle" type="button" aria-expanded="false" aria-controls="service-facade-panel" aria-labelledby="service-facade-label">
-                <span class="service__title" id="service-facade-label">Αποκατάσταση προσόψεων (στηθαία) σε πολυκατοικίες με χρήση σκαλωσιάς</span>
-                <span class="service__chevron" aria-hidden="true"></span>
-              </button>
-            </h3>
-            <div class="service__panel" id="service-facade-panel" role="region" aria-labelledby="service-facade-label">
-              <div class="service__panel-inner">
-                <div class="service__content">
-                  <p>Οργανώνουμε <a href="#service-facade" class="service__internal">αποκατάσταση προσόψεων</a> με ασφαλή σκαλωσιά, αποκαθιστούμε στηθαία και εφαρμόζουμε νέες επιστρώσεις γι πολυκατοικίες στην Αττική.</p>
-                </div>
-                <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
-              </div>
-            </div>
-          </article>
-        </div>
-        <p class="services-empty" data-services-empty hidden>Δεν βρέθηκαν υπηρεσίες για τα κριτήρια αναζήτησης.</p>
-        <div class="services__actions">
-          <button class="btn btn--ghost services__more" type="button" data-services-more>Εμφάνιση περισσότερων</button>
+          <button class="carousel-btn prev" type="button" role="button" aria-label="Προηγούμενη Υπηρεσία" aria-controls="services-carousel" data-carousel-prev>‹</button>
+          <button class="carousel-btn next" type="button" role="button" aria-label="Επόμενη Υπηρεσία" aria-controls="services-carousel" data-carousel-next>›</button>
         </div>
         <div class="under-cta"><a href="#contact" class="btn btn--primary">Θέλω Προσφορά για Υπηρεσία</a></div>
       </div>


### PR DESCRIPTION
## Summary
- replace the services section with a 3D rotating carousel that highlights the front card and introduces the gypsum board service
- add new responsive styles for the circular layout, carousel controls, and CTA buttons with mobile and reduced-motion fallbacks
- rewrite the services JavaScript to drive rotation with requestAnimationFrame, keyboard arrows, buttons, and swipe gestures while pausing off-screen

## Testing
- python -m http.server 8000 *(manual preview)*

------
https://chatgpt.com/codex/tasks/task_e_68f04dd9551c83209f1d876c1624fcf3