### PR TITLE
Enforce lazy-loading policy and tooling

### DIFF
--- a/docs/lazy-loading-audit.md
+++ b/docs/lazy-loading-audit.md
@@ -1,0 +1,88 @@
+# Lazy loading audit
+
+The audit verifies that all non-LCP images opt into `loading="lazy"` and `decoding="async"`, while above-the-fold assets keep eager behaviour.
+
+## Automated summary
+
+Command: `npm run audit:lazy --silent`
+
+```
+Lazy-loading audit report
+================================
+
+No images missing loading="lazy" outside approved exceptions.
+
+Allowed exceptions (not lazied intentionally):
+  - erga.html:32 (hero/logo or above-the-fold) → <img class="brand-logo" src="images/logo.png" alt="FM Renovation λογότυπο" width="1024" height="1024" fetchpriority="high" decoding="sync">
+  - erga.html:117 (lightbox full-size image) → <img id="lb-img" class="lb-img" alt="" decoding="async">
+  - index.html:90 (hero/logo or above-the-fold) → <img class="brand-logo" src="images/logo.png" alt="FM Renovation λογότυπο" width="1024" height="1024" fetchpriority="high" decoding="sync">
+  - index.html:151 (hero/logo or above-the-fold) → <img data-hero src="https://images.unsplash.com/photo-1505691938895-1758d7feb511?q=80&w=1600&auto=format&fit=crop" width="1600" height="1067" alt="Ανακαίνιση σαλονιού στην Αθήνα από FM Renovation με νέα διάταξη επίπλων και φωτισμό που αναδεικνύει τον χώρο της κατοικίας." fetchpriority="high" decoding="sync">
+  - index.html:513 (lightbox full-size image) → <img id="lb-img" class="lb-img" alt="" decoding="async">
+  - privacy-policy.html:25 (hero/logo or above-the-fold) → <img class="brand-logo" src="images/logo.png" alt="FM Renovation λογότυπο" width="1024" height="1024" fetchpriority="high" decoding="sync">
+  - terms.html:25 (hero/logo or above-the-fold) → <img class="brand-logo" src="images/logo.png" alt="FM Renovation λογότυπο" width="1024" height="1024" fetchpriority="high" decoding="sync">
+
+No additional issues detected.
+```
+
+## ripgrep spot checks
+
+The following commands exclude `node_modules/`, build artefacts, tooling, and documentation to focus on rendered assets.
+
+### 1. `<img>` elements without `loading`
+
+Command:
+
+```
+rg -n --pcre2 --glob '!node_modules' --glob '!dist' --glob '!build' --glob '!tools/**' --glob '!docs/**' '<img(?![^>]*\bloading=)[^>]*>' .
+```
+
+Output:
+
+```
+./privacy-policy.html
+25:          <img class="brand-logo" src="images/logo.png" alt="FM Renovation λογότυπο" width="1024" height="1024" fetchpriority="high" decoding="sync">
+
+./erga.html
+32:          <img class="brand-logo" src="images/logo.png" alt="FM Renovation λογότυπο" width="1024" height="1024" fetchpriority="high" decoding="sync">
+117:      <img id="lb-img" class="lb-img" alt="" decoding="async">
+
+./index.html
+90:          <img class="brand-logo" src="images/logo.png" alt="FM Renovation λογότυπο" width="1024" height="1024" fetchpriority="high" decoding="sync">
+151:        <img data-hero src="https://images.unsplash.com/photo-1505691938895-1758d7feb511?q=80&w=1600&auto=format&fit=crop" width="1600" height="1067" alt="Ανακαίνιση σαλονιού στην Αθήνα από FM Renovation με νέα διάταξη επίπλων και φωτισμό που αναδεικνύει τον χώρο της κατοικίας." fetchpriority="high" decoding="sync">
+513:      <img id="lb-img" class="lb-img" alt="" decoding="async">
+
+./terms.html
+25:          <img class="brand-logo" src="images/logo.png" alt="FM Renovation λογότυπο" width="1024" height="1024" fetchpriority="high" decoding="sync">
+```
+
+All matches are intentional eager loads (hero/logo or lightbox canvases).
+
+### 2. `<picture>` blocks with inner `<img>` missing `loading`
+
+Command:
+
+```
+rg -n --pcre2 --glob '!node_modules' --glob '!dist' --glob '!build' --glob '!tools/**' --glob '!docs/**' '<picture>[\s\S]*?<img(?![^>]*\bloading=)[^>]*>[\s\S]*?</picture>' .
+```
+
+Output: _none_
+
+### 3. JavaScript image creation without lazy hints
+
+Command:
+
+```
+rg -n --pcre2 --glob '!node_modules' --glob '!dist' --glob '!build' --glob '!tools/**' --glob '!docs/**' 'new Image\(|document\.createElement\(['\"']img['\"']\)|\.innerHTML\s*=\s*`[^`]*<img' .
+```
+
+Output: _none_
+
+### 4. Gallery thumbnails missing `loading="lazy"`
+
+Command:
+
+```
+rg -n --pcre2 --glob '!node_modules' --glob '!dist' --glob '!build' --glob '!tools/**' --glob '!docs/**' '<img[^>]*(class="[^"]*(thumb|strip|gallery)[^"]*")[^>]*>(?!.*\bloading="lazy")' .
+```
+
+Output: _none_

--- a/docs/lazy-loading.md
+++ b/docs/lazy-loading.md
@@ -1,0 +1,15 @@
+# Lazy loading policy
+
+This site prioritises Largest Contentful Paint (LCP) and scroll performance. Apply the following rules when adding or updating media elements:
+
+- **Hero, LCP, and primary logo images**: keep them eager. Do not add `loading="lazy"`; instead, set `fetchpriority="high"` and prefer `decoding="sync"` so that the browser decodes them immediately.
+- **Above-the-fold illustrations** (e.g. within the first viewport) should follow the same eager loading rules as the hero so that they contribute positively to LCP.
+- **Below-the-fold content images** must set `loading="lazy"` and `decoding="async"` to defer work until the user scrolls near them.
+- **Thumbnails, carousel slides, and gallery strips** should always be lazy-loaded; include the async decoding hint as well.
+- **Lightbox full-size images** are loaded on demand by JavaScript. Keep them eager once requested, but make sure thumbnails that launch the lightbox are lazy.
+- **`<picture>` elements** still apply the lazy attributes on the inner `<img>` element (the `<source>` tags stay unchanged).
+- **Images generated from JavaScript** should have `img.loading = 'lazy'` and `img.decoding = 'async'` by default. Only skip these hints for hero/LCP placeholders.
+- **Width and height attributes**: whenever the intrinsic dimensions of an image are known, include `width` and `height` to avoid layout shifts.
+- **Content images in CSS backgrounds** are discouraged because they cannot be lazy-loaded. Replace them with semantic `<img>` elements where practical.
+
+Review new pages against `npm run audit:lazy` to ensure the policy is respected.

--- a/erga.html
+++ b/erga.html
@@ -29,7 +29,7 @@
     <div class="container header-inner">
       <div class="brand">
         <a href="index.html" class="logo-link" aria-label="Αρχική σελίδα">
-          <img class="brand-logo" src="images/logo.png" alt="FM Renovation λογότυπο">
+          <img class="brand-logo" src="images/logo.png" alt="FM Renovation λογότυπο" width="1024" height="1024" fetchpriority="high" decoding="sync">
         </a>
         <span class="brand-tagline"><strong>Ανακαίνιση χώρου</strong></span>
       </div>
@@ -94,16 +94,16 @@
       <h2 id="metal-works-title" class="metal-works__title">Μεταλλικές Κατασκευές</h2>
       <div class="metal-works__grid">
         <figure class="metal-works__item">
-          <img src="erga/metal1.jpg" alt="Μεταλλική κατασκευή 1" loading="lazy">
+          <img src="erga/metal1.jpg" alt="Μεταλλική κατασκευή 1" width="670" height="512" loading="lazy" decoding="async">
         </figure>
         <figure class="metal-works__item">
-          <img src="erga/metal2.jpg" alt="Μεταλλική κατασκευή 2" loading="lazy">
+          <img src="erga/metal2.jpg" alt="Μεταλλική κατασκευή 2" width="693" height="512" loading="lazy" decoding="async">
         </figure>
         <figure class="metal-works__item">
-          <img src="erga/metal3.jpg" alt="Μεταλλική κατασκευή 3" loading="lazy">
+          <img src="erga/metal3.jpg" alt="Μεταλλική κατασκευή 3" width="662" height="512" loading="lazy" decoding="async">
         </figure>
         <figure class="metal-works__item">
-          <img src="erga/metal4.jpg" alt="Μεταλλική κατασκευή 4" loading="lazy">
+          <img src="erga/metal4.jpg" alt="Μεταλλική κατασκευή 4" width="677" height="512" loading="lazy" decoding="async">
         </figure>
       </div>
     </div>
@@ -114,7 +114,7 @@
     <figure class="lb-frame" role="dialog" aria-modal="true" aria-label="Προβολή εικόνας">
       <button class="lb-close" aria-label="Κλείσιμο" data-lb-close>×</button>
       <button class="lb-nav lb-prev" aria-label="Προηγούμενη">‹</button>
-      <img id="lb-img" class="lb-img" alt="">
+      <img id="lb-img" class="lb-img" alt="" decoding="async">
       <button class="lb-nav lb-next" aria-label="Επόμενη">›</button>
       <figcaption class="lb-meta"><span id="lb-count">1/1</span></figcaption>
     </figure>
@@ -154,7 +154,7 @@
       <div class="footer-brand">
         <div class="brand brand--footer">
           <a href="index.html" class="logo-link" aria-label="Αρχική σελίδα">
-            <img class="brand-logo" src="images/logo.png" alt="FM Renovation λογότυπο">
+            <img class="brand-logo" src="images/logo.png" alt="FM Renovation λογότυπο" width="1024" height="1024" loading="lazy" decoding="async">
           </a>
         </div>
         <nav class="footer-links" aria-label="Χρήσιμες σύνδεσμοι">
@@ -181,13 +181,13 @@
     <div id="contactWidgetPanel" class="contact-widget__panel" aria-hidden="true">
       <a class="contact-widget__link" href="mailto:info@example.com">
         <span class="contact-widget__icon" aria-hidden="true">
-          <img src="images/icons/email.svg" width="36" height="36" alt="" loading="lazy">
+          <img src="images/icons/email.svg" width="36" height="36" alt="" loading="lazy" decoding="async">
         </span>
         <span>Email</span>
       </a>
       <a class="contact-widget__link" href="viber://chat?number=+300000000000">
         <span class="contact-widget__icon" aria-hidden="true">
-          <img src="images/icons/viber.svg" width="36" height="36" alt="" loading="lazy">
+          <img src="images/icons/viber.svg" width="36" height="36" alt="" loading="lazy" decoding="async">
         </span>
         <span>Viber</span>
       </a>

--- a/erga.html
+++ b/erga.html
@@ -6,7 +6,8 @@
   <title>Έργα Ανακαινίσεων | FM Renovation</title>
   <meta name="description" content="Δείτε αντιπροσωπευτικά έργα ανακαινίσεων σε κουζίνες, μπάνια και εσωτερικούς χώρους. Φωτογραφίες, περιγραφές και λεπτομέρειες.">
   <link rel="canonical" href="https://anakainisou.gr/erga">
-  <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Roboto:wght@700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="assets/style.css">
   <link rel="stylesheet" href="assets/css/erga.css">
@@ -29,7 +30,7 @@
     <div class="container header-inner">
       <div class="brand">
         <a href="index.html" class="logo-link" aria-label="Αρχική σελίδα">
-          <img class="brand-logo" src="images/logo.png" alt="FM Renovation λογότυπο" width="1024" height="1024" fetchpriority="high" decoding="sync">
+          <img class="brand-logo" src="images/logo.png" alt="FM Renovation λογότυπο" width="1024" height="1024" decoding="sync">
         </a>
         <span class="brand-tagline"><strong>Ανακαίνιση χώρου</strong></span>
       </div>

--- a/index.html
+++ b/index.html
@@ -87,7 +87,7 @@
     <div class="container header-inner">
       <div class="brand">
         <a href="index.html" class="logo-link" aria-label="Αρχική σελίδα">
-          <img class="brand-logo" src="images/logo.png" alt="FM Renovation λογότυπο">
+          <img class="brand-logo" src="images/logo.png" alt="FM Renovation λογότυπο" width="1024" height="1024" fetchpriority="high" decoding="sync">
         </a>
         <span class="brand-tagline"><strong>Ανακαίνιση χώρου</strong></span>
       </div>
@@ -148,11 +148,11 @@
     <section class="hero">
       <figure class="hero-slider" aria-label="Προβολή έργων">
         <!-- Χρησιμοποιούμε καθαρές εικόνες από Unsplash για άμεση προεπισκόπηση -->
-        <img data-hero src="https://images.unsplash.com/photo-1505691938895-1758d7feb511?q=80&w=1600&auto=format&fit=crop" width="1600" height="1067" alt="Ανακαίνιση σαλονιού στην Αθήνα από FM Renovation με νέα διάταξη επίπλων και φωτισμό που αναδεικνύει τον χώρο της κατοικίας.">
-        <img data-hero src="https://images.unsplash.com/photo-1501045661006-fcebe0257c3f?q=80&w=1600&auto=format&fit=crop" width="1600" height="1067" loading="lazy" alt="Ανακαίνιση κουζίνας στην Αθήνα από FM Renovation με εργονομικές λύσεις και φωτεινά υλικά για σύγχρονη καθημερινότητα.">
-        <img data-hero src="https://images.unsplash.com/photo-1505691723518-36a5ac3b2d55?q=80&w=1600&auto=format&fit=crop" width="1600" height="1067" loading="lazy" alt="Ανακαίνιση επαγγελματικού χώρου στην Αττική από FM Renovation με προσεγμένο φωτισμό και καθαρές γραμμές για λειτουργική εργασία.">
-        <img data-hero src="https://images.unsplash.com/photo-1484154218962-a197022b5858?q=80&w=1600&auto=format&fit=crop" width="1600" height="1067" loading="lazy" alt="Ανακαίνιση μπάνιου στην Αθήνα από FM Renovation με μινιμαλιστική αισθητική και ανθεκτικά υλικά για καθημερινή άνεση.">
-        <img data-hero src="https://images.unsplash.com/photo-1494526585095-c41746248156?q=80&w=1600&auto=format&fit=crop" width="1600" height="1067" loading="lazy" alt="Ανακαίνιση υπνοδωματίου στην Αττική από FM Renovation με γήινους τόνους και φωτισμό που προσφέρει ζεστή ατμόσφαιρα χαλάρωσης.">
+        <img data-hero src="https://images.unsplash.com/photo-1505691938895-1758d7feb511?q=80&w=1600&auto=format&fit=crop" width="1600" height="1067" alt="Ανακαίνιση σαλονιού στην Αθήνα από FM Renovation με νέα διάταξη επίπλων και φωτισμό που αναδεικνύει τον χώρο της κατοικίας." fetchpriority="high" decoding="sync">
+        <img data-hero src="https://images.unsplash.com/photo-1501045661006-fcebe0257c3f?q=80&w=1600&auto=format&fit=crop" width="1600" height="1067" loading="lazy" decoding="async" alt="Ανακαίνιση κουζίνας στην Αθήνα από FM Renovation με εργονομικές λύσεις και φωτεινά υλικά για σύγχρονη καθημερινότητα.">
+        <img data-hero src="https://images.unsplash.com/photo-1505691723518-36a5ac3b2d55?q=80&w=1600&auto=format&fit=crop" width="1600" height="1067" loading="lazy" decoding="async" alt="Ανακαίνιση επαγγελματικού χώρου στην Αττική από FM Renovation με προσεγμένο φωτισμό και καθαρές γραμμές για λειτουργική εργασία.">
+        <img data-hero src="https://images.unsplash.com/photo-1484154218962-a197022b5858?q=80&w=1600&auto=format&fit=crop" width="1600" height="1067" loading="lazy" decoding="async" alt="Ανακαίνιση μπάνιου στην Αθήνα από FM Renovation με μινιμαλιστική αισθητική και ανθεκτικά υλικά για καθημερινή άνεση.">
+        <img data-hero src="https://images.unsplash.com/photo-1494526585095-c41746248156?q=80&w=1600&auto=format&fit=crop" width="1600" height="1067" loading="lazy" decoding="async" alt="Ανακαίνιση υπνοδωματίου στην Αττική από FM Renovation με γήινους τόνους και φωτισμό που προσφέρει ζεστή ατμόσφαιρα χαλάρωσης.">
       </figure>
       <div class="container hero-inner">
         <div class="hero-copy">
@@ -311,7 +311,7 @@
               <h4>Επίσκεψη<br>στον χώρο</h4>
             </div>
             <p>Επισκεπτόμαστε παρουσία σας το χώρο που θέλετε να ανακαινίσετε.</p>
-            <img src="images/visit.jpg" width="1200" height="800" alt="Επίσκεψη τεχνικού της FM Renovation στον χώρο του πελάτη" loading="lazy">
+            <img src="images/visit.jpg" width="1200" height="800" alt="Επίσκεψη τεχνικού της FM Renovation στον χώρο του πελάτη" loading="lazy" decoding="async">
           </div>
 
           <div class="step" data-animate="fade-up">
@@ -320,7 +320,7 @@
               <h4>Καταγραφή επιθυμιών</h4>
             </div>
             <p>Καταγράφουμε τις αλλαγές που θέλετε να γίνουν κι ακούμε με προσοχή τις επιθυμίες σας.</p>
-            <img src="https://images.unsplash.com/photo-1521737604893-d14cc237f11d?q=80&w=1200&auto=format&fit=crop" width="1200" height="800" alt="Καταγραφή αναγκών και επιθυμιών πελάτη" loading="lazy">
+            <img src="https://images.unsplash.com/photo-1521737604893-d14cc237f11d?q=80&w=1200&auto=format&fit=crop" width="1200" height="800" alt="Καταγραφή αναγκών και επιθυμιών πελάτη" loading="lazy" decoding="async">
           </div>
 
           <div class="step" data-animate="fade-up">
@@ -329,7 +329,7 @@
               <h4>Οικονομική προσφορά</h4>
             </div>
             <p>Μέσα στις επόμενες ημέρες λαμβάνετε γραπτή οικονομική προσφορά.</p>
-            <img src="https://images.unsplash.com/photo-1521790797524-b2497295b8a0?q=80&w=1200&auto=format&fit=crop" width="1200" height="800" alt="Παράδοση γραπτής οικονομικής προσφοράς" loading="lazy">
+            <img src="https://images.unsplash.com/photo-1521790797524-b2497295b8a0?q=80&w=1200&auto=format&fit=crop" width="1200" height="800" alt="Παράδοση γραπτής οικονομικής προσφοράς" loading="lazy" decoding="async">
           </div>
 
           <div class="step" data-animate="fade-up">
@@ -338,7 +338,7 @@
               <h4>Συμφωνία &amp; Προγραμματισμός</h4>
             </div>
             <p>Με την έγκριση της προσφοράς μας, συντάσσεται ιδιωτικό συμφωνητικό που καταγράφει τις εργασίες, το χρονοδιάγραμμα και τον τρόπο πληρωμής.</p>
-            <img src="https://images.unsplash.com/photo-1520607162513-77705c0f0d4a?q=80&w=1200&auto=format&fit=crop" width="1200" height="800" alt="Υπογραφή συμφωνητικού και προγραμματισμός έργου" loading="lazy">
+            <img src="https://images.unsplash.com/photo-1520607162513-77705c0f0d4a?q=80&w=1200&auto=format&fit=crop" width="1200" height="800" alt="Υπογραφή συμφωνητικού και προγραμματισμός έργου" loading="lazy" decoding="async">
           </div>
 
           <div class="step" data-animate="fade-up">
@@ -347,7 +347,7 @@
               <h4>Εκτέλεση &amp; Παράδοση</h4>
             </div>
             <p>Οι εργασίες ξεκινούν κι ο πελάτης ενημερώνεται αναλυτικά για κάθε στάδιό τους. Ο χώρος παραδίδεται με το πέρας των εργασιών, έτοιμος προς χρήση.</p>
-            <img src="https://images.unsplash.com/photo-1505691938895-1758d7feb511?q=80&w=1200&auto=format&fit=crop" width="1200" height="800" alt="Παράδοση ολοκληρωμένου έργου ανακαίνισης" loading="lazy">
+            <img src="https://images.unsplash.com/photo-1505691938895-1758d7feb511?q=80&w=1200&auto=format&fit=crop" width="1200" height="800" alt="Παράδοση ολοκληρωμένου έργου ανακαίνισης" loading="lazy" decoding="async">
           </div>
 
         </div>
@@ -366,7 +366,7 @@
         <div class="reasons-list">
 
           <div class="reason" data-animate="fade-up">
-            <img src="https://images.unsplash.com/photo-1484154218962-a197022b5858?q=80&w=1200&auto=format&fit=crop" width="1200" height="800" alt="Εξειδικευμένα συνεργεία της FM Renovation κατά τη διάρκεια έργου ανακαίνισης" loading="lazy">
+            <img src="https://images.unsplash.com/photo-1484154218962-a197022b5858?q=80&w=1200&auto=format&fit=crop" width="1200" height="800" alt="Εξειδικευμένα συνεργεία της FM Renovation κατά τη διάρκεια έργου ανακαίνισης" loading="lazy" decoding="async">
             <h4>Εμπιστοσύνη &amp; Επαγγελματισμός</h4>
             <p>Η ανακαίνιση, ολική ή μερική, είναι μια διαδικασία πολυδιάστατη.<br><br>
               Η εταιρεία μας αναλαμβάνει υπεύθυνα την υλοποίησή της από το Α ως το Ω, απαλλάσσοντάς σας από το άγχος.<br><br>
@@ -374,7 +374,7 @@
           </div>
 
           <div class="reason" data-animate="fade-up">
-            <img src="https://images.unsplash.com/photo-1497366216548-37526070297c?q=80&w=1200&auto=format&fit=crop" width="1200" height="800" alt="Ενημέρωση πελάτη για την πρόοδο έργου ανακαίνισης της FM Renovation" loading="lazy">
+            <img src="https://images.unsplash.com/photo-1497366216548-37526070297c?q=80&w=1200&auto=format&fit=crop" width="1200" height="800" alt="Ενημέρωση πελάτη για την πρόοδο έργου ανακαίνισης της FM Renovation" loading="lazy" decoding="async">
             <h4>Διαφάνεια &amp; Ενημέρωση</h4>
             <p>Το έργο παραδίδεται ολοκληρωμένο, “με το κλειδί στο χέρι” και με γραπτή εγγύηση ποιότητας.<br><br>
               Οι τιμές μας είναι οι πλέον ανταγωνιστικές της αγοράς και το πλάνο πληρωμών τέτοιο ώστε να ανταποκρίνεται στις δυνατότητές σας.</p>
@@ -395,21 +395,21 @@
         <div class="carousel" data-carousel>
           <button class="car-btn prev" aria-label="Προηγούμενη">‹</button>
           <div class="car-track" data-track>
-            <img class="car-img" src="photos/fm1.jpg" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – ανακαίνιση καθιστικού με σύγχρονη διαρρύθμιση.">
-            <img class="car-img" src="photos/fm2.jpg" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – ανανεωμένη κουζίνα με λειτουργική εργονομία.">
-            <img class="car-img" src="photos/fm3.jpg" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – ανακαινισμένο μπάνιο με μοντέρνα αισθητική.">
-            <img class="car-img" src="photos/fm4.jpg" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – φωτεινός ενιαίος χώρος σαλονιού.">
-            <img class="car-img" src="photos/fm5.jpg" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – ανακαινισμένο υπνοδωμάτιο με γήινες αποχρώσεις.">
-            <img class="car-img" src="photos/fm6.jpg" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – λεπτομέρειες κουζίνας με ποιοτικά υλικά.">
-            <img class="car-img" src="photos/fm7.jpg" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – διαμόρφωση καθιστικού με ξύλινες υφές.">
-            <img class="car-img" src="photos/fm8.jpg" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – σύγχρονο μπάνιο με μινιμαλιστική γραμμή.">
-            <img class="car-img" src="photos/fm9.jpg" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – ανανεωμένος χώρος εργασίας με άπλετο φως.">
-            <img class="car-img" src="photos/fm10.jpg" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – καθιστικό με έμφαση στη λεπτομέρεια.">
-            <img class="car-img" src="photos/fm11.jpg" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – χώροι φιλοξενίας με ζεστή ατμόσφαιρα.">
-            <img class="car-img" src="photos/fm12.jpg" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – πλήρης ανακαίνιση κουζίνας.">
-            <img class="car-img" src="photos/fm13.jpg" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – σύγχρονος χώρος διαβίωσης με καθαρές γραμμές.">
-            <img class="car-img" src="photos/fm14.jpg" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – λεπτομέρειες σαλονιού με κομψό φωτισμό.">
-            <img class="car-img" src="photos/fm15.jpg" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – φωτεινός χώρος τραπεζαρίας σε πρόσφατη ανακαίνιση.">
+            <img class="car-img" src="photos/fm1.jpg" width="600" height="600" loading="lazy" decoding="async" alt="Έργο FM Renovation – ανακαίνιση καθιστικού με σύγχρονη διαρρύθμιση.">
+            <img class="car-img" src="photos/fm2.jpg" width="600" height="600" loading="lazy" decoding="async" alt="Έργο FM Renovation – ανανεωμένη κουζίνα με λειτουργική εργονομία.">
+            <img class="car-img" src="photos/fm3.jpg" width="600" height="600" loading="lazy" decoding="async" alt="Έργο FM Renovation – ανακαινισμένο μπάνιο με μοντέρνα αισθητική.">
+            <img class="car-img" src="photos/fm4.jpg" width="600" height="600" loading="lazy" decoding="async" alt="Έργο FM Renovation – φωτεινός ενιαίος χώρος σαλονιού.">
+            <img class="car-img" src="photos/fm5.jpg" width="600" height="600" loading="lazy" decoding="async" alt="Έργο FM Renovation – ανακαινισμένο υπνοδωμάτιο με γήινες αποχρώσεις.">
+            <img class="car-img" src="photos/fm6.jpg" width="600" height="600" loading="lazy" decoding="async" alt="Έργο FM Renovation – λεπτομέρειες κουζίνας με ποιοτικά υλικά.">
+            <img class="car-img" src="photos/fm7.jpg" width="600" height="600" loading="lazy" decoding="async" alt="Έργο FM Renovation – διαμόρφωση καθιστικού με ξύλινες υφές.">
+            <img class="car-img" src="photos/fm8.jpg" width="600" height="600" loading="lazy" decoding="async" alt="Έργο FM Renovation – σύγχρονο μπάνιο με μινιμαλιστική γραμμή.">
+            <img class="car-img" src="photos/fm9.jpg" width="600" height="600" loading="lazy" decoding="async" alt="Έργο FM Renovation – ανανεωμένος χώρος εργασίας με άπλετο φως.">
+            <img class="car-img" src="photos/fm10.jpg" width="600" height="600" loading="lazy" decoding="async" alt="Έργο FM Renovation – καθιστικό με έμφαση στη λεπτομέρεια.">
+            <img class="car-img" src="photos/fm11.jpg" width="600" height="600" loading="lazy" decoding="async" alt="Έργο FM Renovation – χώροι φιλοξενίας με ζεστή ατμόσφαιρα.">
+            <img class="car-img" src="photos/fm12.jpg" width="600" height="600" loading="lazy" decoding="async" alt="Έργο FM Renovation – πλήρης ανακαίνιση κουζίνας.">
+            <img class="car-img" src="photos/fm13.jpg" width="600" height="600" loading="lazy" decoding="async" alt="Έργο FM Renovation – σύγχρονος χώρος διαβίωσης με καθαρές γραμμές.">
+            <img class="car-img" src="photos/fm14.jpg" width="600" height="600" loading="lazy" decoding="async" alt="Έργο FM Renovation – λεπτομέρειες σαλονιού με κομψό φωτισμό.">
+            <img class="car-img" src="photos/fm15.jpg" width="600" height="600" loading="lazy" decoding="async" alt="Έργο FM Renovation – φωτεινός χώρος τραπεζαρίας σε πρόσφατη ανακαίνιση.">
           </div>
           <button class="car-btn next" aria-label="Επόμενη">›</button>
         </div>
@@ -510,7 +510,7 @@
       <button class="lb-close" aria-label="Κλείσιμο" data-lb-close>×</button>
 
       <button class="lb-nav lb-prev" aria-label="Προηγούμενη εικόνα">‹</button>
-      <img id="lb-img" class="lb-img" alt="">
+      <img id="lb-img" class="lb-img" alt="" decoding="async">
       <button class="lb-nav lb-next" aria-label="Επόμενη εικόνα">›</button>
 
       <figcaption class="lb-meta">
@@ -553,7 +553,7 @@
       <div class="footer-brand">
         <div class="brand brand--footer">
           <a href="index.html" class="logo-link" aria-label="Αρχική σελίδα">
-            <img class="brand-logo" src="images/logo.png" alt="FM Renovation λογότυπο">
+            <img class="brand-logo" src="images/logo.png" alt="FM Renovation λογότυπο" width="1024" height="1024" loading="lazy" decoding="async">
           </a>
         </div>
         <nav class="footer-links" aria-label="Χρήσιμες σύνδεσμοι">
@@ -580,13 +580,13 @@
     <div id="contactWidgetPanel" class="contact-widget__panel" aria-hidden="true">
       <a class="contact-widget__link" href="mailto:info@example.com">
         <span class="contact-widget__icon" aria-hidden="true">
-          <img src="images/icons/email.svg" width="36" height="36" alt="" loading="lazy">
+          <img src="images/icons/email.svg" width="36" height="36" alt="" loading="lazy" decoding="async">
         </span>
         <span>Email</span>
       </a>
       <a class="contact-widget__link" href="viber://chat?number=+300000000000">
         <span class="contact-widget__icon" aria-hidden="true">
-          <img src="images/icons/viber.svg" width="36" height="36" alt="" loading="lazy">
+          <img src="images/icons/viber.svg" width="36" height="36" alt="" loading="lazy" decoding="async">
         </span>
         <span>Viber</span>
       </a>

--- a/index.html
+++ b/index.html
@@ -6,7 +6,8 @@
   <title>FM Renovation | Ανακαινίσεις Κατοικιών & Επαγγελματικών Χώρων – anakainisou.gr</title>
   <meta name="description" content="FM Renovation: ολοκληρωμένες ανακαινίσεις σπιτιών, μπάνιου, κουζίνας & επαγγελματικών χώρων. Τεχνική ακρίβεια, συνέπεια και διαφάνεια. Ζητήστε προσφορά.">
   <link rel="canonical" href="https://anakainisou.gr/">
-  <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Roboto:wght@700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="assets/style.css">
   <link rel="stylesheet" href="assets/css/services.css">
@@ -87,7 +88,7 @@
     <div class="container header-inner">
       <div class="brand">
         <a href="index.html" class="logo-link" aria-label="Αρχική σελίδα">
-          <img class="brand-logo" src="images/logo.png" alt="FM Renovation λογότυπο" width="1024" height="1024" fetchpriority="high" decoding="sync">
+          <img class="brand-logo" src="images/logo.png" alt="FM Renovation λογότυπο" width="1024" height="1024" decoding="sync">
         </a>
         <span class="brand-tagline"><strong>Ανακαίνιση χώρου</strong></span>
       </div>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "anakainisou-site",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "audit:lazy": "node tools/report-lazy-images.js",
+    "fix:lazy": "node tools/fix-lazy-images.js"
+  }
+}

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -6,7 +6,8 @@
   <title>FM Renovation – Πολιτική Απορρήτου</title>
   <meta name="description" content="Πολιτική απορρήτου της FM Renovation σύμφωνα με τον Γενικό Κανονισμό Προστασίας Δεδομένων (GDPR).">
   <link rel="canonical" href="https://www.anakainisou.gr/privacy-policy.html">
