### PR TITLE
Add accessible gallery lightbox overlay

### DIFF
--- a/assets/css/lightbox.css
+++ b/assets/css/lightbox.css
@@ -1,0 +1,139 @@
+:root {
+  --lb-bg: rgba(255, 255, 255, 0.92);
+  --lb-fg: #0f172a;
+  --lb-amber: #f59e0b;
+}
+
+.lb {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 9999;
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition: opacity 0.22s ease;
+  outline: none;
+}
+
+.lb.on {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+}
+
+.lb-backdrop {
+  position: absolute;
+  inset: 0;
+  background: var(--lb-bg);
+}
+
+.lb-frame {
+  position: relative;
+  margin: 0;
+  max-width: min(92vw, 1200px);
+  max-height: 90vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+}
+
+.lb-img {
+  max-width: 100%;
+  max-height: 90vh;
+  border-radius: 12px;
+  box-shadow: 0 6px 26px rgba(0, 0, 0, 0.18);
+}
+
+.lb-close {
+  position: absolute;
+  top: -44px;
+  right: 0;
+  width: 40px;
+  height: 40px;
+  border-radius: 999px;
+  border: 0;
+  background: #fff;
+  color: var(--lb-fg);
+  font-size: 24px;
+  cursor: pointer;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+  display: grid;
+  place-items: center;
+  line-height: 1;
+}
+
+.lb-nav {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 44px;
+  height: 44px;
+  border-radius: 999px;
+  border: 0;
+  cursor: pointer;
+  background: #fff;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.18);
+  font-size: 26px;
+  line-height: 1;
+  color: var(--lb-fg);
+  display: grid;
+  place-items: center;
+}
+
+.lb-nav:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
+
+.lb-prev {
+  left: -52px;
+}
+
+.lb-next {
+  right: -52px;
+}
+
+.lb-meta {
+  position: absolute;
+  bottom: -40px;
+  left: 50%;
+  transform: translateX(-50%);
+  font-weight: 700;
+  color: var(--lb-fg);
+  background: #fff;
+  padding: 6px 10px;
+  border-radius: 999px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  min-width: 72px;
+  text-align: center;
+}
+
+@media (max-width: 640px) {
+  .lb-close {
+    top: -52px;
+    right: 0;
+  }
+
+  .lb-prev {
+    left: 8px;
+  }
+
+  .lb-next {
+    right: 8px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .lb {
+    transition: none;
+  }
+}
+
+.car-img[role="button"]:focus-visible {
+  outline: 3px solid var(--lb-amber);
+  outline-offset: 4px;
+}

--- a/assets/js/lightbox.js
+++ b/assets/js/lightbox.js
@@ -1,0 +1,188 @@
+(function () {
+  const lightbox = document.getElementById('lightbox');
+  if (!lightbox) {
+    return;
+  }
+
+  const imageEl = document.getElementById('lb-img');
+  const countEl = document.getElementById('lb-count');
+  const prevBtn = lightbox.querySelector('.lb-prev');
+  const nextBtn = lightbox.querySelector('.lb-next');
+  const dialogFrame = lightbox.querySelector('.lb-frame');
+  const closeTriggers = lightbox.querySelectorAll('[data-lb-close]');
+  const html = document.documentElement;
+
+  if (!imageEl || !countEl || !prevBtn || !nextBtn || !dialogFrame) {
+    return;
+  }
+
+  dialogFrame.setAttribute('tabindex', '-1');
+
+  const thumbnails = Array.from(
+    document.querySelectorAll('.car-img, .gallery img')
+  ).filter((el, index, arr) => el instanceof HTMLImageElement && arr.indexOf(el) === index);
+
+  if (!thumbnails.length) {
+    return;
+  }
+
+  const sources = thumbnails.map((thumb) => ({
+    src: thumb.currentSrc || thumb.src,
+    alt: thumb.alt || ''
+  }));
+
+  let activeIndex = 0;
+  let previousFocus = null;
+  let focusableElements = [];
+  let firstFocusable = null;
+  let lastFocusable = null;
+
+  thumbnails.forEach((thumb, index) => {
+    thumb.style.cursor = 'zoom-in';
+    thumb.setAttribute('data-lb-index', String(index));
+    thumb.setAttribute('role', 'button');
+    thumb.setAttribute('tabindex', '0');
+    thumb.setAttribute('aria-haspopup', 'dialog');
+
+    thumb.addEventListener('click', () => open(index));
+    thumb.addEventListener('keydown', (event) => {
+      if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault();
+        open(index);
+      }
+    });
+  });
+
+  function open(index) {
+    activeIndex = index;
+    previousFocus = document.activeElement;
+    render();
+    lightbox.classList.add('on');
+    lightbox.setAttribute('aria-hidden', 'false');
+    html.style.overflow = 'hidden';
+    updateFocusable();
+    requestAnimationFrame(() => {
+      dialogFrame.focus({ preventScroll: true });
+    });
+  }
+
+  function close() {
+    if (!lightbox.classList.contains('on')) {
+      return;
+    }
+
+    lightbox.classList.remove('on');
+    lightbox.setAttribute('aria-hidden', 'true');
+    html.style.overflow = '';
+
+    if (previousFocus && typeof previousFocus.focus === 'function') {
+      requestAnimationFrame(() => {
+        previousFocus.focus();
+      });
+    }
+  }
+
+  function render() {
+    const currentItem = sources[activeIndex];
+    if (!currentItem) {
+      return;
+    }
+
+    if (imageEl.src !== currentItem.src) {
+      imageEl.src = currentItem.src;
+    }
+    imageEl.alt = currentItem.alt;
+    countEl.textContent = `${activeIndex + 1}/${sources.length}`;
+
+    const isFirst = activeIndex === 0;
+    const isLast = activeIndex === sources.length - 1;
+
+    prevBtn.disabled = isFirst;
+    nextBtn.disabled = isLast;
+
+    prevBtn.setAttribute('aria-disabled', String(isFirst));
+    nextBtn.setAttribute('aria-disabled', String(isLast));
+
+    updateFocusable();
+  }
+
+  function goPrev() {
+    if (activeIndex > 0) {
+      activeIndex -= 1;
+      render();
+    }
+  }
+
+  function goNext() {
+    if (activeIndex < sources.length - 1) {
+      activeIndex += 1;
+      render();
+    }
+  }
+
+  function updateFocusable() {
+    const selector = 'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
+    focusableElements = Array.from(lightbox.querySelectorAll(selector)).filter((el) => !el.hasAttribute('disabled'));
+    firstFocusable = focusableElements[0] || dialogFrame;
+    lastFocusable = focusableElements[focusableElements.length - 1] || dialogFrame;
+  }
+
+  function trapFocus(event) {
+    if (event.key !== 'Tab') {
+      return;
+    }
+
+    if (!lightbox.classList.contains('on')) {
+      return;
+    }
+
+    if (!focusableElements.length) {
+      event.preventDefault();
+      dialogFrame.focus();
+      return;
+    }
+
+    if (event.shiftKey) {
+      if (document.activeElement === firstFocusable) {
+        event.preventDefault();
+        lastFocusable.focus();
+      }
+    } else if (document.activeElement === lastFocusable) {
+      event.preventDefault();
+      firstFocusable.focus();
+    }
+  }
+
+  prevBtn.addEventListener('click', goPrev);
+  nextBtn.addEventListener('click', goNext);
+
+  closeTriggers.forEach((trigger) => {
+    trigger.addEventListener('click', close);
+  });
+
+  document.addEventListener('keydown', (event) => {
+    if (!lightbox.classList.contains('on')) {
+      return;
+    }
+
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      close();
+      return;
+    }
+
+    if (event.key === 'ArrowLeft') {
+      event.preventDefault();
+      goPrev();
+      return;
+    }
+
+    if (event.key === 'ArrowRight') {
+      event.preventDefault();
+      goNext();
+      return;
+    }
+  });
+
+  document.addEventListener('keydown', trapFocus, true);
+})();

