### PR TITLE
Adjust fade animation trigger for mobile sections

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -688,7 +688,10 @@ if(form){form.addEventListener('submit',e=>{e.preventDefault();alert('Ευχαρ
         observer.unobserve(entry.target);
       }
     });
-  },{threshold:0.2});
+  },{
+    threshold:0.1,
+    rootMargin:'0px 0px 20% 0px'
+  });
 
   fadeEls.forEach(function(el){
     observer.observe(el);


### PR DESCRIPTION
## Summary
- reduce the intersection observer threshold and extend the root margin so the fade-up cards appear sooner on small screens

## Testing
- Manual verification on an emulated mobile viewport

------
https://chatgpt.com/codex/tasks/task_e_68f17a839430832095a13a36c77de8fa