### PR TITLE
feat: rebuild services section with icons

### DIFF
--- a/assets/css/services.css
+++ b/assets/css/services.css
@@ -1,0 +1,51 @@
+:root{
+  --amber:#F59E0B; --slate:#0F172A; --muted:#64748b;
+}
+
+.services{ padding: 24px 16px; max-width: 1100px; margin: 0 auto; }
+.section-title{ font-size: clamp(24px, 3.2vw, 34px); margin: 0 0 6px; color: var(--slate); }
+.section-sub{ margin: 0 0 12px; color:#475569; }
+
+.service-card{
+  background:#fff; border-radius:16px; box-shadow:0 2px 8px rgba(0,0,0,.06);
+  margin:12px 0; overflow:hidden; transition: box-shadow .25s ease;
+}
+.service-card.open{ box-shadow:0 6px 18px rgba(0,0,0,.10); }
+
+.service-header{
+  -webkit-tap-highlight-color:transparent;
+  width:100%; display:flex; align-items:center; justify-content:space-between;
+  gap:12px; padding:14px 16px; background:#F9FAFB; border:0; text-align:left;
+  font-weight:700; font-size:16px; color:#0F172A; position:relative; overflow:hidden;
+}
+.service-header .left{ display:flex; align-items:center; gap:12px; min-width:0; }
+.service-icon{ width:24px; height:24px; color: var(--amber); flex: 0 0 24px; }
+.service-title{ white-space:normal; line-height:1.2; }
+
+.service-arrow{ width:20px; height:20px; color: var(--amber); transition: transform .25s ease; flex:0 0 20px; }
+.service-card.open .service-arrow{ transform: rotate(180deg); }
+
+.service-content{
+  max-height:0; overflow:hidden; background:#fff; padding:0 16px;
+  transition:max-height .3s ease, padding .3s ease; line-height:1.6;
+}
+.service-card.open .service-content{ max-height:440px; padding:12px 16px 16px; }
+.service-content p{ margin:0; color:#334155; }
+.service-meta{ margin-top:8px; color:#64748b; font-size:13px; }
+
+.ripple::after{
+  content:""; position:absolute; left:var(--rx,50%); top:var(--ry,50%);
+  width:0; height:0; transform:translate(-50%,-50%);
+  background:radial-gradient(circle, #d7c9a9 0%, rgba(215,201,169,0) 70%);
+  opacity:.4; border-radius:50%; pointer-events:none;
+  transition: width .45s ease, height .45s ease, opacity .6s ease;
+}
+.ripple:active::after{ width:220px; height:220px; opacity:.15; }
+
+.services-cta{ display:flex; justify-content:center; padding-top:8px; }
+.services-cta .btn{ appearance:none; border:0; border-radius:999px; padding:10px 16px; font-weight:700; cursor:pointer; }
+.services-cta .btn-primary{ background:var(--amber); color:#1f2937; }
+
+@media (min-width:680px){
+  .service-header{ font-size:17px; }
+}

--- a/assets/js/services.js
+++ b/assets/js/services.js
@@ -1,0 +1,131 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const mount = document.getElementById('services-list');
+  if (!mount) return;
+
+  const RAW_SERVICES = [
+    { title: "Γκρεμίσματα - αποξηλώσεις", desc: "Ασφαλείς κατεδαφίσεις και αποξηλώσεις με έλεγχο σκόνης, προστασία χώρου και υπεύθυνη αποκομιδή μπαζών." },
+    { title: "Χτισίματα - σοβατίσματα", desc: "Χτίσιμο νέων χωρισμάτων/τοιχίων και εφαρμογή σοβάδων για λεία, έτοιμη προς βαφή επιφάνεια." },
+    { title: "Ελαιοχρωματισμοί τοιχοποιίας", desc: "Σωστή προετοιμασία υποστρώματος, αστάρια και βαφές αντοχής για ομοιόμορφο, καθαρό αποτέλεσμα." },
+    { title: "Υδραυλικές εργασίες", desc: "Νέες εγκαταστάσεις και αντικαταστάσεις σωληνώσεων σε μπάνιο/κουζίνα, επισκευές διαρροών και συστήματα θέρμανσης." },
+    { title: "Ηλεκτρολογικές εργασίες", desc: "Νέες γραμμές/πίνακες, φωτισμός, πρίζες/ασφάλειες και πιστοποιήσεις σύμφωνα με τους κανονισμούς ασφαλείας." },
+    { title: "Κουφώματα αλουμινίου - pvc", desc: "Κατασκευή/τοποθέτηση κουφωμάτων αλουμινίου ή PVC με ενεργειακά υαλοστάσια και άριστη στεγάνωση." },
+    { title: "Τοποθέτηση πλακιδίων τοίχου - δαπέδου", desc: "Τοποθέτηση με ευθυγράμμιση, κοπές ακριβείας και άρτιες αρμολογήσεις σε μπάνια, κουζίνες και δάπεδα." },
+    { title: "Πατώματα ξύλινα και laminate", desc: "Τοποθέτηση παρκέ/laminate με κατάλληλα υποστρώματα και καθαρές τελικές λεπτομέρειες." },
+    { title: "Μωσαϊκά δάπεδα", desc: "Επισκευές, τρίψιμο/γυάλισμα και νέες εφαρμογές μωσαϊκού με ανθεκτικές σφραγίσεις." },
+    { title: "Ντουλάπια κουζίνας", desc: "Σχεδιασμός/τοποθέτηση κουζινόπορτων, μηχανισμοί soft-close και εργονομικές αποθηκεύσεις." },
+    { title: "Ντουλάπες", desc: "Ελεύθερες ή εντοιχισμένες ντουλάπες με ποιοτικά φινιρίσματα και λειτουργική εσωτερική διαμόρφωση." },
+    { title: "Πόρτες εισόδου (ασφαλείας) - εσωτερικές πόρτες", desc: "Θωρακισμένες πόρτες εισόδου και εσωτερικές πόρτες με ακριβή εφαρμογή και επιλογές φινιρισμάτων." },
+    { title: "Μονώσεις παντός τύπου", desc: "Θερμομονώσεις/στεγανοποιήσεις ταρατσών και τοιχοποιιών με πιστοποιημένα υλικά και εγγυήσεις εφαρμογής." },
+    { title: "Μεταλλικές κατασκευές", desc: "Κάγκελα, σκάλες, στέγαστρα και ειδικές μεταλλικές λύσεις με ασφάλεια και αντοχή." },
+    { title: "Αποκατάσταση προσόψεων (στηθαία) σε πολυκατοικίες με χρήση σκαλωσιάς", desc: "Επισκευές ρωγμών, αποκατάσταση σοβάδων/στηθαίων και βαφές προσόψεων με όλα τα μέτρα ασφαλείας." }
+  ];
+
+  const ORDER = [
+    "Ηλεκτρολογικές εργασίες",
+    "Υδραυλικές εργασίες",
+    "Τοποθέτηση πλακιδίων τοίχου - δαπέδου",
+    "Κουφώματα αλουμινίου - pvc",
+    "Πατώματα ξύλινα και laminate",
+    "Γκρεμίσματα - αποξηλώσεις",
+    "Χτισίματα - σοβατίσματα",
+    "Ελαιοχρωματισμοί τοιχοποιίας",
+    "Μονώσεις παντός τύπου",
+    "Πόρτες εισόδου (ασφαλείας) - εσωτερικές πόρτες",
+    "Ντουλάπια κουζίνας",
+    "Ντουλάπες",
+    "Μεταλλικές κατασκευές",
+    "Μωσαϊκά δάπεδα",
+    "Αποκατάσταση προσόψεων (στηθαία) σε πολυκατοικίες με χρήση σκαλωσιάς"
+  ];
+
+  const byTitle = new Map(RAW_SERVICES.map(s => [s.title, s]));
+  const SERVICES = ORDER.map(t => byTitle.get(t)).filter(Boolean);
+
+  const ICON_MAP = {
+    "Γκρεμίσματα - αποξηλώσεις": "hammer",
+    "Χτισίματα - σοβατίσματα": "construction",
+    "Ελαιοχρωματισμοί τοιχοποιίας": "paint-roller",
+    "Υδραυλικές εργασίες": "pipe",
+    "Ηλεκτρολογικές εργασίες": "plug",
+    "Κουφώματα αλουμινίου - pvc": "square",
+    "Τοποθέτηση πλακιδίων τοίχου - δαπέδου": "grid",
+    "Πατώματα ξύλινα και laminate": "layers",
+    "Μωσαϊκά δάπεδα": "grid-2x2",
+    "Ντουλάπια κουζίνας": "box",
+    "Ντουλάπες": "boxes",
+    "Πόρτες εισόδου (ασφαλείας) - εσωτερικές πόρτες": "door-closed",
+    "Μονώσεις παντός τύπου": "shield",
+    "Μεταλλικές κατασκευές": "wrench",
+    "Αποκατάσταση προσόψεων (στηθαία) σε πολυκατοικίες με χρήση σκαλωσιάς": "building"
+  };
+
+  const allowedIcons = new Set([
+    "hammer","paint-roller","pipe","plug","square","grid","layers","grid-2x2",
+    "box","boxes","door-closed","door-open","shield","wrench","building","construction"
+  ]);
+
+  function safeIcon(name){
+    const wanted = ICON_MAP[name] || "wrench";
+    return allowedIcons.has(wanted) ? wanted : "wrench";
+  }
+
+  function slugify(s){
+    return s.toLowerCase()
+      .replace(/[ά]/g,'a').replace(/[έ]/g,'e').replace(/[ίϊΐ]/g,'i')
+      .replace(/[ό]/g,'o').replace(/[ύϋΰ]/g,'y').replace(/[ή]/g,'i').replace(/[ώ]/g,'o')
+      .replace(/[^a-z0-9\s-]/g,'').replace(/\s+/g,'-').replace(/-+/g,'-').trim();
+  }
+
+  mount.innerHTML = SERVICES.map(s => cardTpl(s)).join("");
+
+  if (window.lucide && typeof lucide.createIcons === 'function') {
+    lucide.createIcons();
+  }
+
+  document.querySelectorAll('.service-icon[data-lucide]').forEach(el => {
+    if (!el.firstElementChild) {
+      el.setAttribute('data-lucide','wrench');
+    }
+  });
+  document.querySelectorAll('.service-arrow[data-lucide]').forEach(el => {
+    if (!el.firstElementChild) {
+      el.setAttribute('data-lucide','chevron-down');
+    }
+  });
+  if (window.lucide && typeof lucide.createIcons === 'function') {
+    lucide.createIcons();
+  }
+
+  document.querySelectorAll('.service-card .service-header').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const card = btn.closest('.service-card');
+      const open = card.classList.toggle('open');
+      btn.setAttribute('aria-expanded', open);
+    });
+    btn.addEventListener('pointerdown', e => {
+      const r = e.currentTarget.getBoundingClientRect();
+      btn.style.setProperty('--rx', (e.clientX - r.left) + 'px');
+      btn.style.setProperty('--ry', (e.clientY - r.top) + 'px');
+    });
+  });
+
+  function cardTpl(s){
+    const icon = safeIcon(s.title);
+    const id = slugify(s.title);
+    return `
+      <article class="service-card" id="${id}">
+        <button class="service-header ripple" aria-expanded="false" aria-controls="${id}-content">
+          <span class="left">
+            <i class="service-icon" data-lucide="${icon}" aria-hidden="true"></i>
+            <span class="service-title">${s.title}</span>
+          </span>
+          <i class="service-arrow" data-lucide="chevron-down" aria-hidden="true"></i>
+        </button>
+        <div class="service-content" id="${id}-content" role="region" aria-labelledby="${id}">
+          <p>${s.desc}</p>
+          <div class="service-meta">Για μελέτη & προσφορά: <a href="/epikoinonia">επικοινωνήστε μαζί μας</a>.</div>
+        </div>
+      </article>
+    `;
+  }
+});

