### PR TITLE
Update process and reasons sections with SEO copy and scroll animations

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -555,22 +555,6 @@ const y=document.getElementById('year'); if(y) y.textContent=new Date().getFullY
   },4000);
 })();
 
-// Process interactive description
-const stepDesc=document.getElementById('step-desc');
-document.querySelectorAll('.step').forEach(btn=>{
-  btn.addEventListener('click',()=>{
-    document.querySelectorAll('.step').forEach(b=>b.removeAttribute('aria-current'));
-    btn.setAttribute('aria-current','true');
-    const m={
-      1:'Επίσκεψη στον χώρο, αποτύπωση και μελέτη αναγκών.',
-      2:'Γραπτή προσφορά με σαφή παραδοτέα και χρονοδιάγραμμα.',
-      3:'Συντονισμός συνεργείων & ποιοτικός έλεγχος.',
-      4:'Καθαρή παράδοση και after-sales υποστήριξη.'
-    };
-    stepDesc.textContent=m[btn.dataset.step]||'';
-  });
-});
-
 // Gallery carousel buttons
 document.querySelectorAll('[data-carousel]').forEach(car=>{
   const track=car.querySelector('[data-track]');
@@ -680,3 +664,20 @@ document.querySelectorAll('a.brand').forEach(function(link){
     }
   });
 });
+
+// Fade-up on scroll
+const fadeEls=document.querySelectorAll('[data-animate="fade-up"]');
+if('IntersectionObserver'in window){
+  const observer=new IntersectionObserver(entries=>{
+    entries.forEach(entry=>{
+      if(entry.isIntersecting){
+        entry.target.classList.add('visible');
+        observer.unobserve(entry.target);
+      }
+    });
+  },{threshold:0.2});
+
+  fadeEls.forEach(el=>observer.observe(el));
+}else{
+  fadeEls.forEach(el=>el.classList.add('visible'));
+}

--- a/assets/style.css
+++ b/assets/style.css
@@ -186,14 +186,24 @@ body.nav-open{overflow:hidden}
 .under-cta .btn:hover,.under-cta .btn:focus-visible{color:var(--accent-2)}
 
 /* Reasons & Process */
