### PR TITLE
Fix footer legal links

### DIFF
--- a/index.html
+++ b/index.html
@@ -717,8 +717,8 @@
           </a>
         </div>
         <nav class="footer-links" aria-label="Χρήσιμες σύνδεσμοι">
-          <a href="#">Όροι &amp; Προϋποθέσεις</a>
-          <a href="#">Πολιτική Απορρήτου</a>
+          <a href="terms.html">Όροι &amp; Προϋποθέσεις</a>
+          <a href="privacy-policy.html">Πολιτική Απορρήτου</a>
         </nav>
         <p class="footer-copy">© <span id="year"></span> FM Renovation • <a href="https://anakainisou.gr/">anakainisou.gr</a></p>
       </div>


### PR DESCRIPTION
## Summary
- update the footer legal links to point to the dedicated terms and privacy pages

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68f2b40276fc8320a0d6acd83a8dac79