### PR TITLE
Replace services accordion with responsive card grid

### DIFF
--- a/assets/css/services.css
+++ b/assets/css/services.css
@@ -1,0 +1,119 @@
+:root{
+  --amber:#F59E0B;
+  --slate:#0F172A;
+  --muted:#64748b;
+  --card:#ffffff;
+  --bg:#f8fafc;
+}
+
+#services{background:var(--bg);}
+
+.services{
+  padding:32px 16px;
+  max-width:1200px;
+  margin:0 auto;
+}
+
+.services-head{
+  text-align:center;
+  margin-bottom:12px;
+}
+
+.section-title{
+  margin:0 0 6px;
+  font-size:clamp(24px,3.2vw,36px);
+  color:var(--slate);
+}
+
+.section-sub{
+  margin:0;
+  color:#475569;
+}
+
+.services-grid{
+  display:grid;
+  gap:16px;
+  margin-top:16px;
+  grid-template-columns:1fr;
+}
+
+@media (min-width:640px){
+  .services-grid{grid-template-columns:1fr 1fr;}
+}
+
+@media (min-width:1024px){
+  .services-grid{grid-template-columns:1fr 1fr 1fr;}
+}
+
+.svc{
+  background:var(--card);
+  border-radius:16px;
+  padding:16px;
+  box-shadow:0 2px 8px rgba(0,0,0,.06);
+  display:flex;
+  flex-direction:column;
+  gap:8px;
+  min-height:180px;
+  transform:translateZ(0);
+}
+
+.svc-icon svg{
+  width:28px;
+  height:28px;
+  color:var(--amber);
+}
+
+.svc-title{
+  margin:2px 0 0;
+  font-size:18px;
+  color:var(--slate);
+}
+
+.svc-desc{
+  margin:0;
+  color:#334155;
+  line-height:1.55;
+}
+
+@media (hover:hover){
+  .svc{
+    transition:transform .18s ease, box-shadow .18s ease;
+  }
+  .svc:hover{
+    transform:translateY(-3px);
+    box-shadow:0 8px 24px rgba(0,0,0,.10);
+  }
+}
+
+.services-cta{
+  display:flex;
+  justify-content:center;
+  margin-top:12px;
+}
+
+.services-btn{
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  gap:8px;
+  padding:10px 20px;
+  border-radius:999px;
+  font-weight:700;
+  text-decoration:none;
+  color:#1f2937;
+  background:var(--amber);
+  box-shadow:0 6px 18px rgba(245,158,11,.28);
+  transition:transform .18s ease, box-shadow .18s ease;
+}
+
+.services-btn:hover,
+.services-btn:focus-visible{
+  transform:translateY(-2px);
+  box-shadow:0 12px 28px rgba(245,158,11,.36);
+  outline:none;
+}
+
+@media (prefers-reduced-motion: reduce){
+  .svc{transition:none;}
+  .services-btn{transition:none;}
+}

--- a/assets/style.css
+++ b/assets/style.css
@@ -125,43 +125,6 @@ body.nav-open{overflow:hidden}
 .about-grid{display:grid;gap:20px}
 .bullets{padding-left:18px}
 
