### PR TITLE
Reorder metal works section on projects page

### DIFF
--- a/erga.html
+++ b/erga.html
@@ -87,6 +87,8 @@
     <p>Ενδεικτικά projects με καθαρές φωτογραφίες, συνοπτικές πληροφορίες και πρόσβαση σε ολόκληρο το φωτογραφικό υλικό.</p>
   </header>
 
+  <main id="projects" class="projects" data-json="data/projects.json"></main>
+
   <section class="metal-works" aria-labelledby="metal-works-title">
     <div class="metal-works__inner">
       <h2 id="metal-works-title" class="metal-works__title">Μεταλλικές Κατασκευές</h2>
@@ -106,8 +108,6 @@
       </div>
     </div>
   </section>
-
-  <main id="projects" class="projects" data-json="data/projects.json"></main>
 
   <div class="lb" id="lightbox" aria-hidden="true" tabindex="-1">
     <div class="lb-backdrop" data-lb-close></div>


### PR DESCRIPTION
## Summary
- move the metal works section to the bottom of the projects page so it appears after the main project listing

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_69074ffb49588320af9de67761b99aba