--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Roboto:wght@700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="assets/style.css">
+  <link rel="stylesheet" href="assets/css/lightbox.css">
   <link rel="icon" type="image/png" href="favicon/favicon-96x96.png" sizes="96x96">
   <link rel="icon" type="image/svg+xml" href="favicon/favicon.svg">
   <link rel="shortcut icon" href="favicon/favicon.ico">
@@ -508,21 +509,21 @@
         <div class="carousel" data-carousel>
           <button class="car-btn prev" aria-label="Προηγούμενη">‹</button>
           <div class="car-track" data-track>
-            <img src="photos/fm1.jpg" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – ανακαίνιση καθιστικού με σύγχρονη διαρρύθμιση.">
-            <img src="photos/fm2.jpg" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – ανανεωμένη κουζίνα με λειτουργική εργονομία.">
-            <img src="photos/fm3.jpg" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – ανακαινισμένο μπάνιο με μοντέρνα αισθητική.">
-            <img src="photos/fm4.jpg" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – φωτεινός ενιαίος χώρος σαλονιού.">
-            <img src="photos/fm5.jpg" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – ανακαινισμένο υπνοδωμάτιο με γήινες αποχρώσεις.">
-            <img src="photos/fm6.jpg" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – λεπτομέρειες κουζίνας με ποιοτικά υλικά.">
-            <img src="photos/fm7.jpg" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – διαμόρφωση καθιστικού με ξύλινες υφές.">
-            <img src="photos/fm8.jpg" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – σύγχρονο μπάνιο με μινιμαλιστική γραμμή.">
-            <img src="photos/fm9.jpg" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – ανανεωμένος χώρος εργασίας με άπλετο φως.">
-            <img src="photos/fm10.jpg" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – καθιστικό με έμφαση στη λεπτομέρεια.">
-            <img src="photos/fm11.jpg" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – χώροι φιλοξενίας με ζεστή ατμόσφαιρα.">
-            <img src="photos/fm12.jpg" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – πλήρης ανακαίνιση κουζίνας.">
-            <img src="photos/fm13.jpg" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – σύγχρονος χώρος διαβίωσης με καθαρές γραμμές.">
-            <img src="photos/fm14.jpg" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – λεπτομέρειες σαλονιού με κομψό φωτισμό.">
-            <img src="photos/fm15.jpg" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – φωτεινός χώρος τραπεζαρίας σε πρόσφατη ανακαίνιση.">
+            <img class="car-img" src="photos/fm1.jpg" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – ανακαίνιση καθιστικού με σύγχρονη διαρρύθμιση.">
+            <img class="car-img" src="photos/fm2.jpg" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – ανανεωμένη κουζίνα με λειτουργική εργονομία.">
+            <img class="car-img" src="photos/fm3.jpg" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – ανακαινισμένο μπάνιο με μοντέρνα αισθητική.">
+            <img class="car-img" src="photos/fm4.jpg" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – φωτεινός ενιαίος χώρος σαλονιού.">
+            <img class="car-img" src="photos/fm5.jpg" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – ανακαινισμένο υπνοδωμάτιο με γήινες αποχρώσεις.">
+            <img class="car-img" src="photos/fm6.jpg" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – λεπτομέρειες κουζίνας με ποιοτικά υλικά.">
+            <img class="car-img" src="photos/fm7.jpg" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – διαμόρφωση καθιστικού με ξύλινες υφές.">
+            <img class="car-img" src="photos/fm8.jpg" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – σύγχρονο μπάνιο με μινιμαλιστική γραμμή.">
+            <img class="car-img" src="photos/fm9.jpg" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – ανανεωμένος χώρος εργασίας με άπλετο φως.">
+            <img class="car-img" src="photos/fm10.jpg" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – καθιστικό με έμφαση στη λεπτομέρεια.">
+            <img class="car-img" src="photos/fm11.jpg" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – χώροι φιλοξενίας με ζεστή ατμόσφαιρα.">
+            <img class="car-img" src="photos/fm12.jpg" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – πλήρης ανακαίνιση κουζίνας.">
+            <img class="car-img" src="photos/fm13.jpg" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – σύγχρονος χώρος διαβίωσης με καθαρές γραμμές.">
+            <img class="car-img" src="photos/fm14.jpg" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – λεπτομέρειες σαλονιού με κομψό φωτισμό.">
+            <img class="car-img" src="photos/fm15.jpg" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – φωτεινός χώρος τραπεζαρίας σε πρόσφατη ανακαίνιση.">
           </div>
           <button class="car-btn next" aria-label="Επόμενη">›</button>
         </div>