-  <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Roboto:wght@700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="assets/style.css">
   <link rel="icon" type="image/png" href="favicon/favicon-96x96.png" sizes="96x96">
@@ -22,7 +23,7 @@
     <div class="container header-inner">
       <div class="brand">
         <a href="index.html" class="logo-link" aria-label="Αρχική σελίδα">
-          <img class="brand-logo" src="images/logo.png" alt="FM Renovation λογότυπο" width="1024" height="1024" fetchpriority="high" decoding="sync">
+          <img class="brand-logo" src="images/logo.png" alt="FM Renovation λογότυπο" width="1024" height="1024" decoding="sync">
         </a>
         <span class="brand-tagline"><strong>Ανακαίνιση χώρου</strong></span>
       </div>

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -22,7 +22,7 @@
     <div class="container header-inner">
       <div class="brand">
         <a href="index.html" class="logo-link" aria-label="Αρχική σελίδα">
-          <img class="brand-logo" src="images/logo.png" alt="FM Renovation λογότυπο">
+          <img class="brand-logo" src="images/logo.png" alt="FM Renovation λογότυπο" width="1024" height="1024" fetchpriority="high" decoding="sync">
         </a>
         <span class="brand-tagline"><strong>Ανακαίνιση χώρου</strong></span>
       </div>
