### PR TITLE
Connect contact form to Formspree

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -710,3 +710,32 @@ document.querySelectorAll('.logo-link').forEach(function(link){
     }
   });
 });
+
+// Formspree inline submit (ID: mkgqykrp)
+(()=>{
+  const form=document.getElementById('contactForm');
+  if(!form){return;}
+  const status=document.getElementById('formStatus');
+
+  form.addEventListener('submit',async event=>{
+    event.preventDefault();
+    if(status){status.hidden=false;status.textContent='Αποστολή...';}
+
+    try{
+      const data=new FormData(form);
+      const res=await fetch(form.action,{method:'POST',body:data,headers:{'Accept':'application/json'}});
+
+      if(res.ok){
+        form.reset();
+        if(status){status.textContent='✅ Το μήνυμά σας στάλθηκε με επιτυχία! Θα επικοινωνήσουμε σύντομα.';}
+        // window.gtag?.('event','form_submit',{form:'contact'}); // optional analytics
+      }else if(status){
+        status.textContent='❌ Κάτι πήγε στραβά. Δοκιμάστε ξανά ή καλέστε μας.';
+      }
+    }catch(error){
+      if(status){status.textContent='❌ Πρόβλημα δικτύου. Δοκιμάστε ξανά.';}
+    }
+
+    setTimeout(()=>{if(status){status.hidden=true;}},7000);
+  });
+})();