-.two-col{display:grid;gap:28px}
-.reasons{list-style:none;padding:0;display:grid;gap:10px}
-.reasons li{background:#fff;border:1px solid #e8edf4;border-radius:12px;padding:12px}
-.process .steps{display:grid;grid-template-columns:minmax(0,1fr);gap:10px;margin-bottom:8px}
-.step{background:#fff;border:1px solid #e8edf4;border-radius:12px;padding:12px;cursor:pointer;text-align:left;display:flex;gap:10px;align-items:center}
-.step span{display:inline-grid;place-items:center;width:28px;height:28px;border-radius:50%;background:var(--accent);color:#111;font-weight:700}
-.step[aria-current="true"]{outline:2px solid var(--accent)}
-.step-desc{background:#fff;border:1px solid #e8edf4;border-radius:12px;padding:14px;min-height:60px}
+.process-section,.reasons-section{padding:56px 20px;max-width:var(--maxw);margin:0 auto;display:flex;flex-direction:column;gap:28px}
+.process-section h2,.reasons-section h2{text-align:center;font-size:clamp(1.8rem,3vw,2.3rem);margin:0;color:var(--text)}
+.process-grid,.reasons-grid{display:grid;gap:18px}
+.step,.reason{background:#fff;border:1px solid #e8edf4;border-radius:14px;padding:18px;box-shadow:var(--shadow);display:flex;flex-direction:column;gap:12px;transition:transform .3s ease,box-shadow .3s ease}
+.step h3,.reason h3{margin:0;font-size:1.15rem;line-height:1.4;color:var(--text)}
+.step p,.reason p{margin:0;line-height:1.65;color:rgba(15,23,42,.85)}
+.step:hover,.step:focus-within,.reason:hover,.reason:focus-within{transform:translateY(-4px);box-shadow:0 18px 30px rgba(15,23,42,.08)}
+
+@media (min-width: 640px){
+  .process-grid{grid-template-columns:repeat(2,minmax(0,1fr))}
+  .reasons-grid{grid-template-columns:repeat(2,minmax(0,1fr))}
+}
+
+@media (min-width: 900px){
+  .process-section,.reasons-section{padding:72px 20px}
+  .process-grid{grid-template-columns:repeat(5,minmax(0,1fr))}
+  .reasons-grid{grid-template-columns:repeat(3,minmax(0,1fr))}
+}
 
 /* Carousel */
 .carousel{position:relative}
@@ -376,4 +386,16 @@ body.nav-open{overflow:hidden}
   .card:hover,.card:focus-within{transform:none !important;box-shadow:0 10px 25px rgba(15,23,42,.08)}
   .service__internal{transition:none !important}
   .services-chip,.services-mobile-controls,.service__toggle,.service__panel,.service__panel-inner{transition:none !important}
+}
+
+/* Fade-up animation on scroll */
+[data-animate="fade-up"] {
+  opacity: 0;
+  transform: translateY(20px);
+  transition: all 0.6s ease-out;
+}
+
+[data-animate="fade-up"].visible {
+  opacity: 1;
+  transform: translateY(0);
 }

--- a/index.html
+++ b/index.html
@@ -4,7 +4,8 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>FM Renovation | Ανακαινίσεις Κατοικιών & Επαγγελματικών Χώρων – anakainisou.gr</title>
-  <meta name="description" content="FM Renovation: ολοκληρωμένες ανακαινίσεις σπιτιών, μπάνιου, κουζίνας & επαγγελματικών χώρων. Τεχνική ακρίβεια, συνέπεια και διαφάνεια. Ζητήστε προσφορά.">
+  <meta name="description" content="FM Renovation — Ανακαινίσεις οικιών και επαγγελματικών χώρων στην Αθήνα & Αττική. Διαδικασία υλοποίησης με διαφάνεια, συνέπεια και εγγύηση ποιότητας.">
+  <meta name="keywords" content="ανακαίνιση, ανακαινίσεις, Αθήνα, Αττική, οικία, επαγγελματικός χώρος, FM Renovation, με το κλειδί στο χέρι, εγγύηση ποιότητας">
   <link rel="canonical" href="https://anakainisou.gr/">
   <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Roboto:wght@700&display=swap" rel="stylesheet">
@@ -494,28 +495,55 @@
       </div>
     </section>
 
-    <!-- REASONS + PROCESS: διαδραστικό (tabs/accordion) -->
-    <section id="reasons" class="section">
-      <div class="container two-col">
-        <div>
-          <h2>Γιατί να μας επιλέξετε</h2>
-          <ul class="reasons">
-            <li><strong>Εμπειρία & Εξειδίκευση:</strong> πιστοποιημένα συνεργεία.</li>
-            <li><strong>Διαφάνεια:</strong> σταθερός προϋπολογισμός.</li>
-            <li><strong>Ποιότητα:</strong> επιλεγμένα υλικά & έλεγχος.</li>
-            <li><strong>Χρονοδιάγραμμα:</strong> σαφείς ημερομηνίες.</li>
-            <li><strong>Υποστήριξη:</strong> after-sales φροντίδα.</li>
-          </ul>
+    <!-- REASONS + PROCESS -->
+    <section id="process" class="process-section">
+      <h2>Διαδικασία Υλοποίησης Ανακαίνισης</h2>
+      <div class="process-grid">
+        <div class="step" data-animate="fade-up">
+          <h3>1️⃣ Επίσκεψη στον χώρο</h3>
+          <p>Επισκεπτόμαστε τον χώρο σας στην Αθήνα ή την Αττική, για να καταγράψουμε με ακρίβεια τις ανάγκες και τις επιθυμίες σας σχετικά με την ανακαίνιση του σπιτιού ή του επαγγελματικού σας χώρου.</p>
         </div>
-        <div id="process" class="process">
-          <h2>Διαδικασία υλοποίησης</h2>
-          <div class="steps">
-            <button class="step" data-step="1"><span>1</span> Αυτοψία & Μελέτη</button>
-            <button class="step" data-step="2"><span>2</span> Προσφορά & Χρονοδιάγραμμα</button>
-            <button class="step" data-step="3"><span>3</span> Υλοποίηση & Επίβλεψη</button>
-            <button class="step" data-step="4"><span>4</span> Παράδοση & Υποστήριξη</button>
-          </div>
-          <p class="step-desc" id="step-desc">Πατήστε σε ένα βήμα για λεπτομέρειες.</p>
+        <div class="step" data-animate="fade-up">
+          <h3>2️⃣ Ανάλυση & Καταγραφή</h3>
+          <p>Συζητάμε αναλυτικά τις αλλαγές που θέλετε να πραγματοποιηθούν, λαμβάνοντας υπόψη λειτουργικότητα, αισθητική και προϋπολογισμό.</p>
+        </div>
+        <div class="step" data-animate="fade-up">
+          <h3>3️⃣ Οικονομική Προσφορά</h3>
+          <p>Μέσα σε λίγες ημέρες λαμβάνετε γραπτή και αναλυτική προσφορά με όλες τις προβλεπόμενες εργασίες και το χρονοδιάγραμμα υλοποίησης.</p>
+        </div>
+        <div class="step" data-animate="fade-up">
+          <h3>4️⃣ Συμφωνία & Προετοιμασία</h3>
+          <p>Με την αποδοχή της προσφοράς, συντάσσεται ιδιωτικό συμφωνητικό που καθορίζει σαφώς το αντικείμενο, τα στάδια και τον τρόπο πληρωμής.</p>
+        </div>
+        <div class="step" data-animate="fade-up">
+          <h3>5️⃣ Εκτέλεση & Παράδοση</h3>
+          <p>Η ομάδα μας αναλαμβάνει το έργο με συνέπεια και τεχνική ακρίβεια. Ο πελάτης ενημερώνεται για κάθε στάδιο, και ο χώρος παραδίδεται έτοιμος προς χρήση, καθαρός και οργανωμένος.</p>
+        </div>
+      </div>
+    </section>
+
+    <section id="reasons" class="reasons-section">
+      <h2>Γιατί να επιλέξετε την FM Renovation</h2>
+      <div class="reasons-grid">
+        <div class="reason" data-animate="fade-up">
+          <h3>🔧 Ολική ή Μερική Ανακαίνιση</h3>
+          <p>Αναλαμβάνουμε κάθε τύπο έργου – από μικρές παρεμβάσεις έως πλήρη ανακαίνιση οικίας ή επαγγελματικού χώρου – με εξειδικευμένα συνεργεία και σύγχρονες τεχνικές.</p>
+        </div>
+        <div class="reason" data-animate="fade-up">
+          <h3>🧱 Οργάνωση & Συντονισμός</h3>
+          <p>Αναλαμβάνουμε πλήρως τη διαχείριση του έργου, ώστε να μην χρειάζεται να ασχολείστε με πολλαπλούς προμηθευτές ή συνεργεία. Όλα εκτελούνται βάσει προγράμματος και προϋπολογισμού.</p>
+        </div>
+        <div class="reason" data-animate="fade-up">
+          <h3>📋 Διαφάνεια & Ενημέρωση</h3>
+          <p>Ενημερώνεστε αναλυτικά για την πρόοδο κάθε σταδίου. Καμία εργασία δεν ξεκινά χωρίς τη δική σας ενημέρωση και έγκριση.</p>
+        </div>
+        <div class="reason" data-animate="fade-up">
+          <h3>🪄 Παράδοση “Με το Κλειδί στο Χέρι”</h3>
+          <p>Το έργο ολοκληρώνεται με κάθε λεπτομέρεια έτοιμη. Παραδίδουμε καθαρό, λειτουργικό και αισθητικά άρτιο χώρο, έτοιμο για χρήση.</p>
+        </div>
+        <div class="reason" data-animate="fade-up">
+          <h3>💬 Γραπτή Εγγύηση Ποιότητας</h3>
+          <p>Η FM Renovation προσφέρει γραπτή εγγύηση για κάθε έργο ανακαίνισης, αποδεικνύοντας την αξιοπιστία και τη δέσμευσή μας στην ποιότητα.</p>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- replace the process and reasons sections with new SEO-friendly Greek copy and add fade-up scroll reveal hooks
- extend styling to support the refreshed grids and include a reusable fade-up animation utility
- initialize intersection observer logic to trigger the new animations while removing obsolete interactive step handling
- refresh the meta description and add SEO keywords to the home page head

## Testing
- manual screenshot of updated sections

------
https://chatgpt.com/codex/tasks/task_e_68f05a0702648320979afab5c189d0dc