### PR TITLE
Rename “Διαδικασία” nav label to “Πώς Λειτουργούμε”

### DIFF
--- a/erga.html
+++ b/erga.html
@@ -56,7 +56,7 @@
             </ul>
           </li>
           <li class="nav__item"><a href="/index.html#reasons" class="nav__link">Γιατί εμείς</a></li>
-          <li class="nav__item"><a href="/index.html#process" class="nav__link">Διαδικασία</a></li>
+          <li class="nav__item"><a href="/index.html#process" class="nav__link">Πώς Λειτουργούμε</a></li>
           <li class="nav__item nav__item--projects"><a href="erga.html" class="nav__link nav__link--active" aria-current="page">Έργα</a></li>
           <li class="nav__item"><a href="/index.html#gallery" class="nav__link">Gallery</a></li>
           <li class="nav__item nav__item--cta"><a href="/index.html#contact" class="btn btn--sm nav-cta">Ζητήστε Προσφορά</a></li>
@@ -97,7 +97,7 @@
             </ul>
           </li>
           <li class="nav-mobile__item"><a href="/index.html#reasons" class="nav-mobile__link">Γιατί εμείς</a></li>
-          <li class="nav-mobile__item"><a href="/index.html#process" class="nav-mobile__link">Διαδικασία</a></li>
+          <li class="nav-mobile__item"><a href="/index.html#process" class="nav-mobile__link">Πώς Λειτουργούμε</a></li>
           <li class="nav-mobile__item nav-mobile__item--projects"><a href="erga.html" class="nav-mobile__link nav-mobile__link--active" aria-current="page">Έργα</a></li>
           <li class="nav-mobile__item"><a href="/index.html#gallery" class="nav-mobile__link">Gallery</a></li>
           <li class="nav-mobile__item nav-mobile__item--cta"><a href="/index.html#contact" class="btn btn--primary nav-mobile__cta">Ζητήστε Προσφορά</a></li>

--- a/index.html
+++ b/index.html
@@ -140,7 +140,7 @@
             </ul>
           </li>
           <li class="nav__item"><a href="#reasons" class="nav__link">Γιατί εμείς</a></li>
-          <li class="nav__item"><a href="#process" class="nav__link">Διαδικασία</a></li>
+          <li class="nav__item"><a href="#process" class="nav__link">Πώς Λειτουργούμε</a></li>
           <li class="nav__item nav__item--projects"><a href="erga.html" class="nav__link">Έργα</a></li>
           <li class="nav__item nav__item--cta"><a href="#contact" class="btn btn--sm nav-cta">Ζητήστε Προσφορά</a></li>
         </ul>
@@ -180,7 +180,7 @@
             </ul>
           </li>
           <li class="nav-mobile__item"><a href="#reasons" class="nav-mobile__link">Γιατί εμείς</a></li>
-          <li class="nav-mobile__item"><a href="#process" class="nav-mobile__link">Διαδικασία</a></li>
+          <li class="nav-mobile__item"><a href="#process" class="nav-mobile__link">Πώς Λειτουργούμε</a></li>
           <li class="nav-mobile__item nav-mobile__item--projects"><a href="erga.html" class="nav-mobile__link">Έργα</a></li>
           <li class="nav-mobile__item nav-mobile__item--cta"><a href="#contact" class="btn btn--primary nav-mobile__cta">Ζητήστε Προσφορά</a></li>
         </ul>

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -49,7 +49,7 @@
             </ul>
           </li>
           <li class="nav__item"><a href="/index.html#reasons" class="nav__link">Γιατί εμείς</a></li>
-          <li class="nav__item"><a href="/index.html#process" class="nav__link">Διαδικασία</a></li>
+          <li class="nav__item"><a href="/index.html#process" class="nav__link">Πώς Λειτουργούμε</a></li>
           <li class="nav__item nav__item--projects"><a href="erga.html" class="nav__link">Έργα</a></li>
           <li class="nav__item"><a href="/index.html#gallery" class="nav__link">Gallery</a></li>
           <li class="nav__item nav__item--cta"><a href="/index.html#contact" class="btn btn--sm nav-cta">Ζητήστε Προσφορά</a></li>
@@ -90,7 +90,7 @@
             </ul>
           </li>
           <li class="nav-mobile__item"><a href="/index.html#reasons" class="nav-mobile__link">Γιατί εμείς</a></li>
-          <li class="nav-mobile__item"><a href="/index.html#process" class="nav-mobile__link">Διαδικασία</a></li>
+          <li class="nav-mobile__item"><a href="/index.html#process" class="nav-mobile__link">Πώς Λειτουργούμε</a></li>
           <li class="nav-mobile__item nav-mobile__item--projects"><a href="erga.html" class="nav-mobile__link">Έργα</a></li>
           <li class="nav-mobile__item"><a href="/index.html#gallery" class="nav-mobile__link">Gallery</a></li>
           <li class="nav-mobile__item nav-mobile__item--cta"><a href="/index.html#contact" class="btn btn--primary nav-mobile__cta">Ζητήστε Προσφορά</a></li>

--- a/terms.html
+++ b/terms.html
@@ -49,7 +49,7 @@
             </ul>
           </li>
           <li class="nav__item"><a href="/index.html#reasons" class="nav__link">Γιατί εμείς</a></li>
-          <li class="nav__item"><a href="/index.html#process" class="nav__link">Διαδικασία</a></li>
+          <li class="nav__item"><a href="/index.html#process" class="nav__link">Πώς Λειτουργούμε</a></li>
           <li class="nav__item nav__item--projects"><a href="erga.html" class="nav__link">Έργα</a></li>
           <li class="nav__item"><a href="/index.html#gallery" class="nav__link">Gallery</a></li>
           <li class="nav__item nav__item--cta"><a href="/index.html#contact" class="btn btn--sm nav-cta">Ζητήστε Προσφορά</a></li>
@@ -90,7 +90,7 @@
             </ul>
           </li>
           <li class="nav-mobile__item"><a href="/index.html#reasons" class="nav-mobile__link">Γιατί εμείς</a></li>
-          <li class="nav-mobile__item"><a href="/index.html#process" class="nav-mobile__link">Διαδικασία</a></li>
+          <li class="nav-mobile__item"><a href="/index.html#process" class="nav-mobile__link">Πώς Λειτουργούμε</a></li>
           <li class="nav-mobile__item nav-mobile__item--projects"><a href="erga.html" class="nav-mobile__link">Έργα</a></li>
           <li class="nav-mobile__item"><a href="/index.html#gallery" class="nav-mobile__link">Gallery</a></li>
           <li class="nav-mobile__item nav-mobile__item--cta"><a href="/index.html#contact" class="btn btn--primary nav-mobile__cta">Ζητήστε Προσφορά</a></li>


### PR DESCRIPTION
## Summary
- rename the navigation menu item text from "Διαδικασία" to "Πώς Λειτουργούμε" across the desktop and mobile menus on all pages

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ffddf0d8888320b8afbcfa39c3aac8