### PR TITLE
Fix step 4 heading overflow in process section

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -169,7 +169,7 @@ body.nav-open{overflow:hidden}
 .step{background:#fff;border-radius:24px;padding:28px;border:1px solid rgba(15,23,42,.08);box-shadow:0 16px 32px rgba(15,23,42,.08);display:grid;gap:18px;overflow:hidden}
 .step-header{display:flex;align-items:center;gap:12px}
 .step-number{width:48px;height:48px;border-radius:50%;background:rgba(245,158,11,.14);color:#b45309;display:grid;place-items:center;font-weight:700;font-size:1.1rem}
-.step h4{margin:0;font-size:1.25rem;font-weight:700;color:var(--accent-2)}
+.step h4{margin:0;font-size:1.25rem;font-weight:700;color:var(--accent-2);overflow-wrap:anywhere;hyphens:auto}
 .step p{margin:0;color:rgba(15,23,42,.85);line-height:1.6}
 .step img{border-radius:16px;box-shadow:0 12px 24px rgba(15,23,42,.08);width:100%;height:auto;aspect-ratio:3/2;object-fit:cover}
 .reasons-list{display:grid;gap:28px;margin-top:48px;grid-template-columns:repeat(auto-fit,minmax(280px,1fr))}


### PR DESCRIPTION
## Summary
- allow step card headings to wrap naturally so long Greek words stay inside the card

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6900c1a4842883209ec6c7890b8f590f