### PR TITLE
Configure favicon paths for GitHub Pages deployment

### DIFF
--- a/favicon/site.webmanifest
+++ b/favicon/site.webmanifest
@@ -1,21 +1,14 @@
 {
-  "name": "MyWebSite",
-  "short_name": "MySite",
-  "icons": [
-    {
-      "src": "/web-app-manifest-192x192.png",
-      "sizes": "192x192",
-      "type": "image/png",
-      "purpose": "maskable"
-    },
-    {
-      "src": "/web-app-manifest-512x512.png",
-      "sizes": "512x512",
-      "type": "image/png",
-      "purpose": "maskable"
-    }
-  ],
-  "theme_color": "#ffffff",
+  "name": "FM Renovation",
+  "short_name": "FM Renovation",
+  "start_url": "../",
+  "scope": "../",
+  "display": "standalone",
   "background_color": "#ffffff",
-  "display": "standalone"
+  "theme_color": "#F59E0B",
+  "icons": [
+    { "src": "favicon-96x96.png", "sizes": "96x96", "type": "image/png" },
+    { "src": "web-app-manifest-192x192.png", "sizes": "192x192", "type": "image/png" },
+    { "src": "web-app-manifest-512x512.png", "sizes": "512x512", "type": "image/png" }
+  ]
 }

--- a/index.html
+++ b/index.html
@@ -9,6 +9,13 @@
   <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Roboto:wght@700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="assets/style.css">
+  <link rel="icon" type="image/png" href="favicon/favicon-96x96.png" sizes="96x96">
+  <link rel="icon" type="image/svg+xml" href="favicon/favicon.svg">
+  <link rel="shortcut icon" href="favicon/favicon.ico">
+  <link rel="apple-touch-icon" sizes="180x180" href="favicon/apple-touch-icon.png">
+  <link rel="manifest" href="favicon/site.webmanifest">
+  <link rel="mask-icon" href="favicon/favicon.svg" color="#F59E0B">
+  <meta name="theme-color" content="#F59E0B">
   <meta property="og:type" content="website">
   <meta property="og:locale" content="el_GR">
   <meta property="og:title" content="FM Renovation – Ανακαινίσεις">

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -9,6 +9,13 @@
   <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Roboto:wght@700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="assets/style.css">
+  <link rel="icon" type="image/png" href="favicon/favicon-96x96.png" sizes="96x96">
+  <link rel="icon" type="image/svg+xml" href="favicon/favicon.svg">
+  <link rel="shortcut icon" href="favicon/favicon.ico">
+  <link rel="apple-touch-icon" sizes="180x180" href="favicon/apple-touch-icon.png">
+  <link rel="manifest" href="favicon/site.webmanifest">
+  <link rel="mask-icon" href="favicon/favicon.svg" color="#F59E0B">
+  <meta name="theme-color" content="#F59E0B">
 </head>
 <body>
   <header class="site-header" id="top">

--- a/terms.html
+++ b/terms.html
@@ -9,6 +9,13 @@
   <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Roboto:wght@700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="assets/style.css">
+  <link rel="icon" type="image/png" href="favicon/favicon-96x96.png" sizes="96x96">
+  <link rel="icon" type="image/svg+xml" href="favicon/favicon.svg">
+  <link rel="shortcut icon" href="favicon/favicon.ico">
+  <link rel="apple-touch-icon" sizes="180x180" href="favicon/apple-touch-icon.png">
+  <link rel="manifest" href="favicon/site.webmanifest">
+  <link rel="mask-icon" href="favicon/favicon.svg" color="#F59E0B">
+  <meta name="theme-color" content="#F59E0B">
 </head>
 <body>
   <header class="site-header" id="top">


### PR DESCRIPTION
## Summary
- add consistent favicon and manifest link tags to each HTML document using relative paths
- update the web manifest with FM Renovation branding, icons, and scoped URLs for the favicon directory

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68f2b8758f2c8320890ea9340a8da533