@@ -105,7 +105,7 @@
     <div class="container footer-inner">
       <div class="brand brand--footer">
         <a href="index.html" class="logo-link" aria-label="Αρχική σελίδα">
-          <img class="brand-logo" src="images/logo.png" alt="FM Renovation λογότυπο">
+          <img class="brand-logo" src="images/logo.png" alt="FM Renovation λογότυπο" width="1024" height="1024" loading="lazy" decoding="async">
         </a>
       </div>
       <p>© <span id="year"></span> FM Renovation • <a href="https://anakainisou.gr/">anakainisou.gr</a></p>
@@ -124,13 +124,13 @@
     <div id="contactWidgetPanel" class="contact-widget__panel" aria-hidden="true">
       <a class="contact-widget__link" href="mailto:info@example.com">
         <span class="contact-widget__icon" aria-hidden="true">
-          <img src="images/icons/email.svg" width="36" height="36" alt="" loading="lazy">
+          <img src="images/icons/email.svg" width="36" height="36" alt="" loading="lazy" decoding="async">
         </span>
         <span>Email</span>
       </a>
       <a class="contact-widget__link" href="viber://chat?number=+300000000000">
         <span class="contact-widget__icon" aria-hidden="true">
-          <img src="images/icons/viber.svg" width="36" height="36" alt="" loading="lazy">
+          <img src="images/icons/viber.svg" width="36" height="36" alt="" loading="lazy" decoding="async">
         </span>
         <span>Viber</span>
       </a>