--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Roboto:wght@700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="assets/style.css">
   <link rel="stylesheet" href="assets/css/lightbox.css">
+  <link rel="stylesheet" href="assets/css/services.css">
   <link rel="icon" type="image/png" href="favicon/favicon-96x96.png" sizes="96x96">
   <link rel="icon" type="image/svg+xml" href="favicon/favicon.svg">
   <link rel="shortcut icon" href="favicon/favicon.ico">
@@ -68,40 +69,40 @@
       "https://www.instagram.com/fm.renovation21/"
     ],
     "makesOffer": [
-      {"@type": "Service", "name": "Γκρεμίσματα – αποξηλώσεις – απομάκρυνση παλαιών υλικών με κάδο"},
-      {"@type": "Service", "name": "Χτισίματα – σοβατίσματα – ελαιοχρωματισμοί τοιχοποιίας"},
+      {"@type": "Service", "name": "Γκρεμίσματα - αποξηλώσεις"},
+      {"@type": "Service", "name": "Χτισίματα - σοβατίσματα"},
+      {"@type": "Service", "name": "Ελαιοχρωματισμοί τοιχοποιίας"},
       {"@type": "Service", "name": "Υδραυλικές εργασίες"},
-      {"@type": "Service", "name": "Ηλεκτρολογικές εργασίες – Έκδοση Υ.Δ.Ε."},
-      {"@type": "Service", "name": "Κουφώματα αλουμινίου – PVC"},
-      {"@type": "Service", "name": "Τοποθέτηση πλακιδίων τοίχου – δαπέδου"},
-      {"@type": "Service", "name": "Τοποθέτηση πατωμάτων laminate – αποκατάσταση ξύλινων πατωμάτων"},
-      {"@type": "Service", "name": "Τρίψιμο – γυάλισμα μωσαϊκών δαπέδων"},
-      {"@type": "Service", "name": "Κατασκευή – τοποθέτηση ντουλαπιών κουζίνας"},
-      {"@type": "Service", "name": "Κατασκευή – τοποθέτηση ντουλαπών"},
-      {"@type": "Service", "name": "Πόρτες εισόδου (ασφαλείας) – εσωτερικές πόρτες"},
-      {"@type": "Service", "name": "Μεταλλικές κατασκευές"},
+      {"@type": "Service", "name": "Ηλεκτρολογικές εργασίες"},
+      {"@type": "Service", "name": "Κουφώματα αλουμινίου - pvc"},
+      {"@type": "Service", "name": "Τοποθέτηση πλακιδίων τοίχου - δαπέδου"},
+      {"@type": "Service", "name": "Πατώματα ξύλινα και laminate"},
+      {"@type": "Service", "name": "Μωσαϊκά δάπεδα"},
+      {"@type": "Service", "name": "Ντουλάπια κουζίνας"},
+      {"@type": "Service", "name": "Ντουλάπες"},
+      {"@type": "Service", "name": "Πόρτες εισόδου (ασφαλείας) - εσωτερικές πόρτες"},
       {"@type": "Service", "name": "Μονώσεις παντός τύπου"},
-      {"@type": "Service", "name": "Έκδοση οικοδομικών αδειών"},
+      {"@type": "Service", "name": "Μεταλλικές κατασκευές"},
       {"@type": "Service", "name": "Αποκατάσταση προσόψεων (στηθαία) σε πολυκατοικίες με χρήση σκαλωσιάς"}
     ],
     "hasOfferCatalog": {
       "@type": "OfferCatalog",
       "name": "Υπηρεσίες Ανακαινίσεων",
       "itemListElement": [
-        {"@type": "Offer", "itemOffered": {"@type": "Service", "name": "Γκρεμίσματα – αποξηλώσεις – απομάκρυνση παλαιών υλικών με κάδο"}},
-        {"@type": "Offer", "itemOffered": {"@type": "Service", "name": "Χτισίματα – σοβατίσματα – ελαιοχρωματισμοί τοιχοποιίας"}},
+        {"@type": "Offer", "itemOffered": {"@type": "Service", "name": "Γκρεμίσματα - αποξηλώσεις"}},
+        {"@type": "Offer", "itemOffered": {"@type": "Service", "name": "Χτισίματα - σοβατίσματα"}},
+        {"@type": "Offer", "itemOffered": {"@type": "Service", "name": "Ελαιοχρωματισμοί τοιχοποιίας"}},
         {"@type": "Offer", "itemOffered": {"@type": "Service", "name": "Υδραυλικές εργασίες"}},
-        {"@type": "Offer", "itemOffered": {"@type": "Service", "name": "Ηλεκτρολογικές εργασίες – Έκδοση Υ.Δ.Ε."}},
-        {"@type": "Offer", "itemOffered": {"@type": "Service", "name": "Κουφώματα αλουμινίου – PVC"}},
-        {"@type": "Offer", "itemOffered": {"@type": "Service", "name": "Τοποθέτηση πλακιδίων τοίχου – δαπέδου"}},
-        {"@type": "Offer", "itemOffered": {"@type": "Service", "name": "Τοποθέτηση πατωμάτων laminate – αποκατάσταση ξύλινων πατωμάτων"}},
-        {"@type": "Offer", "itemOffered": {"@type": "Service", "name": "Τρίψιμο – γυάλισμα μωσαϊκών δαπέδων"}},
-        {"@type": "Offer", "itemOffered": {"@type": "Service", "name": "Κατασκευή – τοποθέτηση ντουλαπιών κουζίνας"}},
-        {"@type": "Offer", "itemOffered": {"@type": "Service", "name": "Κατασκευή – τοποθέτηση ντουλαπών"}},
-        {"@type": "Offer", "itemOffered": {"@type": "Service", "name": "Πόρτες εισόδου (ασφαλείας) – εσωτερικές πόρτες"}},
-        {"@type": "Offer", "itemOffered": {"@type": "Service", "name": "Μεταλλικές κατασκευές"}},
+        {"@type": "Offer", "itemOffered": {"@type": "Service", "name": "Ηλεκτρολογικές εργασίες"}},
+        {"@type": "Offer", "itemOffered": {"@type": "Service", "name": "Κουφώματα αλουμινίου - pvc"}},
+        {"@type": "Offer", "itemOffered": {"@type": "Service", "name": "Τοποθέτηση πλακιδίων τοίχου - δαπέδου"}},
+        {"@type": "Offer", "itemOffered": {"@type": "Service", "name": "Πατώματα ξύλινα και laminate"}},
+        {"@type": "Offer", "itemOffered": {"@type": "Service", "name": "Μωσαϊκά δάπεδα"}},
+        {"@type": "Offer", "itemOffered": {"@type": "Service", "name": "Ντουλάπια κουζίνας"}},
+        {"@type": "Offer", "itemOffered": {"@type": "Service", "name": "Ντουλάπες"}},
+        {"@type": "Offer", "itemOffered": {"@type": "Service", "name": "Πόρτες εισόδου (ασφαλείας) - εσωτερικές πόρτες"}},
         {"@type": "Offer", "itemOffered": {"@type": "Service", "name": "Μονώσεις παντός τύπου"}},
-        {"@type": "Offer", "itemOffered": {"@type": "Service", "name": "Έκδοση οικοδομικών αδειών"}},
+        {"@type": "Offer", "itemOffered": {"@type": "Service", "name": "Μεταλλικές κατασκευές"}},
         {"@type": "Offer", "itemOffered": {"@type": "Service", "name": "Αποκατάσταση προσόψεων (στηθαία) σε πολυκατοικίες με χρήση σκαλωσιάς"}}
       ]
     }
