### PR TITLE
Synchronize footer social hover animation with header

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -234,8 +234,9 @@ body.nav-open{overflow:hidden}
 .footer-inner{display:flex;flex-direction:column;align-items:center;gap:20px;text-align:center}
 .footer-contact,.footer-brand,.footer-social{display:flex;flex-direction:column;align-items:center;gap:12px}
 .footer-social .social{justify-content:center}
+.footer-social .icon{background:var(--accent-2);filter:drop-shadow(0 0 0 rgba(15,23,42,0));transition:background .2s ease,opacity .2s ease,transform .2s ease,filter .2s ease}
 .footer-social .icon:hover,
-.footer-social .icon:focus-visible{background-color:#F59E0B}
+.footer-social .icon:focus-visible{opacity:1;background:var(--accent);transform:translateY(-2px);filter:drop-shadow(0 8px 18px rgba(15,23,42,.2));outline:none}
 .footer-heading{font-size:1rem;font-weight:700;margin:0}
 .footer-list{list-style:none;display:flex;flex-direction:column;gap:10px;margin:0;padding:0;width:100%;max-width:280px}
 .footer-list__item{display:flex;align-items:center;justify-content:center;gap:12px;color:inherit;font-weight:500;line-height:1.5}
@@ -252,9 +253,7 @@ body.nav-open{overflow:hidden}
 .brand--footer{margin:0}
 .brand--footer .brand-logo{height:48px}
 .site-footer .social{margin-left:0}
-.site-footer .icon{background:var(--accent-2);transition:background .2s ease,opacity .2s ease,transform .2s ease}
-.site-footer .icon:hover,
-.site-footer .icon:focus-visible{opacity:1;transform:translateY(-2px);background:#F59E0B;outline:none}
+
 .legal-links{font-size:.85rem;opacity:.8;margin-top:8px;text-align:center;width:100%}
 .legal-links a:hover{color:var(--accent)}
 


### PR DESCRIPTION
## Summary
- add dedicated footer social icon styles that mirror the header hover animation
- remove the redundant site-footer icon override now that footer social icons inherit the shared animation

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68f9377a03ec8320815eabf0193f9da3