@@ -615,6 +616,23 @@
     </section>
   </main>
 
+  <!-- Lightbox -->
+  <div class="lb" id="lightbox" aria-hidden="true" tabindex="-1">
+    <div class="lb-backdrop" data-lb-close></div>
+
+    <figure class="lb-frame" role="dialog" aria-modal="true" aria-label="Προβολή εικόνας">
+      <button class="lb-close" aria-label="Κλείσιμο" data-lb-close>×</button>
+
+      <button class="lb-nav lb-prev" aria-label="Προηγούμενη εικόνα">‹</button>
+      <img id="lb-img" class="lb-img" alt="">
+      <button class="lb-nav lb-next" aria-label="Επόμενη εικόνα">›</button>
+
+      <figcaption class="lb-meta">
+        <span class="lb-count" id="lb-count">1/1</span>
+      </figcaption>
+    </figure>
+  </div>
+
   <footer class="site-footer">
     <div class="container footer-inner">
       <div class="footer-contact">
@@ -695,6 +713,7 @@
     </button>
   </div>
 
+  <script src="assets/js/lightbox.js" defer></script>
   <script src="assets/app.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add reusable lightbox markup, styles and script to power the gallery overlay
- wire carousel images to open in the overlay with keyboard navigation, counters and close affordances
- lock scrolling, provide focus management and fade transitions for an accessible experience

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f92ce25d788320a8cef5c3de6b16fa