### PR TITLE
Adjust header navigation links

### DIFF
--- a/index.html
+++ b/index.html
@@ -98,11 +98,10 @@
       </button>
       <nav id="site-nav" class="nav" aria-label="Κύρια πλοήγηση">
         <ul class="nav__list">
-          <li class="nav__item"><a href="#about" class="nav__link">Σχετικά</a></li>
+          <li class="nav__item"><a href="#top" class="nav__link">Αρχική</a></li>
           <li class="nav__item"><a href="#services" class="nav__link">Υπηρεσίες</a></li>
-          <li class="nav__item"><a href="#process" class="nav__link">Πώς Λειτουργούμε</a></li>
-          <li class="nav__item"><a href="#reasons" class="nav__link">Γιατί Εμάς</a></li>
-          <li class="nav__item nav__item--projects"><a href="erga.html" class="nav__link">Έργα</a></li>
+          <li class="nav__item nav__item--projects"><a href="erga.html" class="nav__link">Έργα μας</a></li>
+          <li class="nav__item"><a href="#contact" class="nav__link">Επικοινωνία</a></li>
           <li class="nav__item nav__item--cta"><a href="#contact" class="btn btn--sm nav-cta">Ζητήστε Προσφορά</a></li>
         </ul>
       </nav>
@@ -125,11 +124,10 @@
       </div>
       <nav class="nav-mobile" aria-label="Κύρια πλοήγηση" data-mobile-nav>
         <ul class="nav-mobile__list">
-          <li class="nav-mobile__item"><a href="#about" class="nav-mobile__link">Σχετικά</a></li>
+          <li class="nav-mobile__item"><a href="#top" class="nav-mobile__link">Αρχική</a></li>
           <li class="nav-mobile__item"><a href="#services" class="nav-mobile__link">Υπηρεσίες</a></li>
-          <li class="nav-mobile__item"><a href="#process" class="nav-mobile__link">Πώς Λειτουργούμε</a></li>
-          <li class="nav-mobile__item"><a href="#reasons" class="nav-mobile__link">Γιατί Εμάς</a></li>
-          <li class="nav-mobile__item nav-mobile__item--projects"><a href="erga.html" class="nav-mobile__link">Έργα</a></li>
+          <li class="nav-mobile__item nav-mobile__item--projects"><a href="erga.html" class="nav-mobile__link">Έργα μας</a></li>
+          <li class="nav-mobile__item"><a href="#contact" class="nav-mobile__link">Επικοινωνία</a></li>
           <li class="nav-mobile__item nav-mobile__item--cta"><a href="#contact" class="btn btn--primary nav-mobile__cta">Ζητήστε Προσφορά</a></li>
         </ul>
       </nav>


### PR DESCRIPTION
## Summary
- rename the primary navigation entries to highlight the home page and project section
- remove the process and reasons links while adding a direct contact link in both desktop and mobile menus

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_6907df5dde988320bb3a51e23fced747