--- a/terms.html
+++ b/terms.html
@@ -6,7 +6,8 @@
   <title>FM Renovation – Όροι Χρήσης</title>
   <meta name="description" content="Όροι και προϋποθέσεις χρήσης του ιστότοπου anakainisou.gr της εταιρείας FM Renovation.">
   <link rel="canonical" href="https://www.anakainisou.gr/terms.html">
-  <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Roboto:wght@700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="assets/style.css">
   <link rel="icon" type="image/png" href="favicon/favicon-96x96.png" sizes="96x96">
@@ -22,7 +23,7 @@
     <div class="container header-inner">
       <div class="brand">
         <a href="index.html" class="logo-link" aria-label="Αρχική σελίδα">
-          <img class="brand-logo" src="images/logo.png" alt="FM Renovation λογότυπο" width="1024" height="1024" fetchpriority="high" decoding="sync">
+          <img class="brand-logo" src="images/logo.png" alt="FM Renovation λογότυπο" width="1024" height="1024" decoding="sync">
         </a>
         <span class="brand-tagline"><strong>Ανακαίνιση χώρου</strong></span>
       </div>

--- a/terms.html
+++ b/terms.html
@@ -22,7 +22,7 @@
     <div class="container header-inner">
       <div class="brand">
         <a href="index.html" class="logo-link" aria-label="Αρχική σελίδα">
