### PR TITLE
Update gallery to use local renovation photos

### DIFF
--- a/index.html
+++ b/index.html
@@ -585,11 +585,21 @@
         <div class="carousel" data-carousel>
           <button class="car-btn prev" aria-label="Προηγούμενη">‹</button>
           <div class="car-track" data-track>
-            <img src="https://images.unsplash.com/photo-1493666438817-866a91353ca9?q=80&w=1400&auto=format&fit=crop" width="600" height="600" loading="lazy" alt="Διαμόρφωση σαλονιού – δείγμα έργου FM Renovation στην Αθήνα με ανοιχτή διαρρύθμιση και ζεστές αποχρώσεις για σύγχρονη φιλοξενία.">
-            <img src="https://images.unsplash.com/photo-1501183638710-841dd1904471?q=80&w=1400&auto=format&fit=crop" width="600" height="600" loading="lazy" alt="Ανακαίνιση κουζίνας σε μονοκατοικία – FM Renovation, Αττική, με άνετους πάγκους και φωτισμό που υποστηρίζει την καθημερινή μαγειρική.">
-            <img src="https://images.unsplash.com/photo-1497366216548-37526070297c?q=80&w=1400&auto=format&fit=crop" width="600" height="600" loading="lazy" alt="Ανακαίνιση γραφείου – FM Renovation στην Αθήνα με λειτουργικές θέσεις εργασίας και φωτεινή ατμόσφαιρα για παραγωγικές ομάδες.">
-            <img src="https://images.unsplash.com/photo-1501045661006-fcebe0257c3f?q=80&w=1400&auto=format&fit=crop" width="600" height="600" loading="lazy" alt="Ανακαίνιση μπάνιου σε διαμέρισμα – FM Renovation, Αττική, με καθαρές γραμμές, υλικά υψηλής αντοχής και χαλαρωτικό φωτισμό.">
-            <img src="https://images.unsplash.com/photo-1494526585095-c41746248156?q=80&w=1400&auto=format&fit=crop" width="600" height="600" loading="lazy" alt="Ανακαίνιση υπνοδωματίου – δείγμα έργου FM Renovation στην Αθήνα με γήινες υφές, άνετη κλίνη και φωτισμό που ευνοεί τη χαλάρωση.">
+            <img src="photos/fm1.jpg" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – ανακαίνιση καθιστικού με σύγχρονη διαρρύθμιση.">
+            <img src="photos/fm2.jpg" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – ανανεωμένη κουζίνα με λειτουργική εργονομία.">
+            <img src="photos/fm3.jpg" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – ανακαινισμένο μπάνιο με μοντέρνα αισθητική.">
+            <img src="photos/fm4.jpg" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – φωτεινός ενιαίος χώρος σαλονιού.">
+            <img src="photos/fm5.jpg" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – ανακαινισμένο υπνοδωμάτιο με γήινες αποχρώσεις.">
+            <img src="photos/fm6.jpg" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – λεπτομέρειες κουζίνας με ποιοτικά υλικά.">
+            <img src="photos/fm7.jpg" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – διαμόρφωση καθιστικού με ξύλινες υφές.">
+            <img src="photos/fm8.jpg" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – σύγχρονο μπάνιο με μινιμαλιστική γραμμή.">
+            <img src="photos/fm9.jpg" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – ανανεωμένος χώρος εργασίας με άπλετο φως.">
+            <img src="photos/fm10.jpg" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – καθιστικό με έμφαση στη λεπτομέρεια.">
+            <img src="photos/fm11.jpg" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – χώροι φιλοξενίας με ζεστή ατμόσφαιρα.">
+            <img src="photos/fm12.jpg" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – πλήρης ανακαίνιση κουζίνας.">
+            <img src="photos/fm13.jpg" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – σύγχρονος χώρος διαβίωσης με καθαρές γραμμές.">
+            <img src="photos/fm14.jpg" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – λεπτομέρειες σαλονιού με κομψό φωτισμό.">
+            <img src="photos/fm15.jpg" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – φωτεινός χώρος τραπεζαρίας σε πρόσφατη ανακαίνιση.">
           </div>
           <button class="car-btn next" aria-label="Επόμενη">›</button>
         </div>


### PR DESCRIPTION
## Summary
- replace the gallery carousel images with the locally hosted FM Renovation photos
- update descriptive alt text for each image to reflect the new gallery items

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68f916037b0083208c358a88a0a76b45