### PR TITLE
Make site logos link to homepage

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -695,15 +695,15 @@ if(form){form.addEventListener('submit',e=>{e.preventDefault();alert('Ευχαρ
   });
 })();
 
-// Force homepage refresh when clicking on brand logos
-document.querySelectorAll('a.brand').forEach(function(link){
+// Homepage refresh behaviour for logo links
+document.querySelectorAll('.logo-link').forEach(function(link){
   link.addEventListener('click',function(event){
-    const targetUrl=new URL(link.href,window.location.href);
-    const currentUrl=new URL(window.location.href);
-    if(targetUrl.pathname===currentUrl.pathname&&targetUrl.search===currentUrl.search){
+    if(window.location.pathname.endsWith('index.html')||window.location.pathname==='/'){
       event.preventDefault();
-      window.location.href=targetUrl.href;
-      window.location.reload();
+      window.scrollTo({top:0,behavior:'smooth'});
+      setTimeout(function(){
+        window.location.reload();
+      },300);
     }
   });
 });

--- a/assets/style.css
+++ b/assets/style.css
@@ -27,6 +27,9 @@ img{max-width:100%;height:auto;display:block}
 .header-inner{display:flex;align-items:center;gap:12px;padding:12px 0;flex-wrap:wrap}
 .brand{display:inline-flex;flex-direction:column;align-items:center;gap:4px;text-decoration:none;color:inherit;cursor:pointer}
 .brand-logo{height:52px;width:auto}
+/* Logo hover animation */
+.logo-link img{transition:transform .3s ease,opacity .3s ease}
+.logo-link:hover img{transform:scale(1.05);opacity:.9}
 
 
 .nav-toggle{display:inline-flex;flex-direction:column;align-items:center;justify-content:center;gap:6px;width:46px;height:46px;border:1px solid #d8dee9;border-radius:12px;background:rgba(255,255,255,.72);cursor:pointer;transition:background .2s ease,border-color .2s ease}

--- a/index.html
+++ b/index.html
@@ -103,10 +103,12 @@
 <body>
   <header class="site-header" id="top">
     <div class="container header-inner">
-      <a class="brand" href="https://mastereat.github.io/anakainisou.gr/" aria-label="FM Renovation – Αρχική">
-        <img class="brand-logo" src="images/logo.png" alt="FM Renovation λογότυπο">
+      <div class="brand">
+        <a href="index.html" class="logo-link" aria-label="Αρχική σελίδα">
+          <img class="brand-logo" src="images/logo.png" alt="FM Renovation λογότυπο">
+        </a>
         <span class="brand-tagline"><strong>Ανακαινίσεις</strong></span>
-      </a>
+      </div>
       <button class="nav-toggle" type="button" data-nav-toggle aria-expanded="false" aria-controls="mobile-menu" aria-label="Άνοιγμα μενού">
         <span class="nav-toggle-bar"></span>
         <span class="nav-toggle-bar"></span>
@@ -656,9 +658,11 @@
         </ul>
       </div>
       <div class="footer-brand">
-        <a class="brand brand--footer" href="https://mastereat.github.io/anakainisou.gr/" aria-label="FM Renovation – Αρχική">
-          <img class="brand-logo" src="images/logo.png" alt="FM Renovation λογότυπο">
-        </a>
+        <div class="brand brand--footer">
+          <a href="index.html" class="logo-link" aria-label="Αρχική σελίδα">
+            <img class="brand-logo" src="images/logo.png" alt="FM Renovation λογότυπο">
+          </a>
+        </div>
         <nav class="footer-links" aria-label="Χρήσιμες σύνδεσμοι">
           <a href="#">Όροι &amp; Προϋποθέσεις</a>
           <a href="#">Πολιτική Απορρήτου</a>

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -13,10 +13,12 @@
 <body>
   <header class="site-header" id="top">
     <div class="container header-inner">
-      <a class="brand" href="https://mastereat.github.io/anakainisou.gr/" aria-label="FM Renovation – Αρχική">
-        <img class="brand-logo" src="images/logo.png" alt="FM Renovation λογότυπο">
+      <div class="brand">
+        <a href="index.html" class="logo-link" aria-label="Αρχική σελίδα">
+          <img class="brand-logo" src="images/logo.png" alt="FM Renovation λογότυπο">
+        </a>
         <span class="brand-tagline"><strong>Ανακαινίσεις</strong></span>
-      </a>
+      </div>
       <button class="nav-toggle" type="button" data-nav-toggle aria-expanded="false" aria-controls="mobile-menu" aria-label="Άνοιγμα μενού">
         <span class="nav-toggle-bar"></span>
         <span class="nav-toggle-bar"></span>
@@ -120,9 +122,11 @@
 
   <footer class="site-footer">
     <div class="container footer-inner">
-      <a class="brand brand--footer" href="https://mastereat.github.io/anakainisou.gr/" aria-label="FM Renovation – Αρχική">
-        <img class="brand-logo" src="images/logo.png" alt="FM Renovation λογότυπο">
-      </a>
+      <div class="brand brand--footer">
+        <a href="index.html" class="logo-link" aria-label="Αρχική σελίδα">
+          <img class="brand-logo" src="images/logo.png" alt="FM Renovation λογότυπο">
+        </a>
+      </div>
       <p>© <span id="year"></span> FM Renovation • <a href="https://anakainisou.gr/">anakainisou.gr</a></p>
       <div class="social">
         <a href="#" aria-label="Facebook" class="icon fb"></a>

--- a/terms.html
+++ b/terms.html
@@ -13,10 +13,12 @@
 <body>
   <header class="site-header" id="top">
     <div class="container header-inner">
-      <a class="brand" href="https://mastereat.github.io/anakainisou.gr/" aria-label="FM Renovation – Αρχική">
-        <img class="brand-logo" src="images/logo.png" alt="FM Renovation λογότυπο">
+      <div class="brand">
+        <a href="index.html" class="logo-link" aria-label="Αρχική σελίδα">
+          <img class="brand-logo" src="images/logo.png" alt="FM Renovation λογότυπο">
+        </a>
         <span class="brand-tagline"><strong>Ανακαινίσεις</strong></span>
-      </a>
+      </div>
       <button class="nav-toggle" type="button" data-nav-toggle aria-expanded="false" aria-controls="mobile-menu" aria-label="Άνοιγμα μενού">
         <span class="nav-toggle-bar"></span>
         <span class="nav-toggle-bar"></span>
@@ -119,9 +121,11 @@
 
   <footer class="site-footer">
     <div class="container footer-inner">
-      <a class="brand brand--footer" href="https://mastereat.github.io/anakainisou.gr/" aria-label="FM Renovation – Αρχική">
-        <img class="brand-logo" src="images/logo.png" alt="FM Renovation λογότυπο">
-      </a>
+      <div class="brand brand--footer">
+        <a href="index.html" class="logo-link" aria-label="Αρχική σελίδα">
+          <img class="brand-logo" src="images/logo.png" alt="FM Renovation λογότυπο">
+        </a>
+      </div>
       <p>© <span id="year"></span> FM Renovation • <a href="https://anakainisou.gr/">anakainisou.gr</a></p>
       <div class="social">
         <a href="#" aria-label="Facebook" class="icon fb"></a>


### PR DESCRIPTION
## Summary
- wrap header and footer logos in a reusable `.logo-link` anchor that points to `index.html` across all pages
- add hover animation styling for logo images and homepage refresh behaviour when already on the landing page

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f15be718f483208d8e5ccb0acf66b3