### PR TITLE
Align erga page navigation with homepage menu

### DIFF
--- a/erga.html
+++ b/erga.html
@@ -40,11 +40,12 @@
       </button>
       <nav id="site-nav" class="nav" aria-label="Κύρια πλοήγηση">
         <ul class="nav__list">
-          <li class="nav__item"><a href="/index.html#about" class="nav__link">Σχετικά</a></li>
-
-          <li class="nav__item"><a href="/index.html#process" class="nav__link">Πώς Λειτουργούμε</a></li>
-          <li class="nav__item nav__item--projects"><a href="erga.html" class="nav__link nav__link--active" aria-current="page">Έργα</a></li>
-          <li class="nav__item nav__item--cta"><a href="/index.html#contact" class="btn btn--sm nav-cta">Ζητήστε Προσφορά</a></li>
+          <li class="nav__item"><a href="index.html#about" class="nav__link">Σχετικά</a></li>
+          <li class="nav__item"><a href="index.html#services" class="nav__link">Υπηρεσίες</a></li>
+          <li class="nav__item"><a href="index.html#process" class="nav__link">Πώς Λειτουργούμε</a></li>
+          <li class="nav__item"><a href="index.html#reasons" class="nav__link">Γιατί Εμάς</a></li>
+          <li class="nav__item nav__item--projects"><a href="erga.html" class="nav__link">Έργα</a></li>
+          <li class="nav__item nav__item--cta"><a href="index.html#contact" class="btn btn--sm nav-cta">Ζητήστε Προσφορά</a></li>
         </ul>
       </nav>
       <div class="social">
@@ -66,11 +67,12 @@
       </div>
       <nav class="nav-mobile" aria-label="Κύρια πλοήγηση" data-mobile-nav>
         <ul class="nav-mobile__list">
-          <li class="nav-mobile__item"><a href="/index.html#about" class="nav-mobile__link">Σχετικά</a></li>
-
-          <li class="nav-mobile__item"><a href="/index.html#process" class="nav-mobile__link">Πώς Λειτουργούμε</a></li>
-          <li class="nav-mobile__item nav-mobile__item--projects"><a href="erga.html" class="nav-mobile__link nav-mobile__link--active" aria-current="page">Έργα</a></li>
-          <li class="nav-mobile__item nav-mobile__item--cta"><a href="/index.html#contact" class="btn btn--primary nav-mobile__cta">Ζητήστε Προσφορά</a></li>
+          <li class="nav-mobile__item"><a href="index.html#about" class="nav-mobile__link">Σχετικά</a></li>
+          <li class="nav-mobile__item"><a href="index.html#services" class="nav-mobile__link">Υπηρεσίες</a></li>
+          <li class="nav-mobile__item"><a href="index.html#process" class="nav-mobile__link">Πώς Λειτουργούμε</a></li>
+          <li class="nav-mobile__item"><a href="index.html#reasons" class="nav-mobile__link">Γιατί Εμάς</a></li>
+          <li class="nav-mobile__item nav-mobile__item--projects"><a href="erga.html" class="nav-mobile__link">Έργα</a></li>
+          <li class="nav-mobile__item nav-mobile__item--cta"><a href="index.html#contact" class="btn btn--primary nav-mobile__cta">Ζητήστε Προσφορά</a></li>
         </ul>
       </nav>
       <div class="nav-overlay__social">


### PR DESCRIPTION
## Summary
- update the desktop navigation in `erga.html` to match the homepage menu structure and links
- mirror the same navigation items for the mobile menu so both views stay consistent

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ffef12246083209d4bab5391250fc0