### PR TITLE
Prevent empty project gallery thumbnails from rendering

### DIFF
--- a/assets/js/erga.js
+++ b/assets/js/erga.js
@@ -203,21 +203,33 @@
 
   function normalizeImage(item) {
     if (typeof item === 'string') {
-      return { file: item, alt: '' };
+      const file = item.trim();
+      if (!file) {
+        return null;
+      }
+
+      return { file, alt: '' };
     }
 
     if (!item || typeof item !== 'object') {
       return null;
     }
 
-    const file = typeof item.file === 'string' ? item.file : typeof item.src === 'string' ? item.src : '';
+    const rawFile =
+      typeof item.file === 'string'
+        ? item.file
+        : typeof item.src === 'string'
+          ? item.src
+          : '';
+
+    const file = rawFile.trim();
     if (!file) {
       return null;
     }
 
     return {
       file,
-      alt: typeof item.alt === 'string' ? item.alt : ''
+      alt: typeof item.alt === 'string' ? item.alt.trim() : ''
     };
   }
 


### PR DESCRIPTION
## Summary
- trim gallery image entries before rendering so blank records are discarded
- normalize optional image metadata by trimming whitespace

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_6900c03437f083208632d87b390197e6