### PR TITLE
Add navigation link to the reasons section

### DIFF
--- a/index.html
+++ b/index.html
@@ -127,6 +127,7 @@
           <li class="nav__item"><a href="#about" class="nav__link">Σχετικά</a></li>
           <li class="nav__item"><a href="#services" class="nav__link">Υπηρεσίες</a></li>
           <li class="nav__item"><a href="#process" class="nav__link">Πώς Λειτουργούμε</a></li>
+          <li class="nav__item"><a href="#reasons" class="nav__link">Γιατί Εμάς</a></li>
           <li class="nav__item nav__item--projects"><a href="erga.html" class="nav__link">Έργα</a></li>
           <li class="nav__item nav__item--cta"><a href="#contact" class="btn btn--sm nav-cta">Ζητήστε Προσφορά</a></li>
         </ul>
@@ -153,6 +154,7 @@
           <li class="nav-mobile__item"><a href="#about" class="nav-mobile__link">Σχετικά</a></li>
           <li class="nav-mobile__item"><a href="#services" class="nav-mobile__link">Υπηρεσίες</a></li>
           <li class="nav-mobile__item"><a href="#process" class="nav-mobile__link">Πώς Λειτουργούμε</a></li>
+          <li class="nav-mobile__item"><a href="#reasons" class="nav-mobile__link">Γιατί Εμάς</a></li>
           <li class="nav-mobile__item nav-mobile__item--projects"><a href="erga.html" class="nav-mobile__link">Έργα</a></li>
           <li class="nav-mobile__item nav-mobile__item--cta"><a href="#contact" class="btn btn--primary nav-mobile__cta">Ζητήστε Προσφορά</a></li>
         </ul>


### PR DESCRIPTION
## Summary
- add a "Γιατί Εμάς" menu item to the desktop navigation that anchors to the reasons section
- mirror the new link in the mobile navigation menu

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ffec90bf9c83209b0c5912e345924b