### PR TITLE
Update navigation label to correct wording

### DIFF
--- a/erga.html
+++ b/erga.html
@@ -55,7 +55,7 @@
               <li><a href="/index.html#services" class="submenu__link">Κουφώματα</a></li>
             </ul>
           </li>
-          <li class="nav__item"><a href="/index.html#reasons" class="nav__link">Γιατί εμείς</a></li>
+          <li class="nav__item"><a href="/index.html#reasons" class="nav__link">Γιατί Εμάς</a></li>
           <li class="nav__item"><a href="/index.html#process" class="nav__link">Πώς Λειτουργούμε</a></li>
           <li class="nav__item nav__item--projects"><a href="erga.html" class="nav__link nav__link--active" aria-current="page">Έργα</a></li>
           <li class="nav__item"><a href="/index.html#gallery" class="nav__link">Gallery</a></li>
@@ -96,7 +96,7 @@
               <li><a href="/index.html#services" class="nav-mobile__sublink">Κουφώματα</a></li>
             </ul>
           </li>
-          <li class="nav-mobile__item"><a href="/index.html#reasons" class="nav-mobile__link">Γιατί εμείς</a></li>
+          <li class="nav-mobile__item"><a href="/index.html#reasons" class="nav-mobile__link">Γιατί Εμάς</a></li>
           <li class="nav-mobile__item"><a href="/index.html#process" class="nav-mobile__link">Πώς Λειτουργούμε</a></li>
           <li class="nav-mobile__item nav-mobile__item--projects"><a href="erga.html" class="nav-mobile__link nav-mobile__link--active" aria-current="page">Έργα</a></li>
           <li class="nav-mobile__item"><a href="/index.html#gallery" class="nav-mobile__link">Gallery</a></li>

--- a/index.html
+++ b/index.html
@@ -139,7 +139,7 @@
               <li><a href="#services" class="submenu__link">Κουφώματα</a></li>
             </ul>
           </li>
-          <li class="nav__item"><a href="#reasons" class="nav__link">Γιατί εμείς</a></li>
+          <li class="nav__item"><a href="#reasons" class="nav__link">Γιατί Εμάς</a></li>
           <li class="nav__item"><a href="#process" class="nav__link">Πώς Λειτουργούμε</a></li>
           <li class="nav__item nav__item--projects"><a href="erga.html" class="nav__link">Έργα</a></li>
           <li class="nav__item nav__item--cta"><a href="#contact" class="btn btn--sm nav-cta">Ζητήστε Προσφορά</a></li>
@@ -179,7 +179,7 @@
               <li><a href="#services" class="nav-mobile__sublink">Κουφώματα</a></li>
             </ul>
           </li>
-          <li class="nav-mobile__item"><a href="#reasons" class="nav-mobile__link">Γιατί εμείς</a></li>
+          <li class="nav-mobile__item"><a href="#reasons" class="nav-mobile__link">Γιατί Εμάς</a></li>
           <li class="nav-mobile__item"><a href="#process" class="nav-mobile__link">Πώς Λειτουργούμε</a></li>
           <li class="nav-mobile__item nav-mobile__item--projects"><a href="erga.html" class="nav-mobile__link">Έργα</a></li>
           <li class="nav-mobile__item nav-mobile__item--cta"><a href="#contact" class="btn btn--primary nav-mobile__cta">Ζητήστε Προσφορά</a></li>

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -48,7 +48,7 @@
               <li><a href="/index.html#services" class="submenu__link">Κουφώματα</a></li>
             </ul>
           </li>
-          <li class="nav__item"><a href="/index.html#reasons" class="nav__link">Γιατί εμείς</a></li>
+          <li class="nav__item"><a href="/index.html#reasons" class="nav__link">Γιατί Εμάς</a></li>
           <li class="nav__item"><a href="/index.html#process" class="nav__link">Πώς Λειτουργούμε</a></li>
           <li class="nav__item nav__item--projects"><a href="erga.html" class="nav__link">Έργα</a></li>
           <li class="nav__item"><a href="/index.html#gallery" class="nav__link">Gallery</a></li>
@@ -89,7 +89,7 @@
               <li><a href="/index.html#services" class="nav-mobile__sublink">Κουφώματα</a></li>
             </ul>
           </li>
-          <li class="nav-mobile__item"><a href="/index.html#reasons" class="nav-mobile__link">Γιατί εμείς</a></li>
+          <li class="nav-mobile__item"><a href="/index.html#reasons" class="nav-mobile__link">Γιατί Εμάς</a></li>
           <li class="nav-mobile__item"><a href="/index.html#process" class="nav-mobile__link">Πώς Λειτουργούμε</a></li>
           <li class="nav-mobile__item nav-mobile__item--projects"><a href="erga.html" class="nav-mobile__link">Έργα</a></li>
           <li class="nav-mobile__item"><a href="/index.html#gallery" class="nav-mobile__link">Gallery</a></li>

--- a/terms.html
+++ b/terms.html
@@ -48,7 +48,7 @@
               <li><a href="/index.html#services" class="submenu__link">Κουφώματα</a></li>
             </ul>
           </li>
-          <li class="nav__item"><a href="/index.html#reasons" class="nav__link">Γιατί εμείς</a></li>
+          <li class="nav__item"><a href="/index.html#reasons" class="nav__link">Γιατί Εμάς</a></li>
           <li class="nav__item"><a href="/index.html#process" class="nav__link">Πώς Λειτουργούμε</a></li>
           <li class="nav__item nav__item--projects"><a href="erga.html" class="nav__link">Έργα</a></li>
           <li class="nav__item"><a href="/index.html#gallery" class="nav__link">Gallery</a></li>
@@ -89,7 +89,7 @@
               <li><a href="/index.html#services" class="nav-mobile__sublink">Κουφώματα</a></li>
             </ul>
           </li>
-          <li class="nav-mobile__item"><a href="/index.html#reasons" class="nav-mobile__link">Γιατί εμείς</a></li>
+          <li class="nav-mobile__item"><a href="/index.html#reasons" class="nav-mobile__link">Γιατί Εμάς</a></li>
           <li class="nav-mobile__item"><a href="/index.html#process" class="nav-mobile__link">Πώς Λειτουργούμε</a></li>
           <li class="nav-mobile__item nav-mobile__item--projects"><a href="erga.html" class="nav-mobile__link">Έργα</a></li>
           <li class="nav-mobile__item"><a href="/index.html#gallery" class="nav-mobile__link">Gallery</a></li>


### PR DESCRIPTION
## Summary
- update the desktop and mobile navigation entries to display "Γιατί Εμάς" instead of "Γιατί εμείς" across all pages

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ffe181b7888320a3a92819eb91ccc5