### PR TITLE
feat: refresh services accordion experience

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -268,277 +268,90 @@ if('IntersectionObserver'in window&&servicesSection&&servicesNavLinks.length){
   observer.observe(servicesSection);
 }
 
+// Accordion toggle + aria
+document.querySelectorAll('.service-card .service-header').forEach(btn=>{
+  const card=btn.closest('.service-card');
+  const content=card?card.querySelector('.service-content'):null;
+  let closeTimer=null;
+  let closeHandler=null;
 
-(function(){
-  if(!servicesSection){return;}
-  const grid=servicesSection.querySelector('[data-services-grid]');
-  if(!grid){return;}
-  const cards=Array.from(grid.querySelectorAll('.service'));
-  if(!cards.length){return;}
-  const cardMap=new Map(cards.map(card=>[card.id,card]));
-  const controls=servicesSection.querySelector('[data-services-controls]');
-  const chipButtons=controls?Array.from(controls.querySelectorAll('[data-services-chip]')):[];
-  const searchInput=controls?controls.querySelector('[data-services-search]'):null;
-  const actions=servicesSection.querySelector('.services__actions');
-  const moreButton=actions?actions.querySelector('[data-services-more]'):null;
-  const emptyState=servicesSection.querySelector('[data-services-empty]');
-  const mobileMedia=window.matchMedia('(max-width: 767px)');
-  const header=document.querySelector('.site-header');
-  const step=6;
-  const openCards=new Set();
-  let lastFiltered=cards.slice();
-  const state={category:'all',search:'',visibleCount:step};
-
-  const getSearchText=card=>{
-    const fromAttr=card.getAttribute('data-search')||'';
-    const title=card.querySelector('.service__title');
-    return `${fromAttr} ${title?title.textContent:''}`;
-  };
-
-  const matchesCategory=card=>{
-    if(state.category==='all'){return true;}
-    const cat=(card.dataset.cat||'').split(/\s+/).filter(Boolean);
-    return cat.includes(state.category);
-  };
-
-  const matchesSearch=card=>{
-    if(!state.search){return true;}
-    return getSearchText(card).toLowerCase().includes(state.search.toLowerCase());
-  };
-
-  const getFilteredCards=()=>cards.filter(card=>matchesCategory(card)&&matchesSearch(card));
-
-  const renderCard=(card,open,{updateStore=true}={})=>{
-    const toggle=card.querySelector('.service__toggle');
-    const panel=card.querySelector('.service__panel');
-    if(!toggle||!panel){return;}
-    if(updateStore){
-      if(open){openCards.add(card.id);}else{openCards.delete(card.id);}
+  const clearPendingClose=()=>{
+    if(closeTimer!==null){
+      clearTimeout(closeTimer);
+      closeTimer=null;
     }
-    toggle.setAttribute('aria-expanded',String(open));
-    card.classList.toggle('is-open',open);
-    if(mobileMedia.matches){
-      panel.style.maxHeight=open?`${panel.scrollHeight}px`:'0px';
+    if(content&&closeHandler){
+      content.removeEventListener('transitionend',closeHandler);
+      closeHandler=null;
+    }
+  };
+
+  const scheduleHide=()=>{
+    if(!content){return;}
+    clearPendingClose();
+    closeHandler=()=>{
+      content.hidden=true;
+      clearPendingClose();
+    };
+    content.addEventListener('transitionend',closeHandler);
+    closeTimer=window.setTimeout(closeHandler,360);
+  };
+
+  if(content){
+    if(card&&card.classList.contains('open')){
+      content.hidden=false;
+      btn.setAttribute('aria-expanded','true');
     }else{
-      panel.style.maxHeight='';
+      content.hidden=true;
+      btn.setAttribute('aria-expanded','false');
     }
-  };
+  }
 
-  const syncAccordions=()=>{
-    cards.forEach(card=>{
-      const toggle=card.querySelector('.service__toggle');
-      if(!toggle){return;}
-      if(mobileMedia.matches){
-        toggle.disabled=false;
-        renderCard(card,openCards.has(card.id),{updateStore:false});
-      }else{
-        toggle.disabled=true;
-        renderCard(card,true,{updateStore:false});
-      }
-    });
-  };
-
-  const refreshOpenPanels=()=>{
-    if(!mobileMedia.matches){return;}
-    openCards.forEach(id=>{
-      const card=cardMap.get(id);
-      if(!card||card.hidden){return;}
-      const panel=card.querySelector('.service__panel');
-      if(panel){panel.style.maxHeight=`${panel.scrollHeight}px`;}
-    });
-  };
-
-  const setVisibleCount=count=>{
-    state.visibleCount=Math.max(step,count);
-  };
-
-  const applyState=()=>{
-    const isMobile=mobileMedia.matches;
-    const filtered=getFilteredCards();
-    lastFiltered=filtered.slice();
-    const total=filtered.length;
-
-    if(!isMobile){
-      cards.forEach(card=>{card.hidden=false;});
-      if(emptyState){emptyState.hidden=true;}
-      if(actions){actions.hidden=true;}
-      syncAccordions();
-      return;
-    }
-
-    setVisibleCount(state.visibleCount);
-    cards.forEach(card=>{card.hidden=true;});
-    const limit=total===0?0:Math.min(state.visibleCount,total);
-    filtered.forEach((card,index)=>{
-      card.hidden=index>=limit;
-    });
-
-    if(emptyState){emptyState.hidden=total!==0;}
-    if(actions){
-      const shouldShowMore=total>step;
-      actions.hidden=!shouldShowMore;
-      if(moreButton){
-        if(shouldShowMore){
-          const showingAll=limit>=total&&total>step;
-          moreButton.textContent=showingAll?'Σύμπτυξη':'Εμφάνιση περισσότερων';
-          moreButton.setAttribute('aria-expanded',showingAll?'true':'false');
+  btn.addEventListener('click',()=>{
+    if(!card){return;}
+    const isOpen=card.classList.contains('open');
+    if(isOpen){
+      card.classList.remove('open');
+      btn.setAttribute('aria-expanded','false');
+      if(content){
+        clearPendingClose();
+        if(prefersReducedMotion.matches){
+          content.hidden=true;
         }else{
-          moreButton.textContent='Εμφάνιση περισσότερων';
-          moreButton.setAttribute('aria-expanded','false');
+          scheduleHide();
         }
       }
-    }
-    syncAccordions();
-    refreshOpenPanels();
-  };
-
-  const updateChipState=()=>{
-    chipButtons.forEach(btn=>{
-      const isActive=(btn.dataset.filter||'all')===state.category;
-      btn.classList.toggle('is-active',isActive);
-      btn.setAttribute('aria-selected',String(isActive));
-    });
-  };
-
-  const debounce=(fn,delay)=>{
-    let timer;
-    return (...args)=>{
-      clearTimeout(timer);
-      timer=setTimeout(()=>fn(...args),delay);
-    };
-  };
-
-  if(chipButtons.length){
-    chipButtons.forEach((btn,index)=>{
-      btn.addEventListener('click',()=>{
-        const value=btn.dataset.filter||'all';
-        if(state.category===value){return;}
-        state.category=value;
-        setVisibleCount(step);
-        updateChipState();
-        applyState();
-      });
-      btn.addEventListener('keydown',event=>{
-        if(event.key!=='ArrowRight'&&event.key!=='ArrowLeft'){return;}
-        event.preventDefault();
-        if(!chipButtons.length){return;}
-        const dir=event.key==='ArrowRight'?1:-1;
-        const next=(index+dir+chipButtons.length)%chipButtons.length;
-        chipButtons[next].focus();
-      });
-    });
-  }
-
-  if(searchInput){
-    const handleSearch=debounce(()=>{
-      state.search=searchInput.value.trim();
-      setVisibleCount(step);
-      applyState();
-    },200);
-    searchInput.addEventListener('input',handleSearch);
-  }
-
-  if(moreButton){
-    moreButton.addEventListener('click',()=>{
-      const total=lastFiltered.length;
-      if(!total){return;}
-      if(state.visibleCount>=total){
-        setVisibleCount(step);
-      }else{
-        setVisibleCount(state.visibleCount+step);
+    }else{
+      if(content){
+        clearPendingClose();
+        content.hidden=false;
       }
-      applyState();
-    });
-  }
-
-  cards.forEach(card=>{
-    const toggle=card.querySelector('.service__toggle');
-    if(!toggle){return;}
-    toggle.addEventListener('click',()=>{
-      if(!mobileMedia.matches){return;}
-      const isOpen=openCards.has(card.id);
-      renderCard(card,!isOpen);
-    });
+      card.classList.add('open');
+      btn.setAttribute('aria-expanded','true');
+    }
   });
 
-  const updateStickyState=()=>{
-    if(!controls){return;}
-    if(!mobileMedia.matches){
-      controls.classList.remove('is-stuck');
-      return;
-    }
-    const sectionTop=servicesSection.getBoundingClientRect().top+window.scrollY;
-    const headerHeight=header?header.offsetHeight:0;
-    const isStuck=window.scrollY+headerHeight>=sectionTop;
-    controls.classList.toggle('is-stuck',isStuck);
-  };
+  btn.addEventListener('pointerdown',event=>{
+    const rect=event.currentTarget.getBoundingClientRect();
+    event.currentTarget.style.setProperty('--rx',`${event.clientX-rect.left}px`);
+    event.currentTarget.style.setProperty('--ry',`${event.clientY-rect.top}px`);
+  });
+});
 
-  let ticking=false;
-  window.addEventListener('scroll',()=>{
-    if(ticking){return;}
-    ticking=true;
-    requestAnimationFrame(()=>{
-      updateStickyState();
-      ticking=false;
+// Scroll-reveal on first view
+if('IntersectionObserver'in window){
+  const io=new IntersectionObserver(entries=>{
+    entries.forEach(entry=>{
+      if(entry.isIntersecting){
+        entry.target.classList.add('in');
+        io.unobserve(entry.target);
+      }
     });
-  },{passive:true});
-
-  const handleMediaChange=()=>{
-    syncAccordions();
-    applyState();
-    updateStickyState();
-  };
-
-  if(typeof mobileMedia.addEventListener==='function'){
-    mobileMedia.addEventListener('change',handleMediaChange);
-  }else if(typeof mobileMedia.addListener==='function'){
-    mobileMedia.addListener(handleMediaChange);
-  }
-
-  window.addEventListener('resize',debounce(()=>{
-    refreshOpenPanels();
-    updateStickyState();
-  },150));
-
-  let initialTarget=null;
-  if(window.location.hash){
-    const raw=decodeURIComponent(window.location.hash);
-    const parts=raw.replace(/^#/, '').split('#').filter(Boolean);
-    for(let i=parts.length-1;i>=0;i-=1){
-      const part=parts[i];
-      if(!part){continue;}
-      const exact=document.getElementById(part);
-      if(exact&&cards.includes(exact)){initialTarget=exact;break;}
-      const prefixed=document.getElementById(`service-${part}`);
-      if(prefixed&&cards.includes(prefixed)){initialTarget=prefixed;break;}
-    }
-    if(!initialTarget&&parts.length){
-      const slug=parts[parts.length-1].toLowerCase();
-      initialTarget=cards.find(card=>{
-        const keywords=(card.getAttribute('data-search')||'').toLowerCase();
-        return keywords.split(/\s+/).includes(slug);
-      })||null;
-    }
-  }
-
-  if(initialTarget){
-    openCards.add(initialTarget.id);
-    const index=cards.indexOf(initialTarget);
-    if(index>-1){setVisibleCount(Math.max(step,index+1));}
-  }
-
-  updateChipState();
-  applyState();
-  updateStickyState();
-  if(initialTarget){
-    renderCard(initialTarget,true);
-    setTimeout(()=>{
-      const behavior=prefersReducedMotion.matches?'auto':'smooth';
-      initialTarget.scrollIntoView({behavior,block:'start'});
-      refreshOpenPanels();
-    },200);
-  }
-})();
+  },{threshold:0.12});
+  document.querySelectorAll('.reveal').forEach(el=>io.observe(el));
+}else{
+  document.querySelectorAll('.reveal').forEach(el=>el.classList.add('in'));
+}
 
 // Footer year
 const y=document.getElementById('year'); if(y) y.textContent=new Date().getFullYear();

--- a/assets/style.css
+++ b/assets/style.css
@@ -146,47 +146,41 @@ body.nav-open{overflow:hidden}
 .bullets{padding-left:18px}
 
 /* Services */
-.grid{display:grid;gap:16px}
-.services{grid-template-columns:minmax(0,1fr)}
-.card{background:var(--card);padding:clamp(20px,4vw,26px);border:1px solid #e8edf4;border-radius:16px;transition:transform .2s, box-shadow .2s;min-height:100%}
-.card:hover,.card:focus-within{transform:scale(1.01);box-shadow:0 14px 32px rgba(15,23,42,.14)}
-.card .link{display:inline-flex;align-items:center;gap:6px;margin-top:6px;text-decoration:underline;font-weight:600;color:var(--accent-2);transition:color .2s ease}
-.card .link:hover,.card .link:focus-visible{color:var(--accent);outline:none}
-.service{display:flex;flex-direction:column;gap:12px;min-height:320px}
-.service__heading{margin:0}
-.service__toggle{width:100%;display:flex;align-items:center;justify-content:space-between;gap:12px;padding:0;border:0;background:none;color:inherit;font:inherit;text-align:left;cursor:pointer;min-height:48px}
-.service__title{display:-webkit-box;font-size:1.08rem;line-height:1.35;font-weight:600;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden}
-.service__chevron{flex-shrink:0;width:16px;height:16px;border-right:2px solid currentColor;border-bottom:2px solid currentColor;transform:rotate(45deg);transition:transform .24s ease}
-.service__panel{display:flex;flex-direction:column;gap:18px}
-.service__panel-inner{display:flex;flex-direction:column;gap:12px;flex:1}
-.service__content{display:flex;flex-direction:column;gap:12px;flex:1}
-.service p{margin:0;line-height:1.6;color:rgba(15,23,42,.9)}
-.service__cta{margin-top:auto;justify-content:flex-start}
-.service.is-open .service__chevron{transform:rotate(-135deg)}
-.service.is-open .service__title{color:var(--accent);text-decoration:underline;text-decoration-thickness:2px;text-decoration-color:var(--accent)}
-
-.services-mobile-controls{display:none}
-.services-chips{display:flex;gap:8px}
-.services-chip{appearance:none;border:1px solid rgba(15,23,42,.18);background:#fff;color:var(--text);border-radius:999px;padding:10px 16px;font-weight:600;font-size:.95rem;line-height:1;display:inline-flex;align-items:center;justify-content:center;gap:8px;min-height:44px;cursor:pointer;transition:background .2s ease,border-color .2s ease,color .2s ease}
-.services-chip.is-active,.services-chip[aria-selected="true"]{background:rgba(245,158,11,.14);border-color:var(--accent);color:#b45309}
-.services-chip:focus-visible{outline:0;box-shadow:0 0 0 3px var(--ring)}
-.services-search{display:none}
-.services-search input{width:100%;border:1px solid rgba(15,23,42,.18);border-radius:999px;padding:10px 16px;font:inherit;color:inherit;background:#fff}
-.services-search input:focus{outline:0;box-shadow:0 0 0 3px var(--ring)}
-.services__actions{display:none}
-.services__more{width:100%;max-width:320px;font-weight:600}
-.services__actions[hidden],.services-empty[hidden]{display:none !important}
-.services-empty{font-weight:600;margin:12px 0 0;opacity:.85}
-
-.service__toggle:focus-visible{outline:0;box-shadow:0 0 0 3px var(--ring);border-radius:12px}
-.service__toggle[disabled]{cursor:default}
-.service__chevron{color:var(--accent)}
-.service.is-open .service__chevron{color:var(--accent)}
-.service__internal{color:var(--accent);font-weight:600;text-decoration:underline;text-decoration-thickness:2px;text-decoration-color:rgba(245,158,11,.45);transition:color .2s ease,text-decoration-color .2s ease}
-.service__internal:hover,.service__internal:focus-visible{color:#b45309;text-decoration-color:#b45309;outline:none}
-.service:hover .service__title,.service:focus-within .service__title{color:var(--accent);text-decoration:underline;text-decoration-thickness:2px;text-decoration-color:var(--accent)}
-.under-cta .btn{font-weight:700}
-.under-cta .btn:hover,.under-cta .btn:focus-visible{color:var(--accent-2)}
+.services{padding:12px;}
+.service-card{background:#fff;border-radius:16px;box-shadow:0 2px 6px rgba(0,0,0,.06);margin:12px 0;overflow:hidden;transform:translateZ(0);transition:box-shadow .25s ease;}
+.service-card.open{box-shadow:0 6px 18px rgba(0,0,0,.10);}
+.service-header{-webkit-tap-highlight-color:transparent;width:100%;display:flex;align-items:center;justify-content:space-between;background:#F9FAFB;border:0;padding:14px 16px;text-align:left;font-weight:700;font-size:16px;color:#0F172A;position:relative;overflow:hidden;}
+.service-title{white-space:normal;line-height:1.25;}
+.arrow{color:#F59E0B;transition:transform .25s ease;}
+.service-card.open .arrow{transform:rotate(180deg);}
+.service-content{max-height:0;overflow:hidden;background:#fff;padding:0 16px;transition:max-height .3s ease,padding .3s ease;line-height:1.6;}
+.service-card.open .service-content{max-height:600px;padding:12px 16px 16px;}
+.service-content p{margin:0 0 12px;color:rgba(15,23,42,.9);}
+.service-content p:last-child{margin-bottom:0;}
+.service__internal{color:var(--accent);font-weight:600;text-decoration:underline;text-decoration-thickness:2px;text-decoration-color:rgba(245,158,11,.45);transition:color .2s ease,text-decoration-color .2s ease;}
+.service__internal:hover,
+.service__internal:focus-visible{color:#b45309;text-decoration-color:#b45309;outline:none;}
+.service__cta{display:inline-flex;align-items:center;gap:6px;margin-top:8px;font-weight:600;color:var(--accent-2);text-decoration:underline;transition:color .2s ease;}
+.service__cta:hover,
+.service__cta:focus-visible{color:var(--accent);outline:none;}
+/* Tap ripple (radial fill #d7c9a9) */
+.ripple::after{content:"";position:absolute;left:var(--rx,50%);top:var(--ry,50%);width:0;height:0;transform:translate(-50%,-50%);background:radial-gradient(circle,#d7c9a9 0%,rgba(215,201,169,0) 70%);opacity:.4;border-radius:50%;pointer-events:none;transition:width .45s ease,height .45s ease,opacity .6s ease;}
+.ripple:active::after{width:220px;height:220px;opacity:.15;}
+/* Scroll-reveal */
+.reveal{opacity:0;transform:translateY(16px);transition:opacity .45s ease,transform .45s ease;}
+.reveal.in{opacity:1;transform:translateY(0);}
+@media (min-width:480px){.service-header{font-size:17px;}}
+@media (min-width:640px){
+  .services{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:18px;}
+  .service-card{margin:0;}
+}
+@media (min-width:1024px){
+  .services{grid-template-columns:repeat(3,minmax(0,1fr));}
+}
+.under-cta{text-align:center;margin-top:18px;}
+.under-cta .btn{font-weight:700;}
+.under-cta .btn:hover,
+.under-cta .btn:focus-visible{color:var(--accent-2);}
 
 /* Process & Reasons */
 .section-light{background:linear-gradient(180deg,#ffffff 0%,#f5f7fa 100%);padding:72px 0}

--- a/index.html
+++ b/index.html
@@ -238,267 +238,188 @@
     <section id="services" class="section section--muted">
       <div class="container">
         <h2>Υπηρεσίες</h2>
-        <div class="services-mobile-controls" data-services-controls>
-          <div class="services-chips" role="tablist" aria-label="Κατηγορίες υπηρεσιών">
-            <button class="services-chip is-active" type="button" role="tab" aria-selected="true" data-services-chip data-filter="all">Όλα</button>
-            <button class="services-chip" type="button" role="tab" aria-selected="false" data-services-chip data-filter="basics">Βασικές εργασίες</button>
-            <button class="services-chip" type="button" role="tab" aria-selected="false" data-services-chip data-filter="installations">Εγκαταστάσεις</button>
-            <button class="services-chip" type="button" role="tab" aria-selected="false" data-services-chip data-filter="openings">Κουφώματα &amp; πόρτες</button>
-            <button class="services-chip" type="button" role="tab" aria-selected="false" data-services-chip data-filter="surfaces">Δάπεδα &amp; επιφάνειες</button>
-            <button class="services-chip" type="button" role="tab" aria-selected="false" data-services-chip data-filter="carpentry">Ξυλουργικά</button>
-            <button class="services-chip" type="button" role="tab" aria-selected="false" data-services-chip data-filter="permits">Άδειες &amp; όψεις</button>
-          </div>
-          <label class="services-search">
-            <span class="visually-hidden">Αναζήτηση υπηρεσιών</span>
-            <input type="search" placeholder="Αναζήτηση υπηρεσίας…" aria-label="Αναζήτηση υπηρεσιών" data-services-search>
-          </label>
-        </div>
-        <div class="grid services" data-services-grid>
-          <article class="card service" id="service-demolition" data-cat="basics" data-search="γκρεμίσματα αποξηλώσεις απομάκρυνση κάδος ανακαίνιση βασικές εργασίες demolition demo removal debris">
-            <h3 class="service__heading">
-              <button class="service__toggle" type="button" aria-expanded="false" aria-controls="service-demolition-panel" aria-labelledby="service-demolition-label">
-                <span class="service__title" id="service-demolition-label">Γκρεμίσματα – αποξηλώσεις – απομάκρυνση παλαιών υλικών με κάδο</span>
-                <span class="service__chevron" aria-hidden="true"></span>
-              </button>
-            </h3>
-            <div class="service__panel" id="service-demolition-panel" role="region" aria-labelledby="service-demolition-label">
-              <div class="service__panel-inner">
-                <div class="service__content">
-                  <p>Οργανώνουμε <a href="#service-demolition" class="service__internal">γκρεμίσματα και αποξηλώσεις</a> με ασφαλιστική κάλυψη, καθαρή απομάκρυνση μπαζών και προστασία κοινόχρηστων χώρων σε όλη την Αττική.</p>
-                </div>
-                <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
-              </div>
+        <section class="services">
+          <article class="service-card reveal" id="service-demolition">
+            <button class="service-header ripple" type="button" aria-expanded="false">
+              <span class="service-title">Γκρεμίσματα – αποξηλώσεις – απομάκρυνση παλαιών υλικών με κάδο</span>
+              <svg class="arrow" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true">
+                <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2"/>
+              </svg>
+            </button>
+            <div class="service-content">
+              <p>Οργανώνουμε <a href="#service-demolition" class="service__internal">γκρεμίσματα και αποξηλώσεις</a> με ασφαλιστική κάλυψη, καθαρή απομάκρυνση μπαζών και προστασία κοινόχρηστων χώρων σε όλη την Αττική.</p>
+              <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
             </div>
           </article>
-          <article class="card service" id="service-masonry" data-cat="basics" data-search="χτισίματα σοβατίσματα ελαιοχρωματισμοί τοιχοποιία βασικές εργασίες masonry plaster painting walls">
-            <h3 class="service__heading">
-              <button class="service__toggle" type="button" aria-expanded="false" aria-controls="service-masonry-panel" aria-labelledby="service-masonry-label">
-                <span class="service__title" id="service-masonry-label">Χτισίματα – σοβατίσματα – ελαιοχρωματισμοί τοιχοποιίας</span>
-                <span class="service__chevron" aria-hidden="true"></span>
-              </button>
-            </h3>
-            <div class="service__panel" id="service-masonry-panel" role="region" aria-labelledby="service-masonry-label">
-              <div class="service__panel-inner">
-                <div class="service__content">
-                  <p>Εφαρμόζουμε επιμελημένα χτισίματα και σοβατίσματα, ενώ οι <a href="#service-masonry" class="service__internal">ελαιοχρωματισμοί τοιχοποιίας</a> προσφέρουν ομοιομορφία και αντοχή στον χρόνο.</p>
-                </div>
-                <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
-              </div>
+          <article class="service-card reveal" id="service-masonry">
+            <button class="service-header ripple" type="button" aria-expanded="false">
+              <span class="service-title">Χτισίματα – σοβατίσματα – ελαιοχρωματισμοί τοιχοποιίας</span>
+              <svg class="arrow" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true">
+                <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2"/>
+              </svg>
+            </button>
+            <div class="service-content">
+              <p>Εφαρμόζουμε επιμελημένα χτισίματα και σοβατίσματα, ενώ οι <a href="#service-masonry" class="service__internal">ελαιοχρωματισμοί τοιχοποιίας</a> προσφέρουν ομοιομορφία και αντοχή στον χρόνο.</p>
+              <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
             </div>
           </article>
-          <article class="card service" id="service-plumbing" data-cat="installations" data-search="υδραυλικά εγκαταστάσεις δίκτυα νερό συντήρηση hydraulika plumbing pipes water">
-            <h3 class="service__heading">
-              <button class="service__toggle" type="button" aria-expanded="false" aria-controls="service-plumbing-panel" aria-labelledby="service-plumbing-label">
-                <span class="service__title" id="service-plumbing-label">Υδραυλικές εργασίες</span>
-                <span class="service__chevron" aria-hidden="true"></span>
-              </button>
-            </h3>
-            <div class="service__panel" id="service-plumbing-panel" role="region" aria-labelledby="service-plumbing-label">
-              <div class="service__panel-inner">
-                <div class="service__content">
-                  <p>Οι τεχνικοί μας για <a href="#service-plumbing" class="service__internal">υδραυλικές εργασίες</a> εγκαθιστούν δίκτυα με ανθεκτικά υλικά, ελέγχουν διαρροές και εξασφαλίζουν σταθερή παροχή νερού.</p>
-                </div>
-                <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
-              </div>
+          <article class="service-card reveal" id="service-plumbing">
+            <button class="service-header ripple" type="button" aria-expanded="false">
+              <span class="service-title">Υδραυλικές εργασίες</span>
+              <svg class="arrow" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true">
+                <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2"/>
+              </svg>
+            </button>
+            <div class="service-content">
+              <p>Οι τεχνικοί μας για <a href="#service-plumbing" class="service__internal">υδραυλικές εργασίες</a> εγκαθιστούν δίκτυα με ανθεκτικά υλικά, ελέγχουν διαρροές και εξασφαλίζουν σταθερή παροχή νερού.</p>
+              <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
             </div>
           </article>
-          <article class="card service" id="service-electrical" data-cat="installations" data-search="ηλεκτρολογικά υδε πίνακας εγκαταστάσεις ρεύμα ilektrologika electrical ude power">
-            <h3 class="service__heading">
-              <button class="service__toggle" type="button" aria-expanded="false" aria-controls="service-electrical-panel" aria-labelledby="service-electrical-label">
-                <span class="service__title" id="service-electrical-label">Ηλεκτρολογικές εργασίες – Έκδοση Υ.Δ.Ε.</span>
-                <span class="service__chevron" aria-hidden="true"></span>
-              </button>
-            </h3>
-            <div class="service__panel" id="service-electrical-panel" role="region" aria-labelledby="service-electrical-label">
-              <div class="service__panel-inner">
-                <div class="service__content">
-                  <p>Σχεδιάζουμε <a href="#service-electrical" class="service__internal">ηλεκτρολογικές εργασίες</a> με μελέτες φορτίων, αναβαθμισμένους πίνακες και υπεύθυνη έκδοση Υ.Δ.Ε. για έργα στην Αθήνα.</p>
-                </div>
-                <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
-              </div>
+          <article class="service-card reveal" id="service-electrical">
+            <button class="service-header ripple" type="button" aria-expanded="false">
+              <span class="service-title">Ηλεκτρολογικές εργασίες – Έκδοση Υ.Δ.Ε.</span>
+              <svg class="arrow" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true">
+                <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2"/>
+              </svg>
+            </button>
+            <div class="service-content">
+              <p>Σχεδιάζουμε <a href="#service-electrical" class="service__internal">ηλεκτρολογικές εργασίες</a> με μελέτες φορτίων, αναβαθμισμένους πίνακες και υπεύθυνη έκδοση Υ.Δ.Ε. για έργα στην Αθήνα.</p>
+              <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
             </div>
           </article>
-          <article class="card service" id="service-frames" data-cat="openings" data-search="κουφώματα αλουμίνιο pvc ενεργειακά παράθυρα πόρτες koufomata frames aluminum windows doors">
-            <h3 class="service__heading">
-              <button class="service__toggle" type="button" aria-expanded="false" aria-controls="service-frames-panel" aria-labelledby="service-frames-label">
-                <span class="service__title" id="service-frames-label">Κουφώματα αλουμινίου – PVC</span>
-                <span class="service__chevron" aria-hidden="true"></span>
-              </button>
-            </h3>
-            <div class="service__panel" id="service-frames-panel" role="region" aria-labelledby="service-frames-label">
-              <div class="service__panel-inner">
-                <div class="service__content">
-                  <p>Τοποθετούμε <a href="#service-frames" class="service__internal">κουφώματα αλουμινίου και PVC</a> με θερμοδιακοπή και ασφαλή στεγανότητα για άνεση και αισθητική σε κάθε χώρο.</p>
-                </div>
-                <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
-              </div>
+          <article class="service-card reveal" id="service-frames">
+            <button class="service-header ripple" type="button" aria-expanded="false">
+              <span class="service-title">Κουφώματα αλουμινίου – PVC</span>
+              <svg class="arrow" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true">
+                <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2"/>
+              </svg>
+            </button>
+            <div class="service-content">
+              <p>Τοποθετούμε <a href="#service-frames" class="service__internal">κουφώματα αλουμινίου και PVC</a> με θερμοδιακοπή και ασφαλή στεγανότητα για άνεση και αισθητική σε κάθε χώρο.</p>
+              <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
             </div>
           </article>
-          <article class="card service" id="service-tiles" data-cat="surfaces" data-search="πλακίδια τοποθέτηση δάπεδο επένδυση μπάνιο κουζίνα plakidia tiles tiling floor wall">
-            <h3 class="service__heading">
-              <button class="service__toggle" type="button" aria-expanded="false" aria-controls="service-tiles-panel" aria-labelledby="service-tiles-label">
-                <span class="service__title" id="service-tiles-label">Τοποθέτηση πλακιδίων τοίχου – δαπέδου</span>
-                <span class="service__chevron" aria-hidden="true"></span>
-              </button>
-            </h3>
-            <div class="service__panel" id="service-tiles-panel" role="region" aria-labelledby="service-tiles-label">
-              <div class="service__panel-inner">
-                <div class="service__content">
-                  <p>Αναλαμβάνουμε <a href="#service-tiles" class="service__internal">τοποθέτηση πλακιδίων</a> με ευθυγράμμιση ακριβείας, προσεγμένο αρμολόγημα και ανθεκτικά υλικά για χώρους που ξεχωρίζουν.</p>
-                </div>
-                <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
-              </div>
+          <article class="service-card reveal" id="service-tiles">
+            <button class="service-header ripple" type="button" aria-expanded="false">
+              <span class="service-title">Τοποθέτηση πλακιδίων τοίχου – δαπέδου</span>
+              <svg class="arrow" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true">
+                <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2"/>
+              </svg>
+            </button>
+            <div class="service-content">
+              <p>Αναλαμβάνουμε <a href="#service-tiles" class="service__internal">τοποθέτηση πλακιδίων</a> με προσοχή στη λεπτομέρεια, ακριβείς κοπές και αρμολόγηση που αντέχει στον χρόνο.</p>
+              <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
             </div>
           </article>
-          <article class="card service" id="service-flooring" data-cat="surfaces" data-search="laminate πάτωμα ξύλινα πατώματα αποκατάσταση flooring floors wood refinishing">
-            <h3 class="service__heading">
-              <button class="service__toggle" type="button" aria-expanded="false" aria-controls="service-flooring-panel" aria-labelledby="service-flooring-label">
-                <span class="service__title" id="service-flooring-label">Τοποθέτηση πατωμάτων laminate – αποκατάσταση ξύλινων πατωμάτων</span>
-                <span class="service__chevron" aria-hidden="true"></span>
-              </button>
-            </h3>
-            <div class="service__panel" id="service-flooring-panel" role="region" aria-labelledby="service-flooring-label">
-              <div class="service__panel-inner">
-                <div class="service__content">
-                  <p>Εξειδικευόμαστε σε <a href="#service-flooring" class="service__internal">τοποθέτηση πατωμάτων laminate</a> και αναζωογόνηση ξύλινων επιφανειών με ελεγχόμενες λειάνσεις και ανθεκτικές επιστρώσεις.</p>
-                </div>
-                <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
-              </div>
+          <article class="service-card reveal" id="service-flooring">
+            <button class="service-header ripple" type="button" aria-expanded="false">
+              <span class="service-title">Τοποθέτηση πατωμάτων laminate – αποκατάσταση ξύλινων πατωμάτων</span>
+              <svg class="arrow" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true">
+                <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2"/>
+              </svg>
+            </button>
+            <div class="service-content">
+              <p>Προσφέρουμε <a href="#service-flooring" class="service__internal">τοποθέτηση laminate</a> και αποκατάσταση ξύλινων δαπέδων με ειδικούς τεχνίτες για ανθεκτικότητα και αισθητική.</p>
+              <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
             </div>
           </article>
-          <article class="card service" id="service-mosaic" data-cat="surfaces" data-search="μωσαϊκό τρίψιμο γυάλισμα επιφάνειες mosaiko terrazzo polishing grinding">
-            <h3 class="service__heading">
-              <button class="service__toggle" type="button" aria-expanded="false" aria-controls="service-mosaic-panel" aria-labelledby="service-mosaic-label">
-                <span class="service__title" id="service-mosaic-label">Τρίψιμο – γυάλισμα μωσαϊκών δαπέδων</span>
-                <span class="service__chevron" aria-hidden="true"></span>
-              </button>
-            </h3>
-            <div class="service__panel" id="service-mosaic-panel" role="region" aria-labelledby="service-mosaic-label">
-              <div class="service__panel-inner">
-                <div class="service__content">
-                  <p>Το συνεργείο μωσαϊκών προσφέρει <a href="#service-mosaic" class="service__internal">τρίψιμο και γυάλισμα</a> με σταδιακό φινίρισμα, επαναφέροντας λάμψη και ομοιομορφία σε κάθε χώρο.</p>
-                </div>
-                <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
-              </div>
+          <article class="service-card reveal" id="service-mosaic">
+            <button class="service-header ripple" type="button" aria-expanded="false">
+              <span class="service-title">Τρίψιμο – γυάλισμα μωσαϊκών δαπέδων</span>
+              <svg class="arrow" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true">
+                <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2"/>
+              </svg>
+            </button>
+            <div class="service-content">
+              <p>Εξειδικευόμαστε σε <a href="#service-mosaic" class="service__internal">τρίψιμο και γυάλισμα μωσαϊκών</a> δαπέδων με εξοπλισμό τελευταίας τεχνολογίας για ομοιόμορφη επιφάνεια.</p>
+              <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
             </div>
           </article>
-          <article class="card service" id="service-kitchen-cabinets" data-cat="carpentry" data-search="ντουλάπια κουζίνας ξυλουργός κατασκευή custom kitchen cabinets joinery cabinetry">
-            <h3 class="service__heading">
-              <button class="service__toggle" type="button" aria-expanded="false" aria-controls="service-kitchen-cabinets-panel" aria-labelledby="service-kitchen-cabinets-label">
-                <span class="service__title" id="service-kitchen-cabinets-label">Κατασκευή – τοποθέτηση ντουλαπιών κουζίνας</span>
-                <span class="service__chevron" aria-hidden="true"></span>
-              </button>
-            </h3>
-            <div class="service__panel" id="service-kitchen-cabinets-panel" role="region" aria-labelledby="service-kitchen-cabinets-label">
-              <div class="service__panel-inner">
-                <div class="service__content">
-                  <p>Σχεδιάζουμε <a href="#service-kitchen-cabinets" class="service__internal">ντουλάπια κουζίνας</a> στα μέτρα σας, με μηχανισμούς soft-close, εργονομικές ζώνες αποθήκευσης και φινίρισμα υψηλής αντοχής.</p>
-                </div>
-                <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
-              </div>
+          <article class="service-card reveal" id="service-kitchen-cabinets">
+            <button class="service-header ripple" type="button" aria-expanded="false">
+              <span class="service-title">Κατασκευή – τοποθέτηση ντουλαπιών κουζίνας</span>
+              <svg class="arrow" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true">
+                <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2"/>
+              </svg>
+            </button>
+            <div class="service-content">
+              <p>Δημιουργούμε <a href="#service-kitchen-cabinets" class="service__internal">εξατομικευμένα ντουλάπια κουζίνας</a> με εργονομικό σχεδιασμό, ανθεκτικά υλικά και άψογο φινίρισμα.</p>
+              <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
             </div>
           </article>
-          <article class="card service" id="service-wardrobes" data-cat="carpentry" data-search="ντουλάπες ξυλουργικά συρόμενες ντουλάπες αποθήκευση wardrobes closets storage joinery">
-            <h3 class="service__heading">
-              <button class="service__toggle" type="button" aria-expanded="false" aria-controls="service-wardrobes-panel" aria-labelledby="service-wardrobes-label">
-                <span class="service__title" id="service-wardrobes-label">Κατασκευή – τοποθέτηση ντουλαπών</span>
-                <span class="service__chevron" aria-hidden="true"></span>
-              </button>
-            </h3>
-            <div class="service__panel" id="service-wardrobes-panel" role="region" aria-labelledby="service-wardrobes-label">
-              <div class="service__panel-inner">
-                <div class="service__content">
-                  <p>Κατασκευάζουμε <a href="#service-wardrobes" class="service__internal">ντουλάπες υπνοδωματίου</a> με λειτουργική εσωτερική διαρρύθμιση, ανθεκτικούς μηχανισμούς και αισθητικές επιλογές για κάθε χώρο.</p>
-                </div>
-                <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
-              </div>
+          <article class="service-card reveal" id="service-wardrobes">
+            <button class="service-header ripple" type="button" aria-expanded="false">
+              <span class="service-title">Κατασκευή – τοποθέτηση ντουλαπών</span>
+              <svg class="arrow" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true">
+                <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2"/>
+              </svg>
+            </button>
+            <div class="service-content">
+              <p>Σχεδιάζουμε <a href="#service-wardrobes" class="service__internal">ντουλάπες</a> με εργονομικούς μηχανισμούς, εσωτερικές διαμορφώσεις και αισθητικές επιλογές που ταιριάζουν στον χώρο σας.</p>
+              <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
             </div>
           </article>
-          <article class="card service" id="service-doors" data-cat="openings" data-search="πόρτες ασφαλείας εσωτερικές θυρόφυλλα κουφώματα doors security interior entries">
-            <h3 class="service__heading">
-              <button class="service__toggle" type="button" aria-expanded="false" aria-controls="service-doors-panel" aria-labelledby="service-doors-label">
-                <span class="service__title" id="service-doors-label">Πόρτες εισόδου (ασφαλείας) – εσωτερικές πόρτες</span>
-                <span class="service__chevron" aria-hidden="true"></span>
-              </button>
-            </h3>
-            <div class="service__panel" id="service-doors-panel" role="region" aria-labelledby="service-doors-label">
-              <div class="service__panel-inner">
-                <div class="service__content">
-                  <p>Παρέχουμε <a href="#service-doors" class="service__internal">πόρτες ασφαλείας και εσωτερικές πόρτες</a> με πιστοποιήσεις, ηχομονωτικές λύσεις και ακριβή τοποθέτηση για μέγιστη λειτουργικότητα.</p>
-                </div>
-                <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
-              </div>
+          <article class="service-card reveal" id="service-doors">
+            <button class="service-header ripple" type="button" aria-expanded="false">
+              <span class="service-title">Πόρτες εισόδου (ασφαλείας) – εσωτερικές πόρτες</span>
+              <svg class="arrow" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true">
+                <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2"/>
+              </svg>
+            </button>
+            <div class="service-content">
+              <p>Παρέχουμε <a href="#service-doors" class="service__internal">πόρτες ασφαλείας και εσωτερικές πόρτες</a> με πιστοποιήσεις, ηχομονωτικές λύσεις και ακριβή τοποθέτηση για μέγιστη λειτουργικότητα.</p>
+              <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
             </div>
           </article>
-          <article class="card service" id="service-metal" data-cat="basics" data-search="μεταλλικές κατασκευές κιγκλιδώματα στέγες στατικά metal constructions steel structures">
-            <h3 class="service__heading">
-              <button class="service__toggle" type="button" aria-expanded="false" aria-controls="service-metal-panel" aria-labelledby="service-metal-label">
-                <span class="service__title" id="service-metal-label">Μεταλλικές κατασκευές</span>
-                <span class="service__chevron" aria-hidden="true"></span>
-              </button>
-            </h3>
-            <div class="service__panel" id="service-metal-panel" role="region" aria-labelledby="service-metal-label">
-              <div class="service__panel-inner">
-                <div class="service__content">
-                  <p>Μελετάμε <a href="#service-metal" class="service__internal">μεταλλικές κατασκευές</a> μικρής και μεγάλης κλίμακας, εξασφαλίζοντας στατική επάρκεια, προστασία από διάβρωση και άψογη εφαρμογή.</p>
-                </div>
-                <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
-              </div>
+          <article class="service-card reveal" id="service-metal">
+            <button class="service-header ripple" type="button" aria-expanded="false">
+              <span class="service-title">Μεταλλικές κατασκευές</span>
+              <svg class="arrow" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true">
+                <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2"/>
+              </svg>
+            </button>
+            <div class="service-content">
+              <p>Μελετάμε <a href="#service-metal" class="service__internal">μεταλλικές κατασκευές</a> μικρής και μεγάλης κλίμακας, εξασφαλίζοντας στατική επάρκεια, προστασία από διάβρωση και άψογη εφαρμογή.</p>
+              <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
             </div>
           </article>
-          <article class="card service" id="service-insulation" data-cat="permits" data-search="μονώσεις θερμομόνωση υγρομόνωση ταράτσα όψεις monoseis insulation waterproofing facade">
-            <h3 class="service__heading">
-              <button class="service__toggle" type="button" aria-expanded="false" aria-controls="service-insulation-panel" aria-labelledby="service-insulation-label">
-                <span class="service__title" id="service-insulation-label">Μονώσεις παντός τύπου</span>
-                <span class="service__chevron" aria-hidden="true"></span>
-              </button>
-            </h3>
-            <div class="service__panel" id="service-insulation-panel" role="region" aria-labelledby="service-insulation-label">
-              <div class="service__panel-inner">
-                <div class="service__content">
-                  <p>Προτείνουμε <a href="#service-insulation" class="service__internal">μονώσεις παντός τύπου</a> με θερμοπρόσοψη, υγρομόνωση και λύσεις εξοικονόμησης που βελτιώνουν την ενεργειακή απόδοση στην Αττική.</p>
-                </div>
-                <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
-              </div>
+          <article class="service-card reveal" id="service-insulation">
+            <button class="service-header ripple" type="button" aria-expanded="false">
+              <span class="service-title">Μονώσεις παντός τύπου</span>
+              <svg class="arrow" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true">
+                <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2"/>
+              </svg>
+            </button>
+            <div class="service-content">
+              <p>Προτείνουμε <a href="#service-insulation" class="service__internal">μονώσεις παντός τύπου</a> με θερμοπρόσοψη, υγρομόνωση και λύσεις εξοικονόμησης που βελτιώνουν την ενεργειακή απόδοση στην Αττική.</p>
+              <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
             </div>
           </article>
-          <article class="card service" id="service-permits" data-cat="permits" data-search="οικοδομικές άδειες μελέτη πολεοδομία adeies permits building licensing">
-            <h3 class="service__heading">
-              <button class="service__toggle" type="button" aria-expanded="false" aria-controls="service-permits-panel" aria-labelledby="service-permits-label">
-                <span class="service__title" id="service-permits-label">Έκδοση οικοδομικών αδειών</span>
-                <span class="service__chevron" aria-hidden="true"></span>
-              </button>
-            </h3>
-            <div class="service__panel" id="service-permits-panel" role="region" aria-labelledby="service-permits-label">
-              <div class="service__panel-inner">
-                <div class="service__content">
-                  <p>Αναλαμβάνουμε <a href="#service-permits" class="service__internal">έκδοση οικοδομικών αδειών</a> με πλήρη φάκελο μελετών, συντονισμό με υπηρεσίες και συνεχή ενημέρωση για κάθε στάδιο.</p>
-                </div>
-                <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
-              </div>
+          <article class="service-card reveal" id="service-permits">
+            <button class="service-header ripple" type="button" aria-expanded="false">
+              <span class="service-title">Έκδοση οικοδομικών αδειών</span>
+              <svg class="arrow" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true">
+                <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2"/>
+              </svg>
+            </button>
+            <div class="service-content">
+              <p>Αναλαμβάνουμε <a href="#service-permits" class="service__internal">έκδοση οικοδομικών αδειών</a> με πλήρη φάκελο μελετών, συντονισμό με υπηρεσίες και συνεχή ενημέρωση για κάθε στάδιο.</p>
+              <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
             </div>
           </article>
-          <article class="card service" id="service-facade" data-cat="permits" data-search="προσόψεις στηθαία ανακαίνιση όψης αποκατάσταση facade restoration balconies prosopseis">
-            <h3 class="service__heading">
-              <button class="service__toggle" type="button" aria-expanded="false" aria-controls="service-facade-panel" aria-labelledby="service-facade-label">
-                <span class="service__title" id="service-facade-label">Αποκατάσταση προσόψεων (στηθαία) σε πολυκατοικίες με χρήση σκαλωσιάς</span>
-                <span class="service__chevron" aria-hidden="true"></span>
-              </button>
-            </h3>
-            <div class="service__panel" id="service-facade-panel" role="region" aria-labelledby="service-facade-label">
-              <div class="service__panel-inner">
-                <div class="service__content">
-                  <p>Οργανώνουμε <a href="#service-facade" class="service__internal">αποκατάσταση προσόψεων</a> με ασφαλή σκαλωσιά, αποκαθιστούμε στηθαία και εφαρμόζουμε νέες επιστρώσεις γι πολυκατοικίες στην Αττική.</p>
-                </div>
-                <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
-              </div>
+          <article class="service-card reveal" id="service-facade">
+            <button class="service-header ripple" type="button" aria-expanded="false">
+              <span class="service-title">Αποκατάσταση προσόψεων (στηθαία) σε πολυκατοικίες με χρήση σκαλωσιάς</span>
+              <svg class="arrow" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true">
+                <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2"/>
+              </svg>
+            </button>
+            <div class="service-content">
+              <p>Οργανώνουμε <a href="#service-facade" class="service__internal">αποκατάσταση προσόψεων</a> με ασφαλή σκαλωσιά, αποκαθιστούμε στηθαία και εφαρμόζουμε νέες επιστρώσεις για πολυκατοικίες στην Αττική.</p>
+              <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
             </div>
           </article>
-        </div>
-        <p class="services-empty" data-services-empty hidden>Δεν βρέθηκαν υπηρεσίες για τα κριτήρια αναζήτησης.</p>
-        <div class="services__actions">
-          <button class="btn btn--ghost services__more" type="button" data-services-more>Εμφάνιση περισσότερων</button>
-        </div>
+        </section>
         <div class="under-cta"><a href="#contact" class="btn btn--primary">Θέλω Προσφορά για Υπηρεσία</a></div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- rebuild the services section as mobile-first accordion cards and remove the unused filters/search UI
- add modern styles for the accordion, ripple effect, and scroll reveal animations with responsive layout tweaks
- replace legacy services filtering script with lightweight accordion/scroll reveal logic

## Testing
- no automated tests were run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68f409ebbfb88320a6f330a80045e098