@@ -201,195 +202,21 @@
       </div>
     </section>
 
-    <!-- SERVICES: grid με hover (scale + shadow). σε mobile tap/active -->
-    <section id="services" class="section section--muted">
-      <div class="container">
-        <h2>Υπηρεσίες</h2>
-        <section class="services">
-          <article class="service-card reveal" id="service-demolition">
-            <button class="service-header ripple" type="button" aria-expanded="false">
-              <span class="service-title">Γκρεμίσματα – αποξηλώσεις – απομάκρυνση παλαιών υλικών με κάδο</span>
-              <svg class="arrow" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true">
-                <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2"/>
-              </svg>
-            </button>
-            <div class="service-content">
-              <p>Οργανώνουμε <a href="#service-demolition" class="service__internal">γκρεμίσματα και αποξηλώσεις</a> με ασφαλιστική κάλυψη, καθαρή απομάκρυνση μπαζών και προστασία κοινόχρηστων χώρων σε όλη την Αττική.</p>
-              <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
-            </div>
-          </article>
-          <article class="service-card reveal" id="service-masonry">
-            <button class="service-header ripple" type="button" aria-expanded="false">
-              <span class="service-title">Χτισίματα – σοβατίσματα – ελαιοχρωματισμοί τοιχοποιίας</span>
-              <svg class="arrow" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true">
-                <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2"/>
-              </svg>
-            </button>
-            <div class="service-content">
-              <p>Εφαρμόζουμε επιμελημένα χτισίματα και σοβατίσματα, ενώ οι <a href="#service-masonry" class="service__internal">ελαιοχρωματισμοί τοιχοποιίας</a> προσφέρουν ομοιομορφία και αντοχή στον χρόνο.</p>
-              <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
-            </div>
-          </article>
-          <article class="service-card reveal" id="service-plumbing">
-            <button class="service-header ripple" type="button" aria-expanded="false">
-              <span class="service-title">Υδραυλικές εργασίες</span>
-              <svg class="arrow" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true">
-                <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2"/>
-              </svg>
-            </button>
-            <div class="service-content">
-              <p>Οι τεχνικοί μας για <a href="#service-plumbing" class="service__internal">υδραυλικές εργασίες</a> εγκαθιστούν δίκτυα με ανθεκτικά υλικά, ελέγχουν διαρροές και εξασφαλίζουν σταθερή παροχή νερού.</p>
-              <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
-            </div>
-          </article>
-          <article class="service-card reveal" id="service-electrical">
-            <button class="service-header ripple" type="button" aria-expanded="false">
-              <span class="service-title">Ηλεκτρολογικές εργασίες – Έκδοση Υ.Δ.Ε.</span>
-              <svg class="arrow" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true">
-                <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2"/>
-              </svg>
-            </button>
-            <div class="service-content">
-              <p>Σχεδιάζουμε <a href="#service-electrical" class="service__internal">ηλεκτρολογικές εργασίες</a> με μελέτες φορτίων, αναβαθμισμένους πίνακες και υπεύθυνη έκδοση Υ.Δ.Ε. για έργα στην Αθήνα.</p>
-              <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
-            </div>
-          </article>
-          <article class="service-card reveal" id="service-frames">
-            <button class="service-header ripple" type="button" aria-expanded="false">
-              <span class="service-title">Κουφώματα αλουμινίου – PVC</span>
-              <svg class="arrow" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true">
-                <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2"/>
-              </svg>
-            </button>
-            <div class="service-content">
-              <p>Τοποθετούμε <a href="#service-frames" class="service__internal">κουφώματα αλουμινίου και PVC</a> με θερμοδιακοπή και ασφαλή στεγανότητα για άνεση και αισθητική σε κάθε χώρο.</p>
-              <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
-            </div>
-          </article>
-          <article class="service-card reveal" id="service-tiles">
-            <button class="service-header ripple" type="button" aria-expanded="false">
-              <span class="service-title">Τοποθέτηση πλακιδίων τοίχου – δαπέδου</span>
-              <svg class="arrow" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true">
-                <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2"/>
-              </svg>
-            </button>
-            <div class="service-content">
-              <p>Αναλαμβάνουμε <a href="#service-tiles" class="service__internal">τοποθέτηση πλακιδίων</a> με προσοχή στη λεπτομέρεια, ακριβείς κοπές και αρμολόγηση που αντέχει στον χρόνο.</p>
-              <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
-            </div>
-          </article>
-          <article class="service-card reveal" id="service-flooring">
-            <button class="service-header ripple" type="button" aria-expanded="false">
-              <span class="service-title">Τοποθέτηση πατωμάτων laminate – αποκατάσταση ξύλινων πατωμάτων</span>
-              <svg class="arrow" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true">
-                <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2"/>
-              </svg>
-            </button>
-            <div class="service-content">
-              <p>Προσφέρουμε <a href="#service-flooring" class="service__internal">τοποθέτηση laminate</a> και αποκατάσταση ξύλινων δαπέδων με ειδικούς τεχνίτες για ανθεκτικότητα και αισθητική.</p>
-              <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
-            </div>
-          </article>
-          <article class="service-card reveal" id="service-mosaic">
-            <button class="service-header ripple" type="button" aria-expanded="false">
-              <span class="service-title">Τρίψιμο – γυάλισμα μωσαϊκών δαπέδων</span>
-              <svg class="arrow" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true">
-                <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2"/>
-              </svg>
-            </button>
-            <div class="service-content">
-              <p>Εξειδικευόμαστε σε <a href="#service-mosaic" class="service__internal">τρίψιμο και γυάλισμα μωσαϊκών</a> δαπέδων με εξοπλισμό τελευταίας τεχνολογίας για ομοιόμορφη επιφάνεια.</p>
-              <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
-            </div>
-          </article>
-          <article class="service-card reveal" id="service-kitchen-cabinets">
-            <button class="service-header ripple" type="button" aria-expanded="false">
-              <span class="service-title">Κατασκευή – τοποθέτηση ντουλαπιών κουζίνας</span>
-              <svg class="arrow" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true">
-                <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2"/>
-              </svg>
-            </button>
-            <div class="service-content">
-              <p>Δημιουργούμε <a href="#service-kitchen-cabinets" class="service__internal">εξατομικευμένα ντουλάπια κουζίνας</a> με εργονομικό σχεδιασμό, ανθεκτικά υλικά και άψογο φινίρισμα.</p>
-              <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
-            </div>
-          </article>
-          <article class="service-card reveal" id="service-wardrobes">
-            <button class="service-header ripple" type="button" aria-expanded="false">
-              <span class="service-title">Κατασκευή – τοποθέτηση ντουλαπών</span>
-              <svg class="arrow" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true">
-                <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2"/>
-              </svg>
-            </button>
-            <div class="service-content">
-              <p>Σχεδιάζουμε <a href="#service-wardrobes" class="service__internal">ντουλάπες</a> με εργονομικούς μηχανισμούς, εσωτερικές διαμορφώσεις και αισθητικές επιλογές που ταιριάζουν στον χώρο σας.</p>
-              <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
-            </div>
-          </article>
-          <article class="service-card reveal" id="service-doors">
-            <button class="service-header ripple" type="button" aria-expanded="false">
-              <span class="service-title">Πόρτες εισόδου (ασφαλείας) – εσωτερικές πόρτες</span>
-              <svg class="arrow" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true">
-                <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2"/>
-              </svg>
-            </button>
-            <div class="service-content">
-              <p>Παρέχουμε <a href="#service-doors" class="service__internal">πόρτες ασφαλείας και εσωτερικές πόρτες</a> με πιστοποιήσεις, ηχομονωτικές λύσεις και ακριβή τοποθέτηση για μέγιστη λειτουργικότητα.</p>
-              <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
-            </div>
-          </article>
-          <article class="service-card reveal" id="service-metal">
-            <button class="service-header ripple" type="button" aria-expanded="false">
-              <span class="service-title">Μεταλλικές κατασκευές</span>
-              <svg class="arrow" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true">
-                <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2"/>
-              </svg>
-            </button>
-            <div class="service-content">
-              <p>Μελετάμε <a href="#service-metal" class="service__internal">μεταλλικές κατασκευές</a> μικρής και μεγάλης κλίμακας, εξασφαλίζοντας στατική επάρκεια, προστασία από διάβρωση και άψογη εφαρμογή.</p>
-              <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
-            </div>
-          </article>
-          <article class="service-card reveal" id="service-insulation">
-            <button class="service-header ripple" type="button" aria-expanded="false">
-              <span class="service-title">Μονώσεις παντός τύπου</span>
-              <svg class="arrow" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true">
-                <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2"/>
-              </svg>
-            </button>
-            <div class="service-content">
-              <p>Προτείνουμε <a href="#service-insulation" class="service__internal">μονώσεις παντός τύπου</a> με θερμοπρόσοψη, υγρομόνωση και λύσεις εξοικονόμησης που βελτιώνουν την ενεργειακή απόδοση στην Αττική.</p>
-              <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
-            </div>
-          </article>
-          <article class="service-card reveal" id="service-permits">
-            <button class="service-header ripple" type="button" aria-expanded="false">
-              <span class="service-title">Έκδοση οικοδομικών αδειών</span>
-              <svg class="arrow" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true">
-                <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2"/>
-              </svg>
-            </button>
-            <div class="service-content">
-              <p>Αναλαμβάνουμε <a href="#service-permits" class="service__internal">έκδοση οικοδομικών αδειών</a> με πλήρη φάκελο μελετών, συντονισμό με υπηρεσίες και συνεχή ενημέρωση για κάθε στάδιο.</p>
-              <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
-            </div>
-          </article>
-          <article class="service-card reveal" id="service-facade">
-            <button class="service-header ripple" type="button" aria-expanded="false">
-              <span class="service-title">Αποκατάσταση προσόψεων (στηθαία) σε πολυκατοικίες με χρήση σκαλωσιάς</span>
-              <svg class="arrow" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true">
-                <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2"/>
-              </svg>
-            </button>
-            <div class="service-content">
-              <p>Οργανώνουμε <a href="#service-facade" class="service__internal">αποκατάσταση προσόψεων</a> με ασφαλή σκαλωσιά, αποκαθιστούμε στηθαία και εφαρμόζουμε νέες επιστρώσεις για πολυκατοικίες στην Αττική.</p>
-              <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
-            </div>
-          </article>
-        </section>
-        <div class="under-cta"><a href="#contact" class="btn btn--primary">Θέλω Προσφορά για Υπηρεσία</a></div>
+    <!-- SERVICES -->
+    <section id="services" class="services" aria-labelledby="services-title">
+      <h2 class="section-title" id="services-title">Υπηρεσίες</h2>
+      <p class="section-sub">Ολοκληρωμένες εργασίες ανακαίνισης με ασφάλεια, συνέπεια και πιστοποιημένα υλικά.</p>
+
+      <!-- Auto-generated list -->
+      <div id="services-list"></div>
+
+      <div class="services-cta">
+        <a class="btn btn-primary" href="/epikoinonia">Ζητήστε Προσφορά</a>
       </div>
     </section>
+
+    <!-- Lucide icons -->
+    <script src="https://unpkg.com/lucide@latest"></script>
 
     <!-- PROCESS -->
     <section id="process" class="section-light">
@@ -693,6 +520,7 @@
     </button>
   </div>
 
+  <script src="assets/js/services.js" defer></script>
   <script src="assets/js/lightbox.js" defer></script>
   <script src="assets/app.js" defer></script>
 </body>


### PR DESCRIPTION
## Summary
- replace the services section with a Lucide-powered accordion fed from the new services list and CTA to /epikoinonia
- add dedicated CSS/JS assets to render the services with safe icon mapping, ripple/toggle behavior, and anchor slugs
- align the LocalBusiness structured data entries with the refreshed services catalog

## Testing
- python -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_6900ccfaaea08320a9c5be4ae14a1b52