### PR TITLE
Fix broken images in process and reasons sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -506,35 +506,35 @@
             <span class="step-number">1</span>
             <h4>Επίσκεψη στον χώρο</h4>
             <p>Επισκεπτόμαστε παρουσία σας το χώρο που θέλετε να ανακαινίσετε.</p>
-            <img src="images/project-1.webp" alt="Επίσκεψη τεχνικού της FM Renovation στον χώρο του πελάτη" loading="lazy">
+            <img src="https://images.unsplash.com/photo-1523419409543-0c1df022bdd3?q=80&w=1200&auto=format&fit=crop" width="1200" height="800" alt="Επίσκεψη τεχνικού της FM Renovation στον χώρο του πελάτη" loading="lazy">
           </div>
 
           <div class="step" data-animate="fade-up">
             <span class="step-number">2</span>
             <h4>Καταγραφή επιθυμιών</h4>
             <p>Καταγράφουμε τις αλλαγές που θέλετε να γίνουν κι ακούμε με προσοχή τις επιθυμίες σας.</p>
-            <img src="images/project-2.webp" alt="Καταγραφή αναγκών και επιθυμιών πελάτη" loading="lazy">
+            <img src="https://images.unsplash.com/photo-1521737604893-d14cc237f11d?q=80&w=1200&auto=format&fit=crop" width="1200" height="800" alt="Καταγραφή αναγκών και επιθυμιών πελάτη" loading="lazy">
           </div>
 
           <div class="step" data-animate="fade-up">
             <span class="step-number">3</span>
             <h4>Οικονομική προσφορά</h4>
             <p>Μέσα στις επόμενες ημέρες λαμβάνετε γραπτή οικονομική προσφορά.</p>
-            <img src="images/project-3.webp" alt="Παράδοση γραπτής οικονομικής προσφοράς" loading="lazy">
+            <img src="https://images.unsplash.com/photo-1521790797524-b2497295b8a0?q=80&w=1200&auto=format&fit=crop" width="1200" height="800" alt="Παράδοση γραπτής οικονομικής προσφοράς" loading="lazy">
           </div>
 
           <div class="step" data-animate="fade-up">
             <span class="step-number">4</span>
             <h4>Συμφωνία &amp; Προγραμματισμός</h4>
             <p>Με την έγκριση της προσφοράς μας, συντάσσεται ιδιωτικό συμφωνητικό που καταγράφει τις εργασίες, το χρονοδιάγραμμα και τον τρόπο πληρωμής.</p>
-            <img src="images/project-4.webp" alt="Υπογραφή συμφωνητικού και προγραμματισμός έργου" loading="lazy">
+            <img src="https://images.unsplash.com/photo-1520607162513-77705c0f0d4a?q=80&w=1200&auto=format&fit=crop" width="1200" height="800" alt="Υπογραφή συμφωνητικού και προγραμματισμός έργου" loading="lazy">
           </div>
 
           <div class="step" data-animate="fade-up">
             <span class="step-number">5</span>
             <h4>Εκτέλεση &amp; Παράδοση</h4>
             <p>Οι εργασίες ξεκινούν κι ο πελάτης ενημερώνεται αναλυτικά για κάθε στάδιό τους. Ο χώρος παραδίδεται με το πέρας των εργασιών, έτοιμος προς χρήση.</p>
-            <img src="images/hero.webp" alt="Παράδοση ολοκληρωμένου έργου ανακαίνισης" loading="lazy">
+            <img src="https://images.unsplash.com/photo-1505691938895-1758d7feb511?q=80&w=1200&auto=format&fit=crop" width="1200" height="800" alt="Παράδοση ολοκληρωμένου έργου ανακαίνισης" loading="lazy">
           </div>
 
         </div>
@@ -554,13 +554,13 @@
         <div class="reasons-list">
 
           <div class="reason" data-animate="fade-up">
-            <img src="images/project-1.webp" alt="Εξειδικευμένα συνεργεία της FM Renovation κατά τη διάρκεια έργου ανακαίνισης" loading="lazy">
+            <img src="https://images.unsplash.com/photo-1484154218962-a197022b5858?q=80&w=1200&auto=format&fit=crop" width="1200" height="800" alt="Εξειδικευμένα συνεργεία της FM Renovation κατά τη διάρκεια έργου ανακαίνισης" loading="lazy">
             <h4>Εμπιστοσύνη &amp; Επαγγελματισμός</h4>
             <p>Η ανακαίνιση, ολική ή μερική, είναι μια διαδικασία πολυδιάστατη. Η εταιρεία μας αναλαμβάνει υπεύθυνα την υλοποίησή της, απαλλάσσοντάς σας από το άγχος.</p>
           </div>
 
           <div class="reason" data-animate="fade-up">
-            <img src="images/project-2.webp" alt="Ενημέρωση πελάτη για την πρόοδο έργου ανακαίνισης της FM Renovation" loading="lazy">
+            <img src="https://images.unsplash.com/photo-1497366216548-37526070297c?q=80&w=1200&auto=format&fit=crop" width="1200" height="800" alt="Ενημέρωση πελάτη για την πρόοδο έργου ανακαίνισης της FM Renovation" loading="lazy">
             <h4>Διαφάνεια &amp; Ενημέρωση</h4>
             <p>Ενημερώνεστε αναλυτικά για κάθε στάδιο. Το έργο παραδίδεται ολοκληρωμένο, “με το κλειδί στο χέρι”, και με γραπτή εγγύηση ποιότητας.</p>
           </div>


### PR DESCRIPTION
## Summary
- replace the placeholder project images in the process timeline with live Unsplash assets so the visuals render
- update the reasons cards to use the same hosted imagery and include intrinsic dimensions for better layout stability

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f157a6bef48320a84889ceb5594313