### PR TITLE
Remove gallery link from projects navigation menu

### DIFF
--- a/erga.html
+++ b/erga.html
@@ -44,7 +44,6 @@
 
           <li class="nav__item"><a href="/index.html#process" class="nav__link">Πώς Λειτουργούμε</a></li>
           <li class="nav__item nav__item--projects"><a href="erga.html" class="nav__link nav__link--active" aria-current="page">Έργα</a></li>
-          <li class="nav__item"><a href="/index.html#gallery" class="nav__link">Gallery</a></li>
           <li class="nav__item nav__item--cta"><a href="/index.html#contact" class="btn btn--sm nav-cta">Ζητήστε Προσφορά</a></li>
         </ul>
       </nav>
@@ -71,7 +70,6 @@
 
           <li class="nav-mobile__item"><a href="/index.html#process" class="nav-mobile__link">Πώς Λειτουργούμε</a></li>
           <li class="nav-mobile__item nav-mobile__item--projects"><a href="erga.html" class="nav-mobile__link nav-mobile__link--active" aria-current="page">Έργα</a></li>
-          <li class="nav-mobile__item"><a href="/index.html#gallery" class="nav-mobile__link">Gallery</a></li>
           <li class="nav-mobile__item nav-mobile__item--cta"><a href="/index.html#contact" class="btn btn--primary nav-mobile__cta">Ζητήστε Προσφορά</a></li>
         </ul>
       </nav>


### PR DESCRIPTION
## Summary
- remove the gallery link from the desktop navigation on the projects page
- remove the gallery link from the mobile navigation on the projects page

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ffed2a7ff48320bdf80d169694289f