### PR TITLE
Add responsive imagery to service cards

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -147,8 +147,12 @@ body.nav-open{overflow:hidden}
 
 /* Services */
 .services{padding:12px;}
-.service-card{background:#fff;border-radius:16px;box-shadow:0 2px 6px rgba(0,0,0,.06);margin:12px 0;overflow:hidden;transform:translateZ(0);transition:box-shadow .25s ease;}
+.service-card{background:#fff;border-radius:16px;box-shadow:0 2px 6px rgba(0,0,0,.06);margin:12px 0;overflow:hidden;transform:translateZ(0);transition:box-shadow .25s ease;display:flex;flex-direction:column;}
 .service-card.open{box-shadow:0 6px 18px rgba(0,0,0,.10);}
+.service-media{position:relative;overflow:hidden;aspect-ratio:4/3;background:#f3f4f6;}
+.service-media img{width:100%;height:100%;object-fit:cover;transition:transform .35s ease;}
+.service-card:hover .service-media img{transform:scale(1.05);}
+.service-body{display:flex;flex-direction:column;flex:1;}
 .service-header{-webkit-tap-highlight-color:transparent;width:100%;display:flex;align-items:center;justify-content:space-between;background:#F9FAFB;border:0;padding:14px 16px;text-align:left;font-weight:700;font-size:16px;color:#0F172A;position:relative;overflow:hidden;}
 .service-title{white-space:normal;line-height:1.25;}
 .arrow{color:#F59E0B;transition:transform .25s ease;}

--- a/index.html
+++ b/index.html
@@ -240,183 +240,258 @@
         <h2>Υπηρεσίες</h2>
         <section class="services">
           <article class="service-card reveal" id="service-demolition">
-            <button class="service-header ripple" type="button" aria-expanded="false">
-              <span class="service-title">Γκρεμίσματα – αποξηλώσεις – απομάκρυνση παλαιών υλικών με κάδο</span>
-              <svg class="arrow" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true">
-                <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2"/>
-              </svg>
-            </button>
-            <div class="service-content">
-              <p>Οργανώνουμε <a href="#service-demolition" class="service__internal">γκρεμίσματα και αποξηλώσεις</a> με ασφαλιστική κάλυψη, καθαρή απομάκρυνση μπαζών και προστασία κοινόχρηστων χώρων σε όλη την Αττική.</p>
-              <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
+            <figure class="service-media">
+              <img src="https://images.unsplash.com/photo-1523419409543-0c1df022bdd2?q=80&amp;w=900&amp;auto=format&amp;fit=crop" width="900" height="675" loading="lazy" alt="Εργατικό συνεργείο πραγματοποιεί γκρεμίσματα και αποξηλώσεις σε ανακαίνιση διαμερίσματος."/>
+            </figure>
+            <div class="service-body">
+              <button class="service-header ripple" type="button" aria-expanded="false">
+                <span class="service-title">Γκρεμίσματα – αποξηλώσεις – απομάκρυνση παλαιών υλικών με κάδο</span>
+                <svg class="arrow" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true">
+                  <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2"/>
+                </svg>
+              </button>
+              <div class="service-content">
+                <p>Οργανώνουμε <a href="#service-demolition" class="service__internal">γκρεμίσματα και αποξηλώσεις</a> με ασφαλιστική κάλυψη, καθαρή απομάκρυνση μπαζών και προστασία κοινόχρηστων χώρων σε όλη την Αττική.</p>
+                <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
+              </div>
             </div>
           </article>
           <article class="service-card reveal" id="service-masonry">
-            <button class="service-header ripple" type="button" aria-expanded="false">
-              <span class="service-title">Χτισίματα – σοβατίσματα – ελαιοχρωματισμοί τοιχοποιίας</span>
-              <svg class="arrow" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true">
-                <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2"/>
-              </svg>
-            </button>
-            <div class="service-content">
-              <p>Εφαρμόζουμε επιμελημένα χτισίματα και σοβατίσματα, ενώ οι <a href="#service-masonry" class="service__internal">ελαιοχρωματισμοί τοιχοποιίας</a> προσφέρουν ομοιομορφία και αντοχή στον χρόνο.</p>
-              <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
+            <figure class="service-media">
+              <img src="https://images.unsplash.com/photo-1503389152951-9f343605f61e?q=80&amp;w=900&amp;auto=format&amp;fit=crop" width="900" height="675" loading="lazy" alt="Τεχνίτης πραγματοποιεί ελαιοχρωματισμούς τοιχοποιίας σε σπίτι υπό ανακαίνιση."/>
+            </figure>
+            <div class="service-body">
+              <button class="service-header ripple" type="button" aria-expanded="false">
+                <span class="service-title">Χτισίματα – σοβατίσματα – ελαιοχρωματισμοί τοιχοποιίας</span>
+                <svg class="arrow" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true">
+                  <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2"/>
+                </svg>
+              </button>
+              <div class="service-content">
+                <p>Εφαρμόζουμε επιμελημένα χτισίματα και σοβατίσματα, ενώ οι <a href="#service-masonry" class="service__internal">ελαιοχρωματισμοί τοιχοποιίας</a> προσφέρουν ομοιομορφία και αντοχή στον χρόνο.</p>
+                <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
+              </div>
             </div>
           </article>
           <article class="service-card reveal" id="service-plumbing">
-            <button class="service-header ripple" type="button" aria-expanded="false">
-              <span class="service-title">Υδραυλικές εργασίες</span>
-              <svg class="arrow" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true">
-                <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2"/>
-              </svg>
-            </button>
-            <div class="service-content">
-              <p>Οι τεχνικοί μας για <a href="#service-plumbing" class="service__internal">υδραυλικές εργασίες</a> εγκαθιστούν δίκτυα με ανθεκτικά υλικά, ελέγχουν διαρροές και εξασφαλίζουν σταθερή παροχή νερού.</p>
-              <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
+            <figure class="service-media">
+              <img src="https://images.unsplash.com/photo-1582719478250-c89cae4dc85b?q=80&amp;w=900&amp;auto=format&amp;fit=crop" width="900" height="675" loading="lazy" alt="Σύγχρονη κουζίνα με νέα υδραυλικά δίκτυα και επιφάνειες υψηλής αντοχής."/>
+            </figure>
+            <div class="service-body">
+              <button class="service-header ripple" type="button" aria-expanded="false">
+                <span class="service-title">Υδραυλικές εργασίες</span>
+                <svg class="arrow" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true">
+                  <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2"/>
+                </svg>
+              </button>
+              <div class="service-content">
+                <p>Οι τεχνικοί μας για <a href="#service-plumbing" class="service__internal">υδραυλικές εργασίες</a> εγκαθιστούν δίκτυα με ανθεκτικά υλικά, ελέγχουν διαρροές και εξασφαλίζουν σταθερή παροχή νερού.</p>
+                <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
+              </div>
             </div>
           </article>
           <article class="service-card reveal" id="service-electrical">
-            <button class="service-header ripple" type="button" aria-expanded="false">
-              <span class="service-title">Ηλεκτρολογικές εργασίες – Έκδοση Υ.Δ.Ε.</span>
-              <svg class="arrow" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true">
-                <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2"/>
-              </svg>
-            </button>
-            <div class="service-content">
-              <p>Σχεδιάζουμε <a href="#service-electrical" class="service__internal">ηλεκτρολογικές εργασίες</a> με μελέτες φορτίων, αναβαθμισμένους πίνακες και υπεύθυνη έκδοση Υ.Δ.Ε. για έργα στην Αθήνα.</p>
-              <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
+            <figure class="service-media">
+              <img src="https://images.unsplash.com/photo-1558002038-1055907df827?q=80&amp;w=900&amp;auto=format&amp;fit=crop" width="900" height="675" loading="lazy" alt="Ηλεκτρολόγος εγκαθιστά νέο ηλεκτρολογικό πίνακα σε έργο ανακαίνισης."/>
+            </figure>
+            <div class="service-body">
+              <button class="service-header ripple" type="button" aria-expanded="false">
+                <span class="service-title">Ηλεκτρολογικές εργασίες – Έκδοση Υ.Δ.Ε.</span>
+                <svg class="arrow" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true">
+                  <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2"/>
+                </svg>
+              </button>
+              <div class="service-content">
+                <p>Σχεδιάζουμε <a href="#service-electrical" class="service__internal">ηλεκτρολογικές εργασίες</a> με μελέτες φορτίων, αναβαθμισμένους πίνακες και υπεύθυνη έκδοση Υ.Δ.Ε. για έργα στην Αθήνα.</p>
+                <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
+              </div>
             </div>
           </article>
           <article class="service-card reveal" id="service-frames">
-            <button class="service-header ripple" type="button" aria-expanded="false">
-              <span class="service-title">Κουφώματα αλουμινίου – PVC</span>
-              <svg class="arrow" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true">
-                <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2"/>
-              </svg>
-            </button>
-            <div class="service-content">
-              <p>Τοποθετούμε <a href="#service-frames" class="service__internal">κουφώματα αλουμινίου και PVC</a> με θερμοδιακοπή και ασφαλή στεγανότητα για άνεση και αισθητική σε κάθε χώρο.</p>
-              <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
+            <figure class="service-media">
+              <img src="https://images.unsplash.com/photo-1519710164239-da123dc03ef4?q=80&amp;w=900&amp;auto=format&amp;fit=crop" width="900" height="675" loading="lazy" alt="Τοποθέτηση νέων ενεργειακών κουφωμάτων σε φωτεινό σαλόνι."/>
+            </figure>
+            <div class="service-body">
+              <button class="service-header ripple" type="button" aria-expanded="false">
+                <span class="service-title">Κουφώματα αλουμινίου – PVC</span>
+                <svg class="arrow" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true">
+                  <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2"/>
+                </svg>
+              </button>
+              <div class="service-content">
+                <p>Τοποθετούμε <a href="#service-frames" class="service__internal">κουφώματα αλουμινίου και PVC</a> με θερμοδιακοπή και ασφαλή στεγανότητα για άνεση και αισθητική σε κάθε χώρο.</p>
+                <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
+              </div>
             </div>
           </article>
           <article class="service-card reveal" id="service-tiles">
-            <button class="service-header ripple" type="button" aria-expanded="false">
-              <span class="service-title">Τοποθέτηση πλακιδίων τοίχου – δαπέδου</span>
-              <svg class="arrow" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true">
-                <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2"/>
-              </svg>
-            </button>
-            <div class="service-content">
-              <p>Αναλαμβάνουμε <a href="#service-tiles" class="service__internal">τοποθέτηση πλακιδίων</a> με προσοχή στη λεπτομέρεια, ακριβείς κοπές και αρμολόγηση που αντέχει στον χρόνο.</p>
-              <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
+            <figure class="service-media">
+              <img src="https://images.unsplash.com/photo-1585776245991-cf89dd7fc73a?q=80&amp;w=900&amp;auto=format&amp;fit=crop" width="900" height="675" loading="lazy" alt="Επαγγελματίας τοποθετεί πλακίδια σε δάπεδο με ακρίβεια."/>
+            </figure>
+            <div class="service-body">
+              <button class="service-header ripple" type="button" aria-expanded="false">
+                <span class="service-title">Τοποθέτηση πλακιδίων τοίχου – δαπέδου</span>
+                <svg class="arrow" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true">
+                  <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2"/>
+                </svg>
+              </button>
+              <div class="service-content">
+                <p>Αναλαμβάνουμε <a href="#service-tiles" class="service__internal">τοποθέτηση πλακιδίων</a> με προσοχή στη λεπτομέρεια, ακριβείς κοπές και αρμολόγηση που αντέχει στον χρόνο.</p>
+                <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
+              </div>
             </div>
           </article>
           <article class="service-card reveal" id="service-flooring">
-            <button class="service-header ripple" type="button" aria-expanded="false">
-              <span class="service-title">Τοποθέτηση πατωμάτων laminate – αποκατάσταση ξύλινων πατωμάτων</span>
-              <svg class="arrow" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true">
-                <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2"/>
-              </svg>
-            </button>
-            <div class="service-content">
-              <p>Προσφέρουμε <a href="#service-flooring" class="service__internal">τοποθέτηση laminate</a> και αποκατάσταση ξύλινων δαπέδων με ειδικούς τεχνίτες για ανθεκτικότητα και αισθητική.</p>
-              <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
+            <figure class="service-media">
+              <img src="https://images.unsplash.com/photo-1505691938895-1758d7feb511?q=80&amp;w=900&amp;auto=format&amp;fit=crop" width="900" height="675" loading="lazy" alt="Ανακαινισμένο καθιστικό με ξύλινο δάπεδο σε άριστη κατάσταση."/>
+            </figure>
+            <div class="service-body">
+              <button class="service-header ripple" type="button" aria-expanded="false">
+                <span class="service-title">Τοποθέτηση πατωμάτων laminate – αποκατάσταση ξύλινων πατωμάτων</span>
+                <svg class="arrow" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true">
+                  <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2"/>
+                </svg>
+              </button>
+              <div class="service-content">
+                <p>Προσφέρουμε <a href="#service-flooring" class="service__internal">τοποθέτηση laminate</a> και αποκατάσταση ξύλινων δαπέδων με ειδικούς τεχνίτες για ανθεκτικότητα και αισθητική.</p>
+                <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
+              </div>
             </div>
           </article>
           <article class="service-card reveal" id="service-mosaic">
-            <button class="service-header ripple" type="button" aria-expanded="false">
-              <span class="service-title">Τρίψιμο – γυάλισμα μωσαϊκών δαπέδων</span>
-              <svg class="arrow" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true">
-                <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2"/>
-              </svg>
-            </button>
-            <div class="service-content">
-              <p>Εξειδικευόμαστε σε <a href="#service-mosaic" class="service__internal">τρίψιμο και γυάλισμα μωσαϊκών</a> δαπέδων με εξοπλισμό τελευταίας τεχνολογίας για ομοιόμορφη επιφάνεια.</p>
-              <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
+            <figure class="service-media">
+              <img src="https://images.unsplash.com/photo-1484154218962-a197022b5858?q=80&amp;w=900&amp;auto=format&amp;fit=crop" width="900" height="675" loading="lazy" alt="Πολυτελές μπάνιο με δάπεδο μωσαϊκού μετά από γυάλισμα."/>
+            </figure>
+            <div class="service-body">
+              <button class="service-header ripple" type="button" aria-expanded="false">
+                <span class="service-title">Τρίψιμο – γυάλισμα μωσαϊκών δαπέδων</span>
+                <svg class="arrow" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true">
+                  <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2"/>
+                </svg>
+              </button>
+              <div class="service-content">
+                <p>Εξειδικευόμαστε σε <a href="#service-mosaic" class="service__internal">τρίψιμο και γυάλισμα μωσαϊκών</a> δαπέδων με εξοπλισμό τελευταίας τεχνολογίας για ομοιόμορφη επιφάνεια.</p>
+                <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
+              </div>
             </div>
           </article>
           <article class="service-card reveal" id="service-kitchen-cabinets">
-            <button class="service-header ripple" type="button" aria-expanded="false">
-              <span class="service-title">Κατασκευή – τοποθέτηση ντουλαπιών κουζίνας</span>
-              <svg class="arrow" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true">
-                <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2"/>
-              </svg>
-            </button>
-            <div class="service-content">
-              <p>Δημιουργούμε <a href="#service-kitchen-cabinets" class="service__internal">εξατομικευμένα ντουλάπια κουζίνας</a> με εργονομικό σχεδιασμό, ανθεκτικά υλικά και άψογο φινίρισμα.</p>
-              <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
+            <figure class="service-media">
+              <img src="https://images.unsplash.com/photo-1501045661006-fcebe0257c3f?q=80&amp;w=900&amp;auto=format&amp;fit=crop" width="900" height="675" loading="lazy" alt="Σύγχρονη κουζίνα με ντουλάπια ειδικής κατασκευής από την FM Renovation."/>
+            </figure>
+            <div class="service-body">
+              <button class="service-header ripple" type="button" aria-expanded="false">
+                <span class="service-title">Κατασκευή – τοποθέτηση ντουλαπιών κουζίνας</span>
+                <svg class="arrow" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true">
+                  <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2"/>
+                </svg>
+              </button>
+              <div class="service-content">
+                <p>Δημιουργούμε <a href="#service-kitchen-cabinets" class="service__internal">εξατομικευμένα ντουλάπια κουζίνας</a> με εργονομικό σχεδιασμό, ανθεκτικά υλικά και άψογο φινίρισμα.</p>
+                <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
+              </div>
             </div>
           </article>
           <article class="service-card reveal" id="service-wardrobes">
-            <button class="service-header ripple" type="button" aria-expanded="false">
-              <span class="service-title">Κατασκευή – τοποθέτηση ντουλαπών</span>
-              <svg class="arrow" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true">
-                <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2"/>
-              </svg>
-            </button>
-            <div class="service-content">
-              <p>Σχεδιάζουμε <a href="#service-wardrobes" class="service__internal">ντουλάπες</a> με εργονομικούς μηχανισμούς, εσωτερικές διαμορφώσεις και αισθητικές επιλογές που ταιριάζουν στον χώρο σας.</p>
-              <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
+            <figure class="service-media">
+              <img src="https://images.unsplash.com/photo-1494526585095-c41746248156?q=80&amp;w=900&amp;auto=format&amp;fit=crop" width="900" height="675" loading="lazy" alt="Ευρύχωρο υπνοδωμάτιο με ντουλάπες κατά παραγγελία."/>
+            </figure>
+            <div class="service-body">
+              <button class="service-header ripple" type="button" aria-expanded="false">
+                <span class="service-title">Κατασκευή – τοποθέτηση ντουλαπών</span>
+                <svg class="arrow" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true">
+                  <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2"/>
+                </svg>
+              </button>
+              <div class="service-content">
+                <p>Σχεδιάζουμε <a href="#service-wardrobes" class="service__internal">ντουλάπες</a> με εργονομικούς μηχανισμούς, εσωτερικές διαμορφώσεις και αισθητικές επιλογές που ταιριάζουν στον χώρο σας.</p>
+                <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
+              </div>
             </div>
           </article>
           <article class="service-card reveal" id="service-doors">
-            <button class="service-header ripple" type="button" aria-expanded="false">
-              <span class="service-title">Πόρτες εισόδου (ασφαλείας) – εσωτερικές πόρτες</span>
-              <svg class="arrow" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true">
-                <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2"/>
-              </svg>
-            </button>
-            <div class="service-content">
-              <p>Παρέχουμε <a href="#service-doors" class="service__internal">πόρτες ασφαλείας και εσωτερικές πόρτες</a> με πιστοποιήσεις, ηχομονωτικές λύσεις και ακριβή τοποθέτηση για μέγιστη λειτουργικότητα.</p>
-              <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
+            <figure class="service-media">
+              <img src="https://images.unsplash.com/photo-1501183638710-841dd1904471?q=80&amp;w=900&amp;auto=format&amp;fit=crop" width="900" height="675" loading="lazy" alt="Νέα πόρτα εισόδου ασφαλείας σε κατοικία της Αττικής."/>
+            </figure>
+            <div class="service-body">
+              <button class="service-header ripple" type="button" aria-expanded="false">
+                <span class="service-title">Πόρτες εισόδου (ασφαλείας) – εσωτερικές πόρτες</span>
+                <svg class="arrow" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true">
+                  <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2"/>
+                </svg>
+              </button>
+              <div class="service-content">
+                <p>Παρέχουμε <a href="#service-doors" class="service__internal">πόρτες ασφαλείας και εσωτερικές πόρτες</a> με πιστοποιήσεις, ηχομονωτικές λύσεις και ακριβή τοποθέτηση για μέγιστη λειτουργικότητα.</p>
+                <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
+              </div>
             </div>
           </article>
           <article class="service-card reveal" id="service-metal">
-            <button class="service-header ripple" type="button" aria-expanded="false">
-              <span class="service-title">Μεταλλικές κατασκευές</span>
-              <svg class="arrow" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true">
-                <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2"/>
-              </svg>
-            </button>
-            <div class="service-content">
-              <p>Μελετάμε <a href="#service-metal" class="service__internal">μεταλλικές κατασκευές</a> μικρής και μεγάλης κλίμακας, εξασφαλίζοντας στατική επάρκεια, προστασία από διάβρωση και άψογη εφαρμογή.</p>
-              <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
+            <figure class="service-media">
+              <img src="https://images.unsplash.com/photo-1497366216548-37526070297c?q=80&amp;w=900&amp;auto=format&amp;fit=crop" width="900" height="675" loading="lazy" alt="Συνεργείο κατασκευάζει μεταλλικό σκελετό σε εργαστήριο."/>
+            </figure>
+            <div class="service-body">
+              <button class="service-header ripple" type="button" aria-expanded="false">
+                <span class="service-title">Μεταλλικές κατασκευές</span>
+                <svg class="arrow" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true">
+                  <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2"/>
+                </svg>
+              </button>
+              <div class="service-content">
+                <p>Μελετάμε <a href="#service-metal" class="service__internal">μεταλλικές κατασκευές</a> μικρής και μεγάλης κλίμακας, εξασφαλίζοντας στατική επάρκεια, προστασία από διάβρωση και άψογη εφαρμογή.</p>
+                <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
+              </div>
             </div>
           </article>
           <article class="service-card reveal" id="service-insulation">
-            <button class="service-header ripple" type="button" aria-expanded="false">
-              <span class="service-title">Μονώσεις παντός τύπου</span>
-              <svg class="arrow" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true">
-                <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2"/>
-              </svg>
-            </button>
-            <div class="service-content">
-              <p>Προτείνουμε <a href="#service-insulation" class="service__internal">μονώσεις παντός τύπου</a> με θερμοπρόσοψη, υγρομόνωση και λύσεις εξοικονόμησης που βελτιώνουν την ενεργειακή απόδοση στην Αττική.</p>
-              <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
+            <figure class="service-media">
+              <img src="https://images.unsplash.com/photo-1493666438817-866a91353ca9?q=80&amp;w=900&amp;auto=format&amp;fit=crop" width="900" height="675" loading="lazy" alt="Τοποθέτηση μονωτικών υλικών σε στέγη κατοικίας."/>
+            </figure>
+            <div class="service-body">
+              <button class="service-header ripple" type="button" aria-expanded="false">
+                <span class="service-title">Μονώσεις παντός τύπου</span>
+                <svg class="arrow" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true">
+                  <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2"/>
+                </svg>
+              </button>
+              <div class="service-content">
+                <p>Προτείνουμε <a href="#service-insulation" class="service__internal">μονώσεις παντός τύπου</a> με θερμοπρόσοψη, υγρομόνωση και λύσεις εξοικονόμησης που βελτιώνουν την ενεργειακή απόδοση στην Αττική.</p>
+                <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
+              </div>
             </div>
           </article>
           <article class="service-card reveal" id="service-permits">
-            <button class="service-header ripple" type="button" aria-expanded="false">
-              <span class="service-title">Έκδοση οικοδομικών αδειών</span>
-              <svg class="arrow" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true">
-                <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2"/>
-              </svg>
-            </button>
-            <div class="service-content">
-              <p>Αναλαμβάνουμε <a href="#service-permits" class="service__internal">έκδοση οικοδομικών αδειών</a> με πλήρη φάκελο μελετών, συντονισμό με υπηρεσίες και συνεχή ενημέρωση για κάθε στάδιο.</p>
-              <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
+            <figure class="service-media">
+              <img src="https://images.unsplash.com/photo-1522708323590-d24dbb6b0267?q=80&amp;w=900&amp;auto=format&amp;fit=crop" width="900" height="675" loading="lazy" alt="Αρχιτεκτονικά σχέδια και άδειες που ετοιμάζει η ομάδα της FM Renovation."/>
+            </figure>
+            <div class="service-body">
+              <button class="service-header ripple" type="button" aria-expanded="false">
+                <span class="service-title">Έκδοση οικοδομικών αδειών</span>
+                <svg class="arrow" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true">
+                  <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2"/>
+                </svg>
+              </button>
+              <div class="service-content">
+                <p>Αναλαμβάνουμε <a href="#service-permits" class="service__internal">έκδοση οικοδομικών αδειών</a> με πλήρη φάκελο μελετών, συντονισμό με υπηρεσίες και συνεχή ενημέρωση για κάθε στάδιο.</p>
+                <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
+              </div>
             </div>
           </article>
           <article class="service-card reveal" id="service-facade">
-            <button class="service-header ripple" type="button" aria-expanded="false">
-              <span class="service-title">Αποκατάσταση προσόψεων (στηθαία) σε πολυκατοικίες με χρήση σκαλωσιάς</span>
-              <svg class="arrow" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true">
-                <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2"/>
-              </svg>
-            </button>
-            <div class="service-content">
-              <p>Οργανώνουμε <a href="#service-facade" class="service__internal">αποκατάσταση προσόψεων</a> με ασφαλή σκαλωσιά, αποκαθιστούμε στηθαία και εφαρμόζουμε νέες επιστρώσεις για πολυκατοικίες στην Αττική.</p>
-              <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
+            <figure class="service-media">
+              <img src="https://images.unsplash.com/photo-1520607162513-77705c0f0d4a?q=80&amp;w=900&amp;auto=format&amp;fit=crop" width="900" height="675" loading="lazy" alt="Σκαλωσιά σε πολυκατοικία για αποκατάσταση προσόψεων στην Αττική."/>
+            </figure>
+            <div class="service-body">
+              <button class="service-header ripple" type="button" aria-expanded="false">
+                <span class="service-title">Αποκατάσταση προσόψεων (στηθαία) σε πολυκατοικίες με χρήση σκαλωσιάς</span>
+                <svg class="arrow" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true">
+                  <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2"/>
+                </svg>
+              </button>
+              <div class="service-content">
+                <p>Οργανώνουμε <a href="#service-facade" class="service__internal">αποκατάσταση προσόψεων</a> με ασφαλή σκαλωσιά, αποκαθιστούμε στηθαία και εφαρμόζουμε νέες επιστρώσεις για πολυκατοικίες στην Αττική.</p>
+                <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
+              </div>
             </div>
           </article>
         </section>


### PR DESCRIPTION
## Summary
- add dedicated media figures to each service card with curated imagery and descriptive alt text
- update service card layout styles to accommodate the new media and provide a subtle hover interaction

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68f507c7ea888320beaaa88e15d73e0e