-          <img class="brand-logo" src="images/logo.png" alt="FM Renovation λογότυπο">
+          <img class="brand-logo" src="images/logo.png" alt="FM Renovation λογότυπο" width="1024" height="1024" fetchpriority="high" decoding="sync">
         </a>
         <span class="brand-tagline"><strong>Ανακαίνιση χώρου</strong></span>
       </div>
@@ -104,7 +104,7 @@
     <div class="container footer-inner">
       <div class="brand brand--footer">
         <a href="index.html" class="logo-link" aria-label="Αρχική σελίδα">
-          <img class="brand-logo" src="images/logo.png" alt="FM Renovation λογότυπο">
+          <img class="brand-logo" src="images/logo.png" alt="FM Renovation λογότυπο" width="1024" height="1024" loading="lazy" decoding="async">
         </a>
       </div>
       <p>© <span id="year"></span> FM Renovation • <a href="https://anakainisou.gr/">anakainisou.gr</a></p>
@@ -123,13 +123,13 @@
     <div id="contactWidgetPanel" class="contact-widget__panel" aria-hidden="true">
       <a class="contact-widget__link" href="mailto:info@example.com">
         <span class="contact-widget__icon" aria-hidden="true">
-          <img src="images/icons/email.svg" width="36" height="36" alt="" loading="lazy">
+          <img src="images/icons/email.svg" width="36" height="36" alt="" loading="lazy" decoding="async">
         </span>
         <span>Email</span>
       </a>
       <a class="contact-widget__link" href="viber://chat?number=+300000000000">
         <span class="contact-widget__icon" aria-hidden="true">
