### PR TITLE
Copy navigation menu from home page to projects page

### DIFF
--- a/erga.html
+++ b/erga.html
@@ -40,12 +40,11 @@
       </button>
       <nav id="site-nav" class="nav" aria-label="Κύρια πλοήγηση">
         <ul class="nav__list">
-          <li class="nav__item"><a href="index.html#about" class="nav__link">Σχετικά</a></li>
-          <li class="nav__item"><a href="index.html#services" class="nav__link">Υπηρεσίες</a></li>
-          <li class="nav__item"><a href="index.html#process" class="nav__link">Πώς Λειτουργούμε</a></li>
-          <li class="nav__item"><a href="index.html#reasons" class="nav__link">Γιατί Εμάς</a></li>
-          <li class="nav__item nav__item--projects"><a href="erga.html" class="nav__link">Έργα</a></li>
-          <li class="nav__item nav__item--cta"><a href="index.html#contact" class="btn btn--sm nav-cta">Ζητήστε Προσφορά</a></li>
+          <li class="nav__item"><a href="#top" class="nav__link">Αρχική</a></li>
+          <li class="nav__item"><a href="#services" class="nav__link">Υπηρεσίες</a></li>
+          <li class="nav__item nav__item--projects"><a href="erga.html" class="nav__link">Έργα μας</a></li>
+          <li class="nav__item"><a href="#contact" class="nav__link">Επικοινωνία</a></li>
+          <li class="nav__item nav__item--cta"><a href="#contact" class="btn btn--sm nav-cta">Ζητήστε Προσφορά</a></li>
         </ul>
       </nav>
       <div class="social">
@@ -67,12 +66,11 @@
       </div>
       <nav class="nav-mobile" aria-label="Κύρια πλοήγηση" data-mobile-nav>
         <ul class="nav-mobile__list">
-          <li class="nav-mobile__item"><a href="index.html#about" class="nav-mobile__link">Σχετικά</a></li>
-          <li class="nav-mobile__item"><a href="index.html#services" class="nav-mobile__link">Υπηρεσίες</a></li>
-          <li class="nav-mobile__item"><a href="index.html#process" class="nav-mobile__link">Πώς Λειτουργούμε</a></li>
-          <li class="nav-mobile__item"><a href="index.html#reasons" class="nav-mobile__link">Γιατί Εμάς</a></li>
-          <li class="nav-mobile__item nav-mobile__item--projects"><a href="erga.html" class="nav-mobile__link">Έργα</a></li>
-          <li class="nav-mobile__item nav-mobile__item--cta"><a href="index.html#contact" class="btn btn--primary nav-mobile__cta">Ζητήστε Προσφορά</a></li>
+          <li class="nav-mobile__item"><a href="#top" class="nav-mobile__link">Αρχική</a></li>
+          <li class="nav-mobile__item"><a href="#services" class="nav-mobile__link">Υπηρεσίες</a></li>
+          <li class="nav-mobile__item nav-mobile__item--projects"><a href="erga.html" class="nav-mobile__link">Έργα μας</a></li>
+          <li class="nav-mobile__item"><a href="#contact" class="nav-mobile__link">Επικοινωνία</a></li>
+          <li class="nav-mobile__item nav-mobile__item--cta"><a href="#contact" class="btn btn--primary nav-mobile__cta">Ζητήστε Προσφορά</a></li>
         </ul>
       </nav>
       <div class="nav-overlay__social">


### PR DESCRIPTION
## Summary
- replace the desktop and mobile navigation menus in `erga.html` with the same structure used on the home page

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6907e5fe2c9883208853d77e4aafa597