-/* Services */
-.services{padding:12px;}
-.service-card{background:#fff;border-radius:16px;box-shadow:0 2px 6px rgba(0,0,0,.06);margin:12px 0;overflow:hidden;transform:translateZ(0);transition:box-shadow .25s ease;}
-.service-card.open{box-shadow:0 6px 18px rgba(0,0,0,.10);}
-.service-header{-webkit-tap-highlight-color:transparent;width:100%;display:flex;align-items:center;justify-content:space-between;background:#F9FAFB;border:0;padding:14px 16px;text-align:left;font-weight:700;font-size:16px;color:#0F172A;position:relative;overflow:hidden;}
-.service-title{white-space:normal;line-height:1.25;}
-.arrow{color:#F59E0B;transition:transform .25s ease;}
-.service-card.open .arrow{transform:rotate(180deg);}
-.service-content{max-height:0;overflow:hidden;background:#fff;padding:0 16px;transition:max-height .3s ease,padding .3s ease;line-height:1.6;}
-.service-card.open .service-content{max-height:600px;padding:12px 16px 16px;}
-.service-content p{margin:0 0 12px;color:rgba(15,23,42,.9);}
-.service-content p:last-child{margin-bottom:0;}
-.service__internal{color:var(--accent);font-weight:600;text-decoration:underline;text-decoration-thickness:2px;text-decoration-color:rgba(245,158,11,.45);transition:color .2s ease,text-decoration-color .2s ease;}
-.service__internal:hover,
-.service__internal:focus-visible{color:#b45309;text-decoration-color:#b45309;outline:none;}
-.service__cta{display:inline-flex;align-items:center;gap:6px;margin-top:8px;font-weight:600;color:var(--accent-2);text-decoration:underline;transition:color .2s ease;}
-.service__cta:hover,
-.service__cta:focus-visible{color:var(--accent);outline:none;}
-/* Tap ripple (radial fill #d7c9a9) */
-.ripple::after{content:"";position:absolute;left:var(--rx,50%);top:var(--ry,50%);width:0;height:0;transform:translate(-50%,-50%);background:radial-gradient(circle,#d7c9a9 0%,rgba(215,201,169,0) 70%);opacity:.4;border-radius:50%;pointer-events:none;transition:width .45s ease,height .45s ease,opacity .6s ease;}
-.ripple:active::after{width:220px;height:220px;opacity:.15;}
-/* Scroll-reveal */
-.reveal{opacity:0;transform:translateY(16px);transition:opacity .45s ease,transform .45s ease;}
-.reveal.in{opacity:1;transform:translateY(0);}
-@media (min-width:480px){.service-header{font-size:17px;}}
-@media (min-width:640px){
-  .services{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:18px;}
-  .service-card{margin:0;}
-}
-@media (min-width:1024px){
-  .services{grid-template-columns:repeat(3,minmax(0,1fr));}
-}
-.under-cta{text-align:center;margin-top:18px;}
-.under-cta .btn{font-weight:700;}
-.under-cta .btn:hover,
-.under-cta .btn:focus-visible{color:var(--accent-2);}
-
 /* Process & Reasons */
 .section-light{background:linear-gradient(180deg,#ffffff 0%,#f5f7fa 100%);padding:72px 0}
 .subtitle{margin:12px 0 32px;font-size:1.125rem;font-weight:500;opacity:.85;max-width:720px}

--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Roboto:wght@700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="assets/style.css">
+  <link rel="stylesheet" href="assets/css/services.css">
   <link rel="stylesheet" href="assets/css/lightbox.css">
   <link rel="icon" type="image/png" href="favicon/favicon-96x96.png" sizes="96x96">
   <link rel="icon" type="image/svg+xml" href="favicon/favicon.svg">
@@ -201,193 +202,127 @@
       </div>
     </section>
 
-    <!-- SERVICES: grid με hover (scale + shadow). σε mobile tap/active -->
-    <section id="services" class="section section--muted">
-      <div class="container">
-        <h2>Υπηρεσίες</h2>
-        <section class="services">
-          <article class="service-card reveal" id="service-demolition">
-            <button class="service-header ripple" type="button" aria-expanded="false">
-              <span class="service-title">Γκρεμίσματα – αποξηλώσεις – απομάκρυνση παλαιών υλικών με κάδο</span>
-              <svg class="arrow" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true">
-                <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2"/>
-              </svg>
-            </button>
-            <div class="service-content">
-              <p>Οργανώνουμε <a href="#service-demolition" class="service__internal">γκρεμίσματα και αποξηλώσεις</a> με ασφαλιστική κάλυψη, καθαρή απομάκρυνση μπαζών και προστασία κοινόχρηστων χώρων σε όλη την Αττική.</p>
-              <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
-            </div>
-          </article>
-          <article class="service-card reveal" id="service-masonry">
-            <button class="service-header ripple" type="button" aria-expanded="false">
-              <span class="service-title">Χτισίματα – σοβατίσματα – ελαιοχρωματισμοί τοιχοποιίας</span>
-              <svg class="arrow" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true">
-                <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2"/>
-              </svg>
-            </button>
-            <div class="service-content">
-              <p>Εφαρμόζουμε επιμελημένα χτισίματα και σοβατίσματα, ενώ οι <a href="#service-masonry" class="service__internal">ελαιοχρωματισμοί τοιχοποιίας</a> προσφέρουν ομοιομορφία και αντοχή στον χρόνο.</p>
-              <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
-            </div>
-          </article>
-          <article class="service-card reveal" id="service-plumbing">
-            <button class="service-header ripple" type="button" aria-expanded="false">
-              <span class="service-title">Υδραυλικές εργασίες</span>
-              <svg class="arrow" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true">
-                <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2"/>
-              </svg>
-            </button>
-            <div class="service-content">
-              <p>Οι τεχνικοί μας για <a href="#service-plumbing" class="service__internal">υδραυλικές εργασίες</a> εγκαθιστούν δίκτυα με ανθεκτικά υλικά, ελέγχουν διαρροές και εξασφαλίζουν σταθερή παροχή νερού.</p>
-              <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
-            </div>
-          </article>
-          <article class="service-card reveal" id="service-electrical">
-            <button class="service-header ripple" type="button" aria-expanded="false">
-              <span class="service-title">Ηλεκτρολογικές εργασίες – Έκδοση Υ.Δ.Ε.</span>
-              <svg class="arrow" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true">
-                <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2"/>
-              </svg>
-            </button>
-            <div class="service-content">
-              <p>Σχεδιάζουμε <a href="#service-electrical" class="service__internal">ηλεκτρολογικές εργασίες</a> με μελέτες φορτίων, αναβαθμισμένους πίνακες και υπεύθυνη έκδοση Υ.Δ.Ε. για έργα στην Αθήνα.</p>
-              <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
-            </div>
-          </article>
-          <article class="service-card reveal" id="service-frames">
-            <button class="service-header ripple" type="button" aria-expanded="false">
-              <span class="service-title">Κουφώματα αλουμινίου – PVC</span>
-              <svg class="arrow" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true">
-                <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2"/>
-              </svg>
-            </button>
-            <div class="service-content">
-              <p>Τοποθετούμε <a href="#service-frames" class="service__internal">κουφώματα αλουμινίου και PVC</a> με θερμοδιακοπή και ασφαλή στεγανότητα για άνεση και αισθητική σε κάθε χώρο.</p>
-              <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
-            </div>
-          </article>
-          <article class="service-card reveal" id="service-tiles">
-            <button class="service-header ripple" type="button" aria-expanded="false">
-              <span class="service-title">Τοποθέτηση πλακιδίων τοίχου – δαπέδου</span>
-              <svg class="arrow" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true">
-                <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2"/>
-              </svg>
-            </button>
-            <div class="service-content">
-              <p>Αναλαμβάνουμε <a href="#service-tiles" class="service__internal">τοποθέτηση πλακιδίων</a> με προσοχή στη λεπτομέρεια, ακριβείς κοπές και αρμολόγηση που αντέχει στον χρόνο.</p>
-              <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
-            </div>
-          </article>
-          <article class="service-card reveal" id="service-flooring">
-            <button class="service-header ripple" type="button" aria-expanded="false">
-              <span class="service-title">Τοποθέτηση πατωμάτων laminate – αποκατάσταση ξύλινων πατωμάτων</span>
-              <svg class="arrow" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true">
-                <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2"/>
-              </svg>
-            </button>
-            <div class="service-content">
-              <p>Προσφέρουμε <a href="#service-flooring" class="service__internal">τοποθέτηση laminate</a> και αποκατάσταση ξύλινων δαπέδων με ειδικούς τεχνίτες για ανθεκτικότητα και αισθητική.</p>
-              <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
-            </div>
-          </article>
-          <article class="service-card reveal" id="service-mosaic">
-            <button class="service-header ripple" type="button" aria-expanded="false">
-              <span class="service-title">Τρίψιμο – γυάλισμα μωσαϊκών δαπέδων</span>
-              <svg class="arrow" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true">
-                <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2"/>
-              </svg>
-            </button>
-            <div class="service-content">
-              <p>Εξειδικευόμαστε σε <a href="#service-mosaic" class="service__internal">τρίψιμο και γυάλισμα μωσαϊκών</a> δαπέδων με εξοπλισμό τελευταίας τεχνολογίας για ομοιόμορφη επιφάνεια.</p>
-              <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
-            </div>
-          </article>
-          <article class="service-card reveal" id="service-kitchen-cabinets">
-            <button class="service-header ripple" type="button" aria-expanded="false">
-              <span class="service-title">Κατασκευή – τοποθέτηση ντουλαπιών κουζίνας</span>
-              <svg class="arrow" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true">
-                <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2"/>
-              </svg>
-            </button>
-            <div class="service-content">
-              <p>Δημιουργούμε <a href="#service-kitchen-cabinets" class="service__internal">εξατομικευμένα ντουλάπια κουζίνας</a> με εργονομικό σχεδιασμό, ανθεκτικά υλικά και άψογο φινίρισμα.</p>
-              <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
-            </div>
-          </article>
-          <article class="service-card reveal" id="service-wardrobes">
-            <button class="service-header ripple" type="button" aria-expanded="false">
-              <span class="service-title">Κατασκευή – τοποθέτηση ντουλαπών</span>
-              <svg class="arrow" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true">
-                <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2"/>
-              </svg>
-            </button>
-            <div class="service-content">
-              <p>Σχεδιάζουμε <a href="#service-wardrobes" class="service__internal">ντουλάπες</a> με εργονομικούς μηχανισμούς, εσωτερικές διαμορφώσεις και αισθητικές επιλογές που ταιριάζουν στον χώρο σας.</p>
-              <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
-            </div>
-          </article>
-          <article class="service-card reveal" id="service-doors">
-            <button class="service-header ripple" type="button" aria-expanded="false">
-              <span class="service-title">Πόρτες εισόδου (ασφαλείας) – εσωτερικές πόρτες</span>
-              <svg class="arrow" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true">
-                <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2"/>
-              </svg>
-            </button>
-            <div class="service-content">
-              <p>Παρέχουμε <a href="#service-doors" class="service__internal">πόρτες ασφαλείας και εσωτερικές πόρτες</a> με πιστοποιήσεις, ηχομονωτικές λύσεις και ακριβή τοποθέτηση για μέγιστη λειτουργικότητα.</p>
-              <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
-            </div>
-          </article>
-          <article class="service-card reveal" id="service-metal">
-            <button class="service-header ripple" type="button" aria-expanded="false">
-              <span class="service-title">Μεταλλικές κατασκευές</span>
-              <svg class="arrow" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true">
-                <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2"/>
-              </svg>
-            </button>
-            <div class="service-content">
-              <p>Μελετάμε <a href="#service-metal" class="service__internal">μεταλλικές κατασκευές</a> μικρής και μεγάλης κλίμακας, εξασφαλίζοντας στατική επάρκεια, προστασία από διάβρωση και άψογη εφαρμογή.</p>
-              <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
-            </div>
-          </article>
-          <article class="service-card reveal" id="service-insulation">
-            <button class="service-header ripple" type="button" aria-expanded="false">
-              <span class="service-title">Μονώσεις παντός τύπου</span>
-              <svg class="arrow" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true">
-                <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2"/>
-              </svg>
-            </button>
-            <div class="service-content">
-              <p>Προτείνουμε <a href="#service-insulation" class="service__internal">μονώσεις παντός τύπου</a> με θερμοπρόσοψη, υγρομόνωση και λύσεις εξοικονόμησης που βελτιώνουν την ενεργειακή απόδοση στην Αττική.</p>
-              <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
-            </div>
-          </article>
-          <article class="service-card reveal" id="service-permits">
-            <button class="service-header ripple" type="button" aria-expanded="false">
-              <span class="service-title">Έκδοση οικοδομικών αδειών</span>
-              <svg class="arrow" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true">
-                <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2"/>
-              </svg>
-            </button>
-            <div class="service-content">
-              <p>Αναλαμβάνουμε <a href="#service-permits" class="service__internal">έκδοση οικοδομικών αδειών</a> με πλήρη φάκελο μελετών, συντονισμό με υπηρεσίες και συνεχή ενημέρωση για κάθε στάδιο.</p>
-              <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
-            </div>
-          </article>
-          <article class="service-card reveal" id="service-facade">
-            <button class="service-header ripple" type="button" aria-expanded="false">
-              <span class="service-title">Αποκατάσταση προσόψεων (στηθαία) σε πολυκατοικίες με χρήση σκαλωσιάς</span>
-              <svg class="arrow" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true">
-                <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2"/>
-              </svg>
-            </button>
-            <div class="service-content">
-              <p>Οργανώνουμε <a href="#service-facade" class="service__internal">αποκατάσταση προσόψεων</a> με ασφαλή σκαλωσιά, αποκαθιστούμε στηθαία και εφαρμόζουμε νέες επιστρώσεις για πολυκατοικίες στην Αττική.</p>
-              <a href="#contact" class="link service__cta">Ζητήστε Προσφορά</a>
-            </div>
-          </article>
-        </section>
-        <div class="under-cta"><a href="#contact" class="btn btn--primary">Θέλω Προσφορά για Υπηρεσία</a></div>
+    <section id="services" class="services" aria-labelledby="services-title">
+      <!-- Inline SVG sprite (icons local, no CDN) -->
+      <svg xmlns="http://www.w3.org/2000/svg" style="display:none">
+        <symbol id="ic-hammer" viewBox="0 0 24 24"><path d="M2 22l7-7m2-9l3-3 5 5-3 3M3 21l5-5m6-10l5 5M6 16l2 2" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/></symbol>
+        <symbol id="ic-brick" viewBox="0 0 24 24"><path d="M3 8h18M3 16h18M3 12h8m2 0h8" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round"/></symbol>
+        <symbol id="ic-roller" viewBox="0 0 24 24"><path d="M3 6h10v4H3zM13 8h6a2 2 0 012 2v1M9 10v9" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round"/></symbol>
+        <symbol id="ic-pipe" viewBox="0 0 24 24"><path d="M3 10h6v4H3zm6 2h6a3 3 0 003-3V3M15 12v9" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round"/></symbol>
+        <symbol id="ic-plug" viewBox="0 0 24 24"><path d="M7 2v6m10-6v6M6 8h12v4a6 6 0 11-12 0V8z" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round"/></symbol>
+        <symbol id="ic-frame" viewBox="0 0 24 24"><rect x="3" y="5" width="18" height="14" rx="1.5" ry="1.5" stroke="currentColor" stroke-width="2" fill="none"/></symbol>
+        <symbol id="ic-tiles" viewBox="0 0 24 24"><path d="M3 3h8v8H3zM13 3h8v8h-8zM3 13h8v8H3zM13 13h8v8h-8z" stroke="currentColor" stroke-width="2" fill="none"/></symbol>
+        <symbol id="ic-layers" viewBox="0 0 24 24"><path d="M12 3l9 5-9 5-9-5 9-5zm0 14l-7-4m14 0l-7 4" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round"/></symbol>
+        <symbol id="ic-mosaic" viewBox="0 0 24 24"><path d="M3 3h6v6H3zM9 3h12v12H9zM3 9h6v12H3z" stroke="currentColor" stroke-width="2" fill="none"/></symbol>
+        <symbol id="ic-cabinet" viewBox="0 0 24 24"><path d="M4 4h16v16H4zM9 4v16M15 4v16M8 9h2M14 9h2" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round"/></symbol>
+        <symbol id="ic-wardrobe" viewBox="0 0 24 24"><path d="M5 3h14v18H5zM12 3v18M9 12h1M14 12h1" stroke="currentColor" stroke-width="2" fill="none"/></symbol>
+        <symbol id="ic-door" viewBox="0 0 24 24"><path d="M6 3h12v18H6zM14 12h1" stroke="currentColor" stroke-width="2" fill="none"/></symbol>
+        <symbol id="ic-shield" viewBox="0 0 24 24"><path d="M12 3l7 3v6c0 5-3.5 7.5-7 9-3.5-1.5-7-4-7-9V6l7-3z" stroke="currentColor" stroke-width="2" fill="none"/></symbol>
+        <symbol id="ic-wrench" viewBox="0 0 24 24"><path d="M14 7a4 4 0 10-5 5l-6 6 3 3 6-6a4 4 0 005-5z" stroke="currentColor" stroke-width="2" fill="none"/></symbol>
+        <symbol id="ic-building" viewBox="0 0 24 24"><path d="M4 21V5l8-3 8 3v16M9 9h2m2 0h2m-6 4h2m2 0h2m-6 4h2m2 0h2" stroke="currentColor" stroke-width="2" fill="none"/></symbol>
+      </svg>
+
+      <header class="services-head">
+        <h2 class="section-title" id="services-title">Υπηρεσίες</h2>
+        <p class="section-sub">Ολοκληρωμένες λύσεις ανακαίνισης με ασφάλεια, συνέπεια και πιστοποιημένα υλικά.</p>
+      </header>
+
+      <div class="services-grid">
+        <!-- ΚΑΡΤΕΛΕΣ ΥΠΗΡΕΣΙΩΝ (στατικές, χωρίς JS) -->
+        <!-- Για κάθε κάρτα: αλλάζεις μόνο title, icon, περιγραφή & id anchor -->
+        <article class="svc" id="gkremismata-apoksiloseis">
+          <div class="svc-icon"><svg><use href="#ic-hammer"/></svg></div>
+          <h3 class="svc-title">Γκρεμίσματα - αποξηλώσεις</h3>
+          <p class="svc-desc">Ασφαλείς κατεδαφίσεις και αποξηλώσεις με έλεγχο σκόνης, προστασία χώρου και υπεύθυνη αποκομιδή μπαζών.</p>
+        </article>
+
+        <article class="svc" id="chtisimata-sovatismata">
+          <div class="svc-icon"><svg><use href="#ic-brick"/></svg></div>
+          <h3 class="svc-title">Χτισίματα - σοβατίσματα</h3>
+          <p class="svc-desc">Νέα χωρίσματα/τοιχία και εφαρμογή σοβάδων για λεία, έτοιμη προς βαφή επιφάνεια.</p>
+        </article>
+
+        <article class="svc" id="elaiokhromatismoi-toichopoiias">
+          <div class="svc-icon"><svg><use href="#ic-roller"/></svg></div>
+          <h3 class="svc-title">Ελαιοχρωματισμοί τοιχοποιίας</h3>
+          <p class="svc-desc">Προσεκτική προετοιμασία, αστάρια και βαφές αντοχής για ομοιόμορφο, καθαρό αποτέλεσμα.</p>
+        </article>
+
+        <article class="svc" id="ydravlikes-ergasies">
+          <div class="svc-icon"><svg><use href="#ic-pipe"/></svg></div>
+          <h3 class="svc-title">Υδραυλικές εργασίες</h3>
+          <p class="svc-desc">Εγκαταστάσεις/αντικαταστάσεις σωληνώσεων σε μπάνιο/κουζίνα, επισκευές διαρροών, θέρμανση.</p>
+        </article>
+
+        <article class="svc" id="ilektrologikes-ergasies">
+          <div class="svc-icon"><svg><use href="#ic-plug"/></svg></div>
+          <h3 class="svc-title">Ηλεκτρολογικές εργασίες</h3>
+          <p class="svc-desc">Νέες γραμμές &amp; πίνακες, φωτισμός και πιστοποιήσεις σύμφωνα με τους κανονισμούς ασφαλείας.</p>
+        </article>
+
+        <article class="svc" id="koufomata-alouminiou-pvc">
+          <div class="svc-icon"><svg><use href="#ic-frame"/></svg></div>
+          <h3 class="svc-title">Κουφώματα αλουμινίου - PVC</h3>
+          <p class="svc-desc">Κατασκευή &amp; τοποθέτηση κουφωμάτων με ενεργειακά υαλοστάσια και άριστη στεγάνωση.</p>
+        </article>
+
+        <article class="svc" id="topothetisi-plakidion">
+          <div class="svc-icon"><svg><use href="#ic-tiles"/></svg></div>
+          <h3 class="svc-title">Τοποθέτηση πλακιδίων τοίχου - δαπέδου</h3>
+          <p class="svc-desc">Ευθυγράμμιση, κοπές ακριβείας και αρμολογήσεις σε μπάνια, κουζίνες και δάπεδα υψηλής καταπόνησης.</p>
+        </article>
+
+        <article class="svc" id="patomata-xylina-laminate">
+          <div class="svc-icon"><svg><use href="#ic-layers"/></svg></div>
+          <h3 class="svc-title">Πατώματα ξύλινα και laminate</h3>
+          <p class="svc-desc">Τοποθέτηση παρκέ/laminate με κατάλληλα υποστρώματα και καθαρές τελικές λεπτομέρειες.</p>
+        </article>
+
+        <article class="svc" id="mosaika-dapeda">
+          <div class="svc-icon"><svg><use href="#ic-mosaic"/></svg></div>
+          <h3 class="svc-title">Μωσαϊκά δάπεδα</h3>
+          <p class="svc-desc">Επισκευές, τρίψιμο/γυάλισμα και νέες εφαρμογές μωσαϊκού με ανθεκτικές σφραγίσεις.</p>
+        </article>
+
+        <article class="svc" id="ntoulapia-kouzinas">
+          <div class="svc-icon"><svg><use href="#ic-cabinet"/></svg></div>
+          <h3 class="svc-title">Ντουλάπια κουζίνας</h3>
+          <p class="svc-desc">Σχεδιασμός &amp; τοποθέτηση, μηχανισμοί soft-close και εργονομικές αποθηκεύσεις.</p>
+        </article>
+
+        <article class="svc" id="ntoulapes">
+          <div class="svc-icon"><svg><use href="#ic-wardrobe"/></svg></div>
+          <h3 class="svc-title">Ντουλάπες</h3>
+          <p class="svc-desc">Ελεύθερες ή εντοιχισμένες ντουλάπες με ποιοτικά φινιρίσματα και λειτουργική εσωτερική διαμόρφωση.</p>
+        </article>
+
+        <article class="svc" id="portes-eisodou-esoterikes">
+          <div class="svc-icon"><svg><use href="#ic-door"/></svg></div>
+          <h3 class="svc-title">Πόρτες εισόδου (ασφαλείας) – εσωτερικές πόρτες</h3>
+          <p class="svc-desc">Θωρακισμένες εισόδου &amp; εσωτερικές πόρτες με ακριβή εφαρμογή και επιλογές φινιρισμάτων.</p>
+        </article>
+
+        <article class="svc" id="monoseis">
+          <div class="svc-icon"><svg><use href="#ic-shield"/></svg></div>
+          <h3 class="svc-title">Μονώσεις παντός τύπου</h3>
+          <p class="svc-desc">Θερμομονώσεις &amp; στεγανοποιήσεις ταρατσών/τοιχοποιίας με πιστοποιημένα υλικά και εγγυήσεις.</p>
+        </article>
+
+        <article class="svc" id="metallikes-kataskeves">
+          <div class="svc-icon"><svg><use href="#ic-wrench"/></svg></div>
+          <h3 class="svc-title">Μεταλλικές κατασκευές</h3>
+          <p class="svc-desc">Κάγκελα, σκάλες, στέγαστρα και ειδικές μεταλλικές λύσεις με αντοχή και ασφάλεια.</p>
+        </article>
+
+        <article class="svc" id="apokatastasi-prosopson-skalo">
+          <div class="svc-icon"><svg><use href="#ic-building"/></svg></div>
+          <h3 class="svc-title">Αποκατάσταση προσόψεων (στηθαία) με σκαλωσιά</h3>
+          <p class="svc-desc">Επισκευές ρωγμών, αποκατάσταση σοβάδων/στηθαίων και βαφές προσόψεων με πλήρη μέτρα ασφαλείας.</p>
+        </article>
+      </div>
+
+      <div class="services-cta">
+        <a class="services-btn" href="/epikoinonia">Ζητήστε Προσφορά</a>
       </div>
     </section>
 


### PR DESCRIPTION
## Summary
- replace the accordion-style services section with a responsive card grid using inline SVG icons and CTA
- add dedicated services stylesheet to style the grid layout, hover elevation, and CTA button
- remove obsolete accordion-specific styles from the global stylesheet and load the new services CSS in the page head

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_6900d52f4c8c83208312267d69ca4b86