### PR TITLE
Remove Services dropdown from navigation menus

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -9,20 +9,6 @@ const prefersReducedMotion=window.matchMedia('(prefers-reduced-motion: reduce)')
 const focusableSelectors="a[href]:not([tabindex='-1']), button:not([disabled]):not([tabindex='-1']), [tabindex]:not([tabindex='-1'])";
 let menuOpen=false;
 
-const mobileParent=document.querySelector('[data-mobile-parent]');
-const mobileItem=mobileParent?mobileParent.closest('.nav-mobile__item'):null;
-const mobileSubLinks=mobileItem?Array.from(mobileItem.querySelectorAll('.nav-mobile__submenu a')):[];
-function setMobileSubmenu(open){
-  if(!mobileParent||!mobileItem){return;}
-  mobileParent.setAttribute('aria-expanded',String(open));
-  mobileItem.classList.toggle('nav-mobile__item--open',open);
-  mobileSubLinks.forEach(function(link){
-    if(open){link.removeAttribute('tabindex');}
-    else{link.setAttribute('tabindex','-1');}
-  });
-}
-if(mobileSubLinks.length){setMobileSubmenu(false);}else if(mobileParent){mobileParent.setAttribute('aria-expanded','false');}
-
 function getFocusableElements(){
   if(!navOverlay){return[];}
   return Array.from(navOverlay.querySelectorAll(focusableSelectors)).filter(function(el){
@@ -57,7 +43,6 @@ function handleOverlayEsc(event){
 function openMenu(){
   if(!navToggle||!navOverlay||!navBackdrop||menuOpen){return;}
   menuOpen=true;
-  setMobileSubmenu(false);
   navOverlay.hidden=false;
   navBackdrop.hidden=false;
   body.classList.add('nav-open');
@@ -93,7 +78,6 @@ function closeMenu(returnFocus){
   navToggle.setAttribute('aria-label','Άνοιγμα μενού');
   document.removeEventListener('keydown',handleOverlayEsc);
   navOverlay.removeEventListener('keydown',trapFocus);
-  setMobileSubmenu(false);
   const finalize=function(){
     navOverlay.hidden=true;
     navBackdrop.hidden=true;
@@ -121,7 +105,7 @@ if(navToggle&&navOverlay&&navBackdrop){
   if(navClose){navClose.addEventListener('click',function(){closeMenu();});}
   navBackdrop.addEventListener('click',function(){closeMenu();});
   if(navOverlay){
-    var overlayLinks=navOverlay.querySelectorAll('a.nav-mobile__link, a.nav-mobile__sublink, a.nav-mobile__cta');
+    var overlayLinks=navOverlay.querySelectorAll('a.nav-mobile__link, a.nav-mobile__cta');
     overlayLinks.forEach(function(link){
       link.addEventListener('click',function(){closeMenu();});
     });
@@ -134,103 +118,6 @@ if(navToggle&&navOverlay&&navBackdrop){
   }else if(typeof desktopMedia.addListener==='function'){
     desktopMedia.addListener(handleDesktopChange);
   }
-}
-
-if(mobileParent&&mobileItem){
-  mobileParent.addEventListener('click',function(){
-    const expanded=mobileParent.getAttribute('aria-expanded')==='true';
-    setMobileSubmenu(!expanded);
-    if(!expanded&&mobileSubLinks.length){
-      mobileSubLinks[0].focus({preventScroll:true});
-    }
-  });
-  mobileParent.addEventListener('keydown',function(event){
-    if(event.key==='Escape'){
-      event.preventDefault();
-      setMobileSubmenu(false);
-      mobileParent.focus({preventScroll:true});
-    }
-  });
-  mobileSubLinks.forEach(function(link){
-    link.addEventListener('keydown',function(event){
-      if(event.key==='Escape'){
-        event.preventDefault();
-        setMobileSubmenu(false);
-        mobileParent.focus({preventScroll:true});
-      }
-    });
-  });
-}
-
-const desktopParent=document.querySelector('[data-desktop-parent]');
-const desktopItem=desktopParent?desktopParent.closest('.nav-item--has-submenu'):null;
-const desktopSubLinks=desktopItem?Array.from(desktopItem.querySelectorAll('.submenu__link')):[];
-function setDesktopSubmenu(open){
-  if(!desktopParent||!desktopItem){return;}
-  desktopParent.setAttribute('aria-expanded',String(open));
-  desktopItem.classList.toggle('is-open',open);
-  desktopSubLinks.forEach(function(link){
-    if(open){link.removeAttribute('tabindex');}
-    else{link.setAttribute('tabindex','-1');}
-  });
-}
-if(desktopSubLinks.length){setDesktopSubmenu(false);}else if(desktopParent){desktopParent.setAttribute('aria-expanded','false');}
-
-if(desktopParent&&desktopItem){
-  const openDesktop=function(){
-    if(!desktopMedia.matches){return;}
-    setDesktopSubmenu(true);
-  };
-  const closeDesktop=function(){
-    setDesktopSubmenu(false);
-  };
-  desktopParent.addEventListener('click',function(event){
-    event.preventDefault();
-    const expanded=desktopParent.getAttribute('aria-expanded')==='true';
-    if(expanded){
-      closeDesktop();
-    }else{
-      openDesktop();
-      if(desktopSubLinks.length){
-        desktopSubLinks[0].focus({preventScroll:true});
-      }
-    }
-  });
-  desktopParent.addEventListener('keydown',function(event){
-    if(event.key===' '||event.key==='Enter'){
-      event.preventDefault();
-      const expanded=desktopParent.getAttribute('aria-expanded')==='true';
-      if(expanded){
-        closeDesktop();
-      }else{
-        openDesktop();
-        if(desktopSubLinks.length){
-          desktopSubLinks[0].focus({preventScroll:true});
-        }
-      }
-    }else if(event.key==='Escape'){
-      event.preventDefault();
-      closeDesktop();
-      desktopParent.focus({preventScroll:true});
-    }
-  });
-  desktopItem.addEventListener('mouseenter',openDesktop);
-  desktopItem.addEventListener('mouseleave',closeDesktop);
-  desktopItem.addEventListener('focusin',openDesktop);
-  desktopItem.addEventListener('focusout',function(event){
-    if(!desktopItem.contains(event.relatedTarget)){
-      closeDesktop();
-    }
-  });
-  desktopSubLinks.forEach(function(link){
-    link.addEventListener('keydown',function(event){
-      if(event.key==='Escape'){
-        event.preventDefault();
-        closeDesktop();
-        desktopParent.focus({preventScroll:true});
-      }
-    });
-  });
 }
 
 const siteHeader=document.querySelector('.site-header');
@@ -248,12 +135,7 @@ if(siteHeader){
 
 // Active nav state for services
 const servicesSection=document.getElementById('services');
-const servicesNavLinks=[];
-if(desktopParent){servicesNavLinks.push(desktopParent);}
-if(mobileParent){servicesNavLinks.push(mobileParent);}
-document.querySelectorAll('a.nav__link[href="#services"], a.nav-mobile__link[href="#services"]').forEach(function(link){
-  servicesNavLinks.push(link);
-});
+const servicesNavLinks=Array.from(document.querySelectorAll('a.nav__link[href="#services"], a.nav-mobile__link[href="#services"]'));
 if('IntersectionObserver'in window&&servicesSection&&servicesNavLinks.length){
   const toggleActive=function(isActive){
     servicesNavLinks.forEach(function(link){

--- a/assets/style.css
+++ b/assets/style.css
@@ -48,20 +48,6 @@ img{max-width:100%;height:auto;display:block}
 .nav__item--cta .btn:hover,
 .nav__item--cta .btn:focus-visible{background:#F59E0B;color:#FFFFFF;outline:none}
 .nav-cta{font-weight:600}
-.nav-item--has-submenu{position:relative}
-.nav__link--parent{background:none;border:none;padding:0;font:inherit;cursor:pointer}
-.nav__link--parent:focus-visible{outline:none}
-.nav-caret{width:9px;height:9px;border-right:2px solid currentColor;border-bottom:2px solid currentColor;transform:rotate(45deg);transition:transform .2s ease}
-.nav-item--has-submenu.is-open .nav-caret,
-.nav-item--has-submenu:hover .nav-caret,
-.nav-item--has-submenu:focus-within .nav-caret{transform:rotate(-135deg)}
-.submenu{list-style:none;margin:0;padding:12px 0;position:absolute;left:50%;top:calc(100% + 16px);transform:translate(-50%,10px);background:#fff;border:1px solid #e8edf4;border-radius:14px;box-shadow:var(--shadow);display:grid;gap:4px;min-width:220px;opacity:0;visibility:hidden;pointer-events:none;transition:opacity .2s ease,transform .2s ease}
-.submenu__link{display:block;padding:8px 18px;color:var(--text);text-decoration:none;font-weight:500;opacity:.9;transition:color .2s ease,opacity .2s ease}
-.submenu__link:hover,
-.submenu__link:focus-visible{opacity:1;color:var(--accent);outline:none}
-.nav-item--has-submenu.is-open .submenu,
-.nav-item--has-submenu:hover .submenu,
-.nav-item--has-submenu:focus-within .submenu{opacity:1;visibility:visible;pointer-events:auto;transform:translate(-50%,0)}
 .social{display:flex;gap:10px}
 .icon{width:28px;height:28px;display:inline-block;background:var(--text);mask-size:cover;-webkit-mask-size:cover;opacity:.85;transform:translateY(0);filter:drop-shadow(0 0 0 rgba(15,23,42,0));transition:background .2s ease,opacity .2s ease,transform .2s ease,filter .2s ease}
 .icon:hover,.icon:focus-visible{opacity:1;background:var(--accent);transform:translateY(-2px);filter:drop-shadow(0 8px 18px rgba(15,23,42,.2));outline:none}
@@ -89,13 +75,6 @@ img{max-width:100%;height:auto;display:block}
 .nav-mobile__link{width:100%;display:flex;align-items:center;justify-content:space-between;gap:12px;padding:14px 0;font-size:1.08rem;font-weight:600;text-decoration:none;color:var(--text);background:none;border:none;cursor:pointer}
 .nav-mobile__link:hover,
 .nav-mobile__link:focus-visible{color:var(--accent);outline:none}
-.nav-mobile__link--parent{cursor:pointer}
-.nav-mobile__submenu{list-style:none;margin:0;padding:0 0 12px 16px;display:grid;gap:10px;max-height:0;overflow:hidden;opacity:0;transition:max-height .3s ease,opacity .3s ease}
-.nav-mobile__sublink{display:block;text-decoration:none;color:var(--text);opacity:.9;font-weight:500;padding:4px 0}
-.nav-mobile__sublink:hover,
-.nav-mobile__sublink:focus-visible{opacity:1;color:var(--accent);outline:none}
-.nav-mobile__item--open .nav-mobile__submenu{max-height:320px;opacity:1}
-.nav-mobile__item--open .nav-mobile__link--parent .nav-caret{transform:rotate(-135deg)}
 .nav-mobile__item--cta{border:none;padding-top:12px}
 .nav-mobile__cta{width:100%;justify-content:center;font-weight:700}
 .nav-overlay__social{margin-top:auto;display:flex;gap:16px;padding-top:20px;border-top:1px solid #e8edf4}
@@ -103,7 +82,7 @@ img{max-width:100%;height:auto;display:block}
 body.nav-open{overflow:hidden}
 
 @media (prefers-reduced-motion: reduce){
-  .nav-toggle,.nav-toggle-bar,.nav-close,.nav-backdrop,.nav-overlay,.nav-overlay__inner,.nav-mobile__submenu,.submenu{transition:none !important}
+  .nav-toggle,.nav-toggle-bar,.nav-close,.nav-backdrop,.nav-overlay,.nav-overlay__inner{transition:none !important}
   .btn{animation:none !important}
 }
 
@@ -375,7 +354,6 @@ body.nav-open{overflow:hidden}
 
 .nav__link--active{color:var(--accent);font-weight:700;text-decoration:underline;text-decoration-thickness:2px;text-decoration-color:var(--accent)}
 .nav-mobile__link.nav__link--active,.nav-mobile__link.nav-mobile__link--active{color:var(--accent);font-weight:700;text-decoration:underline}
-.submenu__link.nav__link--active{color:var(--accent);text-decoration:underline}
 
 @media (prefers-reduced-motion: reduce){
   .card{transition:none !important;transform:none !important}

--- a/erga.html
+++ b/erga.html
@@ -41,20 +41,7 @@
       <nav id="site-nav" class="nav" aria-label="Κύρια πλοήγηση">
         <ul class="nav__list">
           <li class="nav__item"><a href="/index.html#about" class="nav__link">Σχετικά</a></li>
-          <li class="nav__item nav-item--has-submenu">
-            <button class="nav__link nav__link--parent" type="button" aria-expanded="false" data-desktop-parent>
-              Υπηρεσίες
-              <span class="nav-caret" aria-hidden="true"></span>
-            </button>
-            <ul class="submenu">
-              <li><a href="/index.html#services" class="submenu__link">Ανακαίνιση Κατοικίας</a></li>
-              <li><a href="/index.html#services" class="submenu__link">Μπάνιο</a></li>
-              <li><a href="/index.html#services" class="submenu__link">Κουζίνα</a></li>
-              <li><a href="/index.html#services" class="submenu__link">Ηλεκτρολογικά – Υ.Δ.Ε.</a></li>
-              <li><a href="/index.html#services" class="submenu__link">Υδραυλικά</a></li>
-              <li><a href="/index.html#services" class="submenu__link">Κουφώματα</a></li>
-            </ul>
-          </li>
+          <li class="nav__item"><a href="/index.html#services" class="nav__link">Υπηρεσίες</a></li>
           <li class="nav__item"><a href="/index.html#reasons" class="nav__link">Γιατί Εμάς</a></li>
           <li class="nav__item"><a href="/index.html#process" class="nav__link">Πώς Λειτουργούμε</a></li>
           <li class="nav__item nav__item--projects"><a href="erga.html" class="nav__link nav__link--active" aria-current="page">Έργα</a></li>
@@ -82,20 +69,7 @@
       <nav class="nav-mobile" aria-label="Κύρια πλοήγηση" data-mobile-nav>
         <ul class="nav-mobile__list">
           <li class="nav-mobile__item"><a href="/index.html#about" class="nav-mobile__link">Σχετικά</a></li>
-          <li class="nav-mobile__item nav-mobile__item--has-submenu">
-            <button class="nav-mobile__link nav-mobile__link--parent" type="button" aria-expanded="false" data-mobile-parent>
-              Υπηρεσίες
-              <span class="nav-caret" aria-hidden="true"></span>
-            </button>
-            <ul class="nav-mobile__submenu">
-              <li><a href="/index.html#services" class="nav-mobile__sublink">Ανακαίνιση Κατοικίας</a></li>
-              <li><a href="/index.html#services" class="nav-mobile__sublink">Μπάνιο</a></li>
-              <li><a href="/index.html#services" class="nav-mobile__sublink">Κουζίνα</a></li>
-              <li><a href="/index.html#services" class="nav-mobile__sublink">Ηλεκτρολογικά – Υ.Δ.Ε.</a></li>
-              <li><a href="/index.html#services" class="nav-mobile__sublink">Υδραυλικά</a></li>
-              <li><a href="/index.html#services" class="nav-mobile__sublink">Κουφώματα</a></li>
-            </ul>
-          </li>
+          <li class="nav-mobile__item"><a href="/index.html#services" class="nav-mobile__link">Υπηρεσίες</a></li>
           <li class="nav-mobile__item"><a href="/index.html#reasons" class="nav-mobile__link">Γιατί Εμάς</a></li>
           <li class="nav-mobile__item"><a href="/index.html#process" class="nav-mobile__link">Πώς Λειτουργούμε</a></li>
           <li class="nav-mobile__item nav-mobile__item--projects"><a href="erga.html" class="nav-mobile__link nav-mobile__link--active" aria-current="page">Έργα</a></li>

--- a/index.html
+++ b/index.html
@@ -125,21 +125,7 @@
       <nav id="site-nav" class="nav" aria-label="Κύρια πλοήγηση">
         <ul class="nav__list">
           <li class="nav__item"><a href="#about" class="nav__link">Σχετικά</a></li>
-          <li class="nav__item nav-item--has-submenu">
-            <button class="nav__link nav__link--parent" type="button" aria-expanded="false" data-desktop-parent>
-              Υπηρεσίες
-              <span class="nav-caret" aria-hidden="true"></span>
-            </button>
-            <ul class="submenu">
-              <li><a href="#services" class="submenu__link">Ανακαίνιση Κατοικίας</a></li>
-              <li><a href="#services" class="submenu__link">Μπάνιο</a></li>
-              <li><a href="#services" class="submenu__link">Κουζίνα</a></li>
-              <li><a href="#services" class="submenu__link">Ηλεκτρολογικά – Υ.Δ.Ε.</a></li>
-              <li><a href="#services" class="submenu__link">Υδραυλικά</a></li>
-              <li><a href="#services" class="submenu__link">Κουφώματα</a></li>
-            </ul>
-          </li>
-
+          <li class="nav__item"><a href="#services" class="nav__link">Υπηρεσίες</a></li>
           <li class="nav__item"><a href="#process" class="nav__link">Πώς Λειτουργούμε</a></li>
           <li class="nav__item nav__item--projects"><a href="erga.html" class="nav__link">Έργα</a></li>
           <li class="nav__item nav__item--cta"><a href="#contact" class="btn btn--sm nav-cta">Ζητήστε Προσφορά</a></li>
@@ -165,21 +151,7 @@
       <nav class="nav-mobile" aria-label="Κύρια πλοήγηση" data-mobile-nav>
         <ul class="nav-mobile__list">
           <li class="nav-mobile__item"><a href="#about" class="nav-mobile__link">Σχετικά</a></li>
-          <li class="nav-mobile__item nav-mobile__item--has-submenu">
-            <button class="nav-mobile__link nav-mobile__link--parent" type="button" aria-expanded="false" data-mobile-parent>
-              Υπηρεσίες
-              <span class="nav-caret" aria-hidden="true"></span>
-            </button>
-            <ul class="nav-mobile__submenu" data-mobile-submenu>
-              <li><a href="#services" class="nav-mobile__sublink">Ανακαίνιση Κατοικίας</a></li>
-              <li><a href="#services" class="nav-mobile__sublink">Μπάνιο</a></li>
-              <li><a href="#services" class="nav-mobile__sublink">Κουζίνα</a></li>
-              <li><a href="#services" class="nav-mobile__sublink">Ηλεκτρολογικά – Υ.Δ.Ε.</a></li>
-              <li><a href="#services" class="nav-mobile__sublink">Υδραυλικά</a></li>
-              <li><a href="#services" class="nav-mobile__sublink">Κουφώματα</a></li>
-            </ul>
-          </li>
-
+          <li class="nav-mobile__item"><a href="#services" class="nav-mobile__link">Υπηρεσίες</a></li>
           <li class="nav-mobile__item"><a href="#process" class="nav-mobile__link">Πώς Λειτουργούμε</a></li>
           <li class="nav-mobile__item nav-mobile__item--projects"><a href="erga.html" class="nav-mobile__link">Έργα</a></li>
           <li class="nav-mobile__item nav-mobile__item--cta"><a href="#contact" class="btn btn--primary nav-mobile__cta">Ζητήστε Προσφορά</a></li>

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -34,20 +34,7 @@
       <nav id="site-nav" class="nav" aria-label="Κύρια πλοήγηση">
         <ul class="nav__list">
           <li class="nav__item"><a href="/index.html#about" class="nav__link">Σχετικά</a></li>
-          <li class="nav__item nav-item--has-submenu">
-            <button class="nav__link nav__link--parent" type="button" aria-expanded="false" data-desktop-parent>
-              Υπηρεσίες
-              <span class="nav-caret" aria-hidden="true"></span>
-            </button>
-            <ul class="submenu">
-              <li><a href="/index.html#services" class="submenu__link">Ανακαίνιση Κατοικίας</a></li>
-              <li><a href="/index.html#services" class="submenu__link">Μπάνιο</a></li>
-              <li><a href="/index.html#services" class="submenu__link">Κουζίνα</a></li>
-              <li><a href="/index.html#services" class="submenu__link">Ηλεκτρολογικά – Υ.Δ.Ε.</a></li>
-              <li><a href="/index.html#services" class="submenu__link">Υδραυλικά</a></li>
-              <li><a href="/index.html#services" class="submenu__link">Κουφώματα</a></li>
-            </ul>
-          </li>
+          <li class="nav__item"><a href="/index.html#services" class="nav__link">Υπηρεσίες</a></li>
           <li class="nav__item"><a href="/index.html#reasons" class="nav__link">Γιατί Εμάς</a></li>
           <li class="nav__item"><a href="/index.html#process" class="nav__link">Πώς Λειτουργούμε</a></li>
           <li class="nav__item nav__item--projects"><a href="erga.html" class="nav__link">Έργα</a></li>
@@ -75,20 +62,7 @@
       <nav class="nav-mobile" aria-label="Κύρια πλοήγηση" data-mobile-nav>
         <ul class="nav-mobile__list">
           <li class="nav-mobile__item"><a href="/index.html#about" class="nav-mobile__link">Σχετικά</a></li>
-          <li class="nav-mobile__item nav-mobile__item--has-submenu">
-            <button class="nav-mobile__link nav-mobile__link--parent" type="button" aria-expanded="false" data-mobile-parent>
-              Υπηρεσίες
-              <span class="nav-caret" aria-hidden="true"></span>
-            </button>
-            <ul class="nav-mobile__submenu">
-              <li><a href="/index.html#services" class="nav-mobile__sublink">Ανακαίνιση Κατοικίας</a></li>
-              <li><a href="/index.html#services" class="nav-mobile__sublink">Μπάνιο</a></li>
-              <li><a href="/index.html#services" class="nav-mobile__sublink">Κουζίνα</a></li>
-              <li><a href="/index.html#services" class="nav-mobile__sublink">Ηλεκτρολογικά – Υ.Δ.Ε.</a></li>
-              <li><a href="/index.html#services" class="nav-mobile__sublink">Υδραυλικά</a></li>
-              <li><a href="/index.html#services" class="nav-mobile__sublink">Κουφώματα</a></li>
-            </ul>
-          </li>
+          <li class="nav-mobile__item"><a href="/index.html#services" class="nav-mobile__link">Υπηρεσίες</a></li>
           <li class="nav-mobile__item"><a href="/index.html#reasons" class="nav-mobile__link">Γιατί Εμάς</a></li>
           <li class="nav-mobile__item"><a href="/index.html#process" class="nav-mobile__link">Πώς Λειτουργούμε</a></li>
           <li class="nav-mobile__item nav-mobile__item--projects"><a href="erga.html" class="nav-mobile__link">Έργα</a></li>

--- a/terms.html
+++ b/terms.html
@@ -34,20 +34,7 @@
       <nav id="site-nav" class="nav" aria-label="Κύρια πλοήγηση">
         <ul class="nav__list">
           <li class="nav__item"><a href="/index.html#about" class="nav__link">Σχετικά</a></li>
-          <li class="nav__item nav-item--has-submenu">
-            <button class="nav__link nav__link--parent" type="button" aria-expanded="false" data-desktop-parent>
-              Υπηρεσίες
-              <span class="nav-caret" aria-hidden="true"></span>
-            </button>
-            <ul class="submenu">
-              <li><a href="/index.html#services" class="submenu__link">Ανακαίνιση Κατοικίας</a></li>
-              <li><a href="/index.html#services" class="submenu__link">Μπάνιο</a></li>
-              <li><a href="/index.html#services" class="submenu__link">Κουζίνα</a></li>
-              <li><a href="/index.html#services" class="submenu__link">Ηλεκτρολογικά – Υ.Δ.Ε.</a></li>
-              <li><a href="/index.html#services" class="submenu__link">Υδραυλικά</a></li>
-              <li><a href="/index.html#services" class="submenu__link">Κουφώματα</a></li>
-            </ul>
-          </li>
+          <li class="nav__item"><a href="/index.html#services" class="nav__link">Υπηρεσίες</a></li>
           <li class="nav__item"><a href="/index.html#reasons" class="nav__link">Γιατί Εμάς</a></li>
           <li class="nav__item"><a href="/index.html#process" class="nav__link">Πώς Λειτουργούμε</a></li>
           <li class="nav__item nav__item--projects"><a href="erga.html" class="nav__link">Έργα</a></li>
@@ -75,20 +62,7 @@
       <nav class="nav-mobile" aria-label="Κύρια πλοήγηση" data-mobile-nav>
         <ul class="nav-mobile__list">
           <li class="nav-mobile__item"><a href="/index.html#about" class="nav-mobile__link">Σχετικά</a></li>
-          <li class="nav-mobile__item nav-mobile__item--has-submenu">
-            <button class="nav-mobile__link nav-mobile__link--parent" type="button" aria-expanded="false" data-mobile-parent>
-              Υπηρεσίες
-              <span class="nav-caret" aria-hidden="true"></span>
-            </button>
-            <ul class="nav-mobile__submenu">
-              <li><a href="/index.html#services" class="nav-mobile__sublink">Ανακαίνιση Κατοικίας</a></li>
-              <li><a href="/index.html#services" class="nav-mobile__sublink">Μπάνιο</a></li>
-              <li><a href="/index.html#services" class="nav-mobile__sublink">Κουζίνα</a></li>
-              <li><a href="/index.html#services" class="nav-mobile__sublink">Ηλεκτρολογικά – Υ.Δ.Ε.</a></li>
-              <li><a href="/index.html#services" class="nav-mobile__sublink">Υδραυλικά</a></li>
-              <li><a href="/index.html#services" class="nav-mobile__sublink">Κουφώματα</a></li>
-            </ul>
-          </li>
+          <li class="nav-mobile__item"><a href="/index.html#services" class="nav-mobile__link">Υπηρεσίες</a></li>
           <li class="nav-mobile__item"><a href="/index.html#reasons" class="nav-mobile__link">Γιατί Εμάς</a></li>
           <li class="nav-mobile__item"><a href="/index.html#process" class="nav-mobile__link">Πώς Λειτουργούμε</a></li>
           <li class="nav-mobile__item nav-mobile__item--projects"><a href="erga.html" class="nav-mobile__link">Έργα</a></li>


### PR DESCRIPTION
## Summary
- replace the Services dropdown with direct links across desktop and mobile navigation
- simplify navigation script and styles to drop submenu-specific logic

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68ffe76920f08320875dd1fc7992e61b