### PR TITLE
Add metal works gallery to erga page

### DIFF
--- a/assets/css/erga.css
+++ b/assets/css/erga.css
@@ -337,6 +337,63 @@
   color: var(--erga-slate);
 }
 
+.metal-works {
+  padding: 32px 16px 16px;
+  background: #f8fafc;
+}
+
+.metal-works__inner {
+  max-width: 1080px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.metal-works__title {
+  margin: 0;
+  font-size: clamp(26px, 4vw, 34px);
+  text-align: center;
+  color: var(--erga-slate);
+}
+
+.metal-works__grid {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.metal-works__item {
+  margin: 0;
+  border-radius: 18px;
+  overflow: hidden;
+  background: #e2e8f0;
+  aspect-ratio: 4 / 3;
+}
+
+.metal-works__item img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+@media (min-width: 720px) {
+  .metal-works {
+    padding: 48px 24px 24px;
+  }
+
+  .metal-works__grid {
+    gap: 20px;
+  }
+}
+
+@media (max-width: 620px) {
+  .metal-works__grid {
+    grid-template-columns: 1fr;
+  }
+}
+
 @media (max-width: 420px) {
   .card-footer {
     flex-direction: column;

--- a/erga.html
+++ b/erga.html
@@ -87,6 +87,26 @@
     <p>Ενδεικτικά projects με καθαρές φωτογραφίες, συνοπτικές πληροφορίες και πρόσβαση σε ολόκληρο το φωτογραφικό υλικό.</p>
   </header>
 
+  <section class="metal-works" aria-labelledby="metal-works-title">
+    <div class="metal-works__inner">
+      <h2 id="metal-works-title" class="metal-works__title">Μεταλλικές Κατασκευές</h2>
+      <div class="metal-works__grid">
+        <figure class="metal-works__item">
+          <img src="erga/metal1.jpg" alt="Μεταλλική κατασκευή 1" loading="lazy">
+        </figure>
+        <figure class="metal-works__item">
+          <img src="erga/metal2.jpg" alt="Μεταλλική κατασκευή 2" loading="lazy">
+        </figure>
+        <figure class="metal-works__item">
+          <img src="erga/metal3.jpg" alt="Μεταλλική κατασκευή 3" loading="lazy">
+        </figure>
+        <figure class="metal-works__item">
+          <img src="erga/metal4.jpg" alt="Μεταλλική κατασκευή 4" loading="lazy">
+        </figure>
+      </div>
+    </div>
+  </section>
+
   <main id="projects" class="projects" data-json="data/projects.json"></main>
 
   <div class="lb" id="lightbox" aria-hidden="true" tabindex="-1">


### PR DESCRIPTION
## Summary
- add a "Μεταλλικές Κατασκευές" section to the projects page with a dedicated 2x2 gallery
- style the new section so the metal works photos display in a responsive grid

## Testing
- not run (static changes)

------
https://chatgpt.com/codex/tasks/task_e_6904fffcf2188320824bc6d99213889a