--- a/assets/style.css
+++ b/assets/style.css
@@ -219,11 +219,20 @@ body.nav-open{overflow:hidden}
 .testimonials{display:grid;grid-auto-flow:column;grid-auto-columns:85%;gap:14px;overflow-x:auto;scroll-snap-type:x mandatory}
 .t-card{scroll-snap-align:start;background:#fff;border:1px solid #e8edf4;border-radius:14px;padding:16px;box-shadow:var(--shadow)}
 
-/* Contact + Map */
+/* Contact section */
+.contact-section{background:#f8f8f8;padding:80px 20px;text-align:center}
+.contact-intro{max-width:640px;margin:0 auto 32px;color:#333}
+.contact-form{max-width:640px;margin:0 auto;display:flex;flex-direction:column;gap:16px;text-align:left;background:#fff;border:1px solid #e8edf4;border-radius:16px;padding:32px;box-shadow:var(--shadow)}
+#contactForm{display:flex;flex-direction:column;gap:16px}
 .contact{display:grid;grid-template-columns:minmax(0,1fr);gap:28px;align-items:start}
-.form{display:grid;gap:12px;background:#fff;border:1px solid #e8edf4;border-radius:14px;padding:16px;box-shadow:var(--shadow)}
-.form input,.form textarea{width:100%;padding:12px 14px;border:1px solid #dfe6ef;border-radius:10px}
-.form input:focus,.form textarea:focus{outline:2px solid var(--accent)}
+.form-group label{font-weight:600;margin-bottom:6px;display:block}
+.form-group input,.form-group textarea,.form-group select{width:100%;padding:12px 14px;border:1px solid #cfd3d9;border-radius:10px;font:inherit}
+.form-group input:focus,.form-group textarea:focus,.form-group select:focus{outline:none;border-color:var(--accent,#F59E0B);box-shadow:0 0 0 3px rgba(245,158,11,.2)}
+.btn-submit{background:var(--accent,#F59E0B);color:#fff;border:0;padding:14px 20px;border-radius:10px;font-weight:600;cursor:pointer;transition:.25s}
+.btn-submit:hover{background:#e48e0a;transform:translateY(-1px)}
+.form-status{margin-top:8px;font-size:.95rem}
+.gdpr{display:block;font-size:.95rem}
+.gdpr a{color:var(--accent,#F59E0B);text-decoration:underline}
 .map iframe{width:100%;min-height:360px;border:0;border-radius:14px;box-shadow:var(--shadow)}
 
 /* Footer */

--- a/index.html
+++ b/index.html
@@ -607,17 +607,70 @@
     </section>
 
     <!-- CONTACT + MAP -->
-    <section id="contact" class="section section--cta">
+    <section id="contact" class="section contact-section">
       <div class="container contact">
-        <form class="form" method="post" onsubmit="return false" aria-label="Φόρμα επικοινωνίας">
+        <div class="contact-form">
           <h2>Επικοινωνία</h2>
-          <label>Ονοματεπώνυμο <input type="text" required></label>
-          <label>Email <input type="email" required></label>
-          <label>Τηλέφωνο <input type="tel" required></label>
-          <label>Μήνυμα <textarea rows="4" required></textarea></label>
-          <button class="btn btn--primary" type="submit">Αποστολή</button>
-          <p class="form-note">Με την αποστολή αποδέχεστε την επεξεργασία των δεδομένων σύμφωνα με την πολιτική απορρήτου.</p>
-        </form>
+          <p class="contact-intro">Στείλτε μας ένα μήνυμα και θα επικοινωνήσουμε μαζί σας το συντομότερο.</p>
+
+          <form id="contactForm" action="https://formspree.io/f/mkgqykrp" method="POST" novalidate>
+            <div class="form-group">
+              <label for="name">Ονοματεπώνυμο</label>
+              <input id="name" name="name" type="text" placeholder="Πλήρες όνομα" required>
+            </div>
+
+            <div class="form-group">
+              <label for="email">Email</label>
+              <input id="email" name="email" type="email" placeholder="Το email σας" required>
+            </div>
+
+            <div class="form-group">
+              <label for="phone">Τηλέφωνο</label>
+              <input id="phone" name="phone" type="tel" inputmode="tel" placeholder="Π.χ. 2101234567">
+            </div>
+
+            <div class="form-group">
+              <label for="service">Υπηρεσία</label>
+              <select id="service" name="service">
+                <option value="">Επιλέξτε υπηρεσία (προαιρετικό)</option>
+                <option>Γκρεμίσματα / αποξηλώσεις</option>
+                <option>Χτισίματα – σοβατίσματα – ελαιοχρωματισμοί</option>
+                <option>Υδραυλικές εργασίες</option>
+                <option>Ηλεκτρολογικές εργασίες – Υ.Δ.Ε.</option>
+                <option>Κουφώματα αλουμινίου / PVC</option>
+                <option>Πλακίδια – Δάπεδα</option>
+                <option>Γυψοσανίδες – Ψευδοροφές</option>
+                <option>Μονώσεις</option>
+                <option>Άλλο</option>
+              </select>
+            </div>
+
+            <div class="form-group">
+              <label for="message">Μήνυμα</label>
+              <textarea id="message" name="message" rows="5" placeholder="Πείτε μας λίγα λόγια για το έργο…" required></textarea>
+            </div>
+
+            <!-- GDPR -->
+            <label class="gdpr">
+              <input type="checkbox" name="gdpr" required>
+              Συμφωνώ με την <a href="/privacy-policy.html" target="_blank" rel="noopener">Πολιτική Απορρήτου</a>.
+            </label>
+
+            <!-- Honeypot (spam trap) -->
+            <input type="text" name="_gotcha" style="display:none">
+
+            <!-- Subject & Reply-To -->
+            <input type="hidden" name="_subject" value="Νέο μήνυμα από τη φόρμα – FM Renovation">
+            <input type="hidden" name="_replyto" value="{{email}}">
+
+            <!-- <div class="g-recaptcha" data-sitekey="YOUR_RECAPTCHA_SITE_KEY"></div> -->
+
+            <button type="submit" class="btn-submit">Αποστολή Μηνύματος</button>
+
+            <!-- Inline feedback -->
+            <p id="formStatus" class="form-status" aria-live="polite" hidden></p>
+          </form>
+        </div>
         <div class="map">
           <iframe title="Χάρτης" loading="lazy" referrerpolicy="no-referrer-when-downgrade"
             src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3151!2d23.7275!3d37.9838!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x0%3A0x0!2zQXRoZW5z!5e0!3m2!1sel!2sgr!4v0000000000"></iframe>


### PR DESCRIPTION
## Summary
- connect the contact section to Formspree with the required fields, GDPR checkbox, honeypot, and inline status messaging
- add styling and JavaScript to provide Formspree submission handling and visual updates

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68f2a6e4e268832088b967c76444e586