-          <img src="images/icons/viber.svg" width="36" height="36" alt="" loading="lazy">
+          <img src="images/icons/viber.svg" width="36" height="36" alt="" loading="lazy" decoding="async">
         </span>
         <span>Viber</span>
       </a>

--- a/tools/fix-lazy-images.js
+++ b/tools/fix-lazy-images.js
@@ -1,0 +1,341 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+
+const root = path.resolve(__dirname, '..');
+const IGNORE_DIRS = new Set(['node_modules', 'dist', 'build', '.git', '.github']);
+const HTML_EXT = new Set(['.html', '.htm']);
+const JS_EXT = new Set(['.js']);
+
+function walk(dir) {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries) {
+    if (IGNORE_DIRS.has(entry.name)) {
+      continue;
+    }
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...walk(fullPath));
+    } else if (entry.isFile()) {
+      files.push(fullPath);
+    }
+  }
+  return files;
+}
+
+function parseAttributes(section) {
+  const attrs = [];
+  let i = 0;
+  while (i < section.length) {
+    while (i < section.length && /\s/.test(section[i])) {
+      i += 1;
+    }
+    if (i >= section.length) {
+      break;
+    }
+    const nameStart = i;
+    while (i < section.length && !/[\s=]/.test(section[i])) {
+      i += 1;
+    }
+    const name = section.slice(nameStart, i);
+    let value = null;
+    if (section[i] === '=') {
+      i += 1;
+      while (i < section.length && /\s/.test(section[i])) {
+        i += 1;
+      }
+      if (i < section.length) {
+        const quote = section[i];
+        if (quote === '"' || quote === '\'') {
+          i += 1;
+          const valueStart = i;
+          while (i < section.length && section[i] !== quote) {
+            i += 1;
+          }
+          value = section.slice(valueStart, i);
+          if (i < section.length && section[i] === quote) {
+            i += 1;
+          }
+        } else {
+          const valueStart = i;
+          while (i < section.length && !/\s/.test(section[i])) {
+            i += 1;
+          }
+          value = section.slice(valueStart, i);
+        }
+      }
+    }
+    if (name) {
+      attrs.push({ name, value });
+    }
+  }
+  return attrs;
+}
+
+function getAttr(attrs, name) {
+  const lower = name.toLowerCase();
+  const found = attrs.find((attr) => attr.name.toLowerCase() === lower);
+  return found ? found.value : null;
+}
+
+function setAttr(attrs, name, value) {
+  const lower = name.toLowerCase();
+  for (const attr of attrs) {
+    if (attr.name.toLowerCase() === lower) {
+      if (attr.value === value) {
+        return false;
+      }
+      attr.value = value;
+      return true;
+    }
+  }
+  attrs.push({ name, value });
+  return true;
+}
+
+function removeAttr(attrs, name) {
+  const lower = name.toLowerCase();
+  const initial = attrs.length;
+  for (let i = attrs.length - 1; i >= 0; i -= 1) {
+    if (attrs[i].name.toLowerCase() === lower) {
+      attrs.splice(i, 1);
+    }
+  }
+  return attrs.length !== initial;
+}
+
+function buildTag(attrs, selfClosing, closingSuffix) {
+  const parts = attrs.map((attr) => {
+    if (attr.value === null || typeof attr.value === 'undefined') {
+      return attr.name;
+    }
+    return `${attr.name}="${attr.value}"`;
+  });
+  if (parts.length) {
+    return `<img ${parts.join(' ')}${selfClosing ? closingSuffix : '>'}`;
+  }
+  return `<img${selfClosing ? closingSuffix : '>'}`;
+}
+
+function getImageSize(filePath) {
+  if (!fs.existsSync(filePath)) {
+    return null;
+  }
+  const buffer = fs.readFileSync(filePath);
+  if (buffer.length < 10) {
+    return null;
+  }
+  // PNG
+  if (buffer.slice(0, 8).toString('hex') === '89504e470d0a1a0a') {
+    const width = buffer.readUInt32BE(16);
+    const height = buffer.readUInt32BE(20);
+    return { width, height };
+  }
+  // JPEG
+  if (buffer[0] === 0xff && buffer[1] === 0xd8) {
+    let offset = 2;
+    while (offset + 9 < buffer.length) {
+      if (buffer[offset] !== 0xff) {
+        offset += 1;
+        continue;
+      }
+      const marker = buffer[offset + 1];
+      const length = buffer.readUInt16BE(offset + 2);
+      if (marker >= 0xc0 && marker <= 0xcf && marker !== 0xc4 && marker !== 0xcc) {
+        const height = buffer.readUInt16BE(offset + 5);
+        const width = buffer.readUInt16BE(offset + 7);
+        return { width, height };
+      }
+      offset += 2 + length;
+    }
+  }
+  return null;
+}
+
+function classifyImage(attrs, context, hasLoading) {
+  const classValue = (getAttr(attrs, 'class') || '').toLowerCase();
+  const idValue = (getAttr(attrs, 'id') || '').toLowerCase();
+  const hasLogoKeyword = classValue.includes('logo') || idValue.includes('logo');
+  const hasHeroKeyword = classValue.includes('hero') || idValue.includes('hero');
+  const hasDataHero = attrs.some((attr) => attr.name.toLowerCase() === 'data-hero');
+  const contextLower = context.toLowerCase();
+  const nearFooter = /footer-brand|brand--footer|site-footer/.test(contextLower);
+  const nearHeader = /site-header|header-inner|logo-link/.test(contextLower);
+
+  const heroFromData = hasDataHero && !hasLoading;
+  const heroFromClass = hasHeroKeyword && !nearFooter;
+  const heroLogo = hasLogoKeyword && nearHeader && !nearFooter;
+
+  const lightbox = /lb-img|lightbox-full/.test(classValue) || /lb-img|lightbox-full/.test(idValue);
+
+  return {
+    hero: heroFromData || heroFromClass || heroLogo,
+    lightbox,
+  };
+}
+
+function shouldSkipLazy(attrs) {
+  const classValue = (getAttr(attrs, 'class') || '').toLowerCase();
+  const idValue = (getAttr(attrs, 'id') || '').toLowerCase();
+  return /no-lazy/.test(classValue) || /no-lazy/.test(idValue);
+}
+
+function processHtmlFile(filePath) {
+  const original = fs.readFileSync(filePath, 'utf8');
+  let updated = false;
+  let lazyApplied = 0;
+  let heroAdjusted = 0;
+  let dimensionsAdded = 0;
+  let decodingApplied = 0;
+
+  const result = original.replace(/<img[^>]*>/gi, (match, offset) => {
+    const trimmed = match.trimEnd();
+    const hasSelfClosing = trimmed.slice(-2) === '/>';
+    const charBefore = match[match.length - 3] || '';
+    const closingSuffix = hasSelfClosing && /\s/.test(charBefore) ? ' />' : hasSelfClosing ? '/>' : '>';
+    const body = match.slice(4, match.length - closingSuffix.length);
+    const attrs = parseAttributes(body);
+    const hasLoading = attrs.some((attr) => attr.name.toLowerCase() === 'loading');
+    const context = original.slice(Math.max(0, offset - 200), Math.min(original.length, offset + match.length + 200));
+    const classification = classifyImage(attrs, context, hasLoading);
+    const skipLazy = shouldSkipLazy(attrs);
+
+    let tagChanged = false;
+
+    if (classification.hero) {
+      if (removeAttr(attrs, 'loading')) {
+        tagChanged = true;
+      }
+      if (setAttr(attrs, 'fetchpriority', 'high')) {
+        tagChanged = true;
+        heroAdjusted += 1;
+      }
+      if (setAttr(attrs, 'decoding', 'sync')) {
+        tagChanged = true;
+        decodingApplied += 1;
+      }
+    } else if (classification.lightbox) {
+      if (removeAttr(attrs, 'loading')) {
+        tagChanged = true;
+      }
+      if (setAttr(attrs, 'decoding', 'async')) {
+        tagChanged = true;
+        decodingApplied += 1;
+      }
+    } else if (!skipLazy) {
+      if (setAttr(attrs, 'loading', 'lazy')) {
+        tagChanged = true;
+        lazyApplied += 1;
+      }
+      if (setAttr(attrs, 'decoding', 'async')) {
+        tagChanged = true;
+        decodingApplied += 1;
+      }
+    }
+
+    const src = getAttr(attrs, 'src');
+    const hasWidth = attrs.some((attr) => attr.name.toLowerCase() === 'width');
+    const hasHeight = attrs.some((attr) => attr.name.toLowerCase() === 'height');
+    if (src && (!hasWidth || !hasHeight)) {
+      const isRemote = /^(https?:)?\/\//i.test(src) || src.startsWith('data:');
+      if (!isRemote) {
+        const resolved = path.resolve(path.dirname(filePath), src);
+        const size = getImageSize(resolved);
+        if (size) {
+          if (!hasWidth) {
+            if (setAttr(attrs, 'width', String(size.width))) {
+              tagChanged = true;
+              dimensionsAdded += 1;
+            }
+          }
+          if (!hasHeight) {
+            if (setAttr(attrs, 'height', String(size.height))) {
+              tagChanged = true;
+              dimensionsAdded += 1;
+            }
+          }
+        }
+      }
+    }
+
+    if (tagChanged) {
+      updated = true;
+      return buildTag(attrs, hasSelfClosing, closingSuffix);
+    }
+    return match;
+  });
+
+  if (updated) {
+    fs.writeFileSync(filePath, result);
+  }
+
+  return { updated, lazyApplied, heroAdjusted, dimensionsAdded, decodingApplied };
+}
+
+function processJsFile(filePath) {
+  const original = fs.readFileSync(filePath, 'utf8');
+  const lines = original.split('\n');
+  let updated = false;
+  let insertions = 0;
+
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i];
+    const match = line.match(/^(\s*)(const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*(document\.createElement\(['"]img['"]\)|new Image\s*\(\s*\));?\s*$/);
+    if (!match) {
+      continue;
+    }
+    const indent = match[1] || '';
+    const name = match[3];
+    if (/hero|logo/i.test(name)) {
+      continue;
+    }
+    const namePattern = new RegExp(`\\b${name.replace(/[$]/g, '\\$&')}\\s*\\.\\s*loading\\b`);
+    if (namePattern.test(original)) {
+      continue;
+    }
+    lines.splice(i + 1, 0, `${indent}${name}.loading = 'lazy';`, `${indent}${name}.decoding = 'async';`);
+    i += 2;
+    updated = true;
+    insertions += 1;
+  }
+
+  if (updated) {
+    fs.writeFileSync(filePath, lines.join('\n'));
+  }
+
+  return { updated, insertions };
+}
+
+function run() {
+  const files = walk(root);
+  const htmlFiles = files.filter((file) => HTML_EXT.has(path.extname(file).toLowerCase()));
+  const jsFiles = files.filter((file) => JS_EXT.has(path.extname(file).toLowerCase()));
+
+  const summaries = [];
+
+  for (const file of htmlFiles) {
+    const stats = processHtmlFile(file);
+    if (stats.updated) {
+      summaries.push(`${path.relative(root, file)} → imgs updated (lazy:${stats.lazyApplied}, hero:${stats.heroAdjusted}, decoding:${stats.decodingApplied}, dimensions:${stats.dimensionsAdded})`);
+    }
+  }
+
+  for (const file of jsFiles) {
+    const stats = processJsFile(file);
+    if (stats.updated) {
+      summaries.push(`${path.relative(root, file)} → JS image helpers inserted (${stats.insertions})`);
+    }
+  }
+
+  if (summaries.length) {
+    console.log('Lazy-loading fixer results:');
+    for (const line of summaries) {
+      console.log(`- ${line}`);
+    }
+  } else {
+    console.log('No lazy-loading adjustments were necessary.');
+  }
+}
+
+run();

--- a/tools/report-lazy-images.js
+++ b/tools/report-lazy-images.js
@@ -1,0 +1,246 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+
+const root = path.resolve(__dirname, '..');
+const IGNORE_DIRS = new Set(['node_modules', 'dist', 'build', '.git', '.github']);
+const HTML_EXT = new Set(['.html', '.htm']);
+const JS_EXT = new Set(['.js']);
+
+function walk(dir) {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries) {
+    if (IGNORE_DIRS.has(entry.name)) {
+      continue;
+    }
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...walk(fullPath));
+    } else if (entry.isFile()) {
+      files.push(fullPath);
+    }
+  }
+  return files;
+}
+
+function createLineIndex(text) {
+  const offsets = [0];
+  for (let i = 0; i < text.length; i += 1) {
+    if (text[i] === '\n') {
+      offsets.push(i + 1);
+    }
+  }
+  return offsets;
+}
+
+function getLineNumber(offsets, index) {
+  let low = 0;
+  let high = offsets.length - 1;
+  while (low <= high) {
+    const mid = Math.floor((low + high) / 2);
+    const offset = offsets[mid];
+    const next = mid + 1 < offsets.length ? offsets[mid + 1] : Number.POSITIVE_INFINITY;
+    if (index >= offset && index < next) {
+      return mid + 1;
+    }
+    if (index < offset) {
+      high = mid - 1;
+    } else {
+      low = mid + 1;
+    }
+  }
+  return offsets.length;
+}
+
+function parseAttributes(tag) {
+  const attrSection = tag.replace(/^<img\s*/i, '').replace(/\s*\/?>$/i, '');
+  const attrs = [];
+  let i = 0;
+  while (i < attrSection.length) {
+    while (i < attrSection.length && /\s/.test(attrSection[i])) {
+      i += 1;
+    }
+    if (i >= attrSection.length) {
+      break;
+    }
+    const nameStart = i;
+    while (i < attrSection.length && !/[\s=]/.test(attrSection[i])) {
+      i += 1;
+    }
+    const name = attrSection.slice(nameStart, i);
+    let value = null;
+    if (attrSection[i] === '=') {
+      i += 1;
+      while (i < attrSection.length && /\s/.test(attrSection[i])) {
+        i += 1;
+      }
+      if (i < attrSection.length) {
+        const quote = attrSection[i];
+        if (quote === '"' || quote === '\'') {
+          i += 1;
+          const valueStart = i;
+          while (i < attrSection.length && attrSection[i] !== quote) {
+            i += 1;
+          }
+          value = attrSection.slice(valueStart, i);
+          if (i < attrSection.length && attrSection[i] === quote) {
+            i += 1;
+          }
+        } else {
+          const valueStart = i;
+          while (i < attrSection.length && !/\s/.test(attrSection[i])) {
+            i += 1;
+          }
+          value = attrSection.slice(valueStart, i);
+        }
+      }
+    }
+    if (name) {
+      attrs.push({ name, value });
+    }
+  }
+  return attrs;
+}
+
+function getAttr(attrs, name) {
+  const lower = name.toLowerCase();
+  const found = attrs.find((attr) => attr.name.toLowerCase() === lower);
+  return found ? found.value : null;
+}
+
+function classifyImage(tag, context) {
+  const attrs = parseAttributes(tag);
+  const lowerTag = tag.toLowerCase();
+  const hasLoading = /\bloading\s*=/.test(lowerTag);
+  const dataHero = attrs.some((attr) => attr.name.toLowerCase() === 'data-hero');
+  const classValue = (getAttr(attrs, 'class') || '').toLowerCase();
+  const idValue = (getAttr(attrs, 'id') || '').toLowerCase();
+  const contextLower = context.toLowerCase();
+  const nearFooter = /footer-brand|brand--footer|site-footer/.test(contextLower);
+  const nearHeader = /site-header|header-inner|logo-link/.test(contextLower);
+  const hasHeroKeyword = classValue.includes('hero') || idValue.includes('hero');
+  const hasLogoKeyword = classValue.includes('logo') || idValue.includes('logo');
+
+  const heroFromData = dataHero && !hasLoading;
+  const heroFromClass = hasHeroKeyword && !nearFooter;
+  const heroLogo = hasLogoKeyword && nearHeader && !nearFooter;
+
+  const hero = heroFromData || heroFromClass || heroLogo;
+  const lightbox = /lb-img|lightbox-full/.test(classValue) || /lb-img|lightbox-full/.test(idValue);
+
+  return { hero, lightbox };
+}
+
+function makeSnippet(tag) {
+  return tag.length > 160 ? `${tag.slice(0, 160)}…` : tag;
+}
+
+function run() {
+  const files = walk(root);
+  const htmlFiles = files.filter((file) => HTML_EXT.has(path.extname(file).toLowerCase()));
+  const jsFiles = files.filter((file) => JS_EXT.has(path.extname(file).toLowerCase()));
+
+  const missingLoading = [];
+  const allowedMissing = [];
+  const pictureIssues = [];
+  const jsCreations = [];
+  const thumbIssues = [];
+
+  for (const file of htmlFiles) {
+    const content = fs.readFileSync(file, 'utf8');
+    const offsets = createLineIndex(content);
+
+    const imgRegex = /<img(?![^>]*\bloading\s*=)[^>]*>/gi;
+    for (const match of content.matchAll(imgRegex)) {
+      const index = match.index || 0;
+      const line = getLineNumber(offsets, index);
+      const context = content.slice(Math.max(0, index - 200), Math.min(content.length, index + match[0].length + 200));
+      const classification = classifyImage(match[0], context);
+      const record = { file: path.relative(root, file), line, snippet: makeSnippet(match[0]) };
+      if (classification.hero || classification.lightbox) {
+        allowedMissing.push({ ...record, reason: classification.hero ? 'hero/logo or above-the-fold' : 'lightbox full-size image' });
+      } else {
+        missingLoading.push(record);
+      }
+    }
+
+    const pictureRegex = /<picture>[\s\S]*?<img(?![^>]*\bloading\s*=)[^>]*>[\s\S]*?<\/picture>/gi;
+    for (const match of content.matchAll(pictureRegex)) {
+      const index = match.index || 0;
+      const line = getLineNumber(offsets, index);
+      pictureIssues.push({ file: path.relative(root, file), line, snippet: makeSnippet(match[0]) });
+    }
+
+    const thumbRegex = /<img[^>]*class\s*=\s*"[^"]*(thumb|strip|gallery)[^"]*"[^>]*>/gi;
+    for (const match of content.matchAll(thumbRegex)) {
+      if (/\bloading\s*=\s*"lazy"/.test(match[0])) {
+        continue;
+      }
+      const index = match.index || 0;
+      const line = getLineNumber(offsets, index);
+      thumbIssues.push({ file: path.relative(root, file), line, snippet: makeSnippet(match[0]) });
+    }
+  }
+
+  for (const file of jsFiles) {
+    const content = fs.readFileSync(file, 'utf8');
+    const offsets = createLineIndex(content);
+    const pattern = /new Image\(|document\.createElement\(['"]img['"]\)|\.innerHTML\s*=\s*`[^`]*<img/gi;
+    for (const match of content.matchAll(pattern)) {
+      const index = match.index || 0;
+      const line = getLineNumber(offsets, index);
+      jsCreations.push({ file: path.relative(root, file), line, snippet: makeSnippet(match[0]) });
+    }
+  }
+
+  const sections = [];
+
+  sections.push('Lazy-loading audit report');
+  sections.push('================================');
+
+  if (missingLoading.length) {
+    sections.push('\nImages missing loading="lazy":');
+    for (const item of missingLoading) {
+      sections.push(`  - ${item.file}:${item.line} → ${item.snippet}`);
+    }
+  } else {
+    sections.push('\nNo images missing loading="lazy" outside approved exceptions.');
+  }
+
+  if (allowedMissing.length) {
+    sections.push('\nAllowed exceptions (not lazied intentionally):');
+    for (const item of allowedMissing) {
+      sections.push(`  - ${item.file}:${item.line} (${item.reason}) → ${item.snippet}`);
+    }
+  }
+
+  if (pictureIssues.length) {
+    sections.push('\n<picture> blocks with inner <img> missing loading attribute:');
+    for (const item of pictureIssues) {
+      sections.push(`  - ${item.file}:${item.line} → ${item.snippet}`);
+    }
+  }
+
+  if (jsCreations.length) {
+    sections.push('\nPotential JS image creation without lazy-loading:');
+    for (const item of jsCreations) {
+      sections.push(`  - ${item.file}:${item.line} → ${item.snippet}`);
+    }
+  }
+
+  if (thumbIssues.length) {
+    sections.push('\nGallery/thumb images missing loading="lazy":');
+    for (const item of thumbIssues) {
+      sections.push(`  - ${item.file}:${item.line} → ${item.snippet}`);
+    }
+  }
+
+  if (!pictureIssues.length && !jsCreations.length && !thumbIssues.length) {
+    sections.push('\nNo additional issues detected.');
+  }
+
+  console.log(sections.join('\n'));
+}
+
+run();


### PR DESCRIPTION
## Summary
- add audit and remediation scripts plus npm shortcuts for lazy-loading checks
- update page images with consistent lazy/eager hints, async decoding, and intrinsic dimensions where known
- document the lazy-loading policy and capture the latest audit output

## Testing
- npm run audit:lazy --silent
- npm run fix:lazy --silent

------
https://chatgpt.com/codex/tasks/task_e_6907515302488320b7f51edad60d4e5b