### PR TITLE
Remove about section promo card

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -142,7 +142,6 @@ body.nav-open{overflow:hidden}
 
 /* About */
 .about-grid{display:grid;gap:20px}
-.about-card{background:var(--card);border:1px solid #e8edf4;border-radius:16px;padding:20px;box-shadow:var(--shadow)}
 .bullets{padding-left:18px}
 
 /* Services */

--- a/index.html
+++ b/index.html
@@ -228,10 +228,6 @@
             <li>After-sales υποστήριξη</li>
           </ul>
         </div>
-        <div class="about-card">
-          <h3>FM Renovation – anakainisou.gr</h3>
-          <p>Συνδυάζουμε τεχνική γνώση με αρχιτεκτονική αισθητική για αποτέλεσμα που αντέχει και ξεχωρίζει.</p>
-        </div>
       </div>
     </section>
 


### PR DESCRIPTION
## Summary
- remove the FM Renovation promo card from the "Λίγα λόγια για εμάς" section
- delete the unused CSS for the removed card styling

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68ffd95b90e083208c9739f8c59a31bd