### PR TITLE
Make home navigation dynamic and ensure clean canonical URLs

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -1,3 +1,36 @@
+// Dynamic home link handling for GitHub Pages vs custom domain
+(function setDynamicHome(){
+  var isGh=location.hostname.endsWith('github.io');
+  var projSeg=(location.pathname.split('/')[1]||'').trim();
+  var proj=projSeg?('/'+projSeg+'/'):'/';
+  var homeHref=isGh?proj:'/';
+
+  var normalize=function(path){
+    var normalized=(path||'/').replace(/\/+$/,'');
+    if(normalized.toLowerCase().endsWith('/index.html')){
+      normalized=normalized.slice(0,-11).replace(/\/+$/,'');
+    }
+    if(!normalized){return '/';}
+    return normalized;
+  };
+
+  var here=normalize(location.pathname||'/');
+  var target=normalize(homeHref);
+
+  document.querySelectorAll('a[data-home]').forEach(function(a){
+    a.href=homeHref;
+    a.addEventListener('click',function(event){
+      if(here===target){
+        event.preventDefault();
+        window.scrollTo({top:0,behavior:'smooth'});
+      }
+    });
+    if(here===target){
+      a.setAttribute('aria-current','page');
+    }
+  });
+})();
+
 // Navigation interactions
 const body=document.body;
 const navToggle=document.querySelector('[data-nav-toggle]');

--- a/erga.html
+++ b/erga.html
@@ -40,7 +40,7 @@
       </button>
       <nav id="site-nav" class="nav" aria-label="Κύρια πλοήγηση">
         <ul class="nav__list">
-          <li class="nav__item"><a href="#top" class="nav__link">Αρχική</a></li>
+          <li class="nav__item"><a href="#" class="nav__link" data-home rel="home">Αρχική</a></li>
           <li class="nav__item"><a href="#services" class="nav__link">Υπηρεσίες</a></li>
           <li class="nav__item nav__item--projects"><a href="erga.html" class="nav__link">Έργα μας</a></li>
           <li class="nav__item"><a href="#contact" class="nav__link">Επικοινωνία</a></li>
@@ -66,7 +66,7 @@
       </div>
       <nav class="nav-mobile" aria-label="Κύρια πλοήγηση" data-mobile-nav>
         <ul class="nav-mobile__list">
-          <li class="nav-mobile__item"><a href="#top" class="nav-mobile__link">Αρχική</a></li>
+          <li class="nav-mobile__item"><a href="#" class="nav-mobile__link" data-home rel="home">Αρχική</a></li>
           <li class="nav-mobile__item"><a href="#services" class="nav-mobile__link">Υπηρεσίες</a></li>
           <li class="nav-mobile__item nav-mobile__item--projects"><a href="erga.html" class="nav-mobile__link">Έργα μας</a></li>
           <li class="nav-mobile__item"><a href="#contact" class="nav-mobile__link">Επικοινωνία</a></li>

--- a/index.html
+++ b/index.html
@@ -98,7 +98,7 @@
       </button>
       <nav id="site-nav" class="nav" aria-label="Κύρια πλοήγηση">
         <ul class="nav__list">
-          <li class="nav__item"><a href="#top" class="nav__link">Αρχική</a></li>
+          <li class="nav__item"><a href="#" class="nav__link" data-home rel="home">Αρχική</a></li>
           <li class="nav__item"><a href="#services" class="nav__link">Υπηρεσίες</a></li>
           <li class="nav__item nav__item--projects"><a href="erga.html" class="nav__link">Έργα μας</a></li>
           <li class="nav__item"><a href="#contact" class="nav__link">Επικοινωνία</a></li>
@@ -124,7 +124,7 @@
       </div>
       <nav class="nav-mobile" aria-label="Κύρια πλοήγηση" data-mobile-nav>
         <ul class="nav-mobile__list">
-          <li class="nav-mobile__item"><a href="#top" class="nav-mobile__link">Αρχική</a></li>
+          <li class="nav-mobile__item"><a href="#" class="nav-mobile__link" data-home rel="home">Αρχική</a></li>
           <li class="nav-mobile__item"><a href="#services" class="nav-mobile__link">Υπηρεσίες</a></li>
           <li class="nav-mobile__item nav-mobile__item--projects"><a href="erga.html" class="nav-mobile__link">Έργα μας</a></li>
           <li class="nav-mobile__item"><a href="#contact" class="nav-mobile__link">Επικοινωνία</a></li>

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>FM Renovation – Πολιτική Απορρήτου</title>
   <meta name="description" content="Πολιτική απορρήτου της FM Renovation σύμφωνα με τον Γενικό Κανονισμό Προστασίας Δεδομένων (GDPR).">
-  <link rel="canonical" href="https://www.anakainisou.gr/privacy-policy.html">
+  <link rel="canonical" href="https://anakainisou.gr/privacy-policy">
   <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Roboto:wght@700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="assets/style.css">
@@ -33,8 +33,8 @@
       </button>
       <nav id="site-nav" class="nav" aria-label="Κύρια πλοήγηση">
         <ul class="nav__list">
+          <li class="nav__item"><a href="#" class="nav__link" data-home rel="home">Αρχική</a></li>
           <li class="nav__item"><a href="/index.html#about" class="nav__link">Σχετικά</a></li>
-
           <li class="nav__item"><a href="/index.html#process" class="nav__link">Πώς Λειτουργούμε</a></li>
           <li class="nav__item nav__item--projects"><a href="erga.html" class="nav__link">Έργα</a></li>
           <li class="nav__item"><a href="/index.html#gallery" class="nav__link">Gallery</a></li>
@@ -60,8 +60,8 @@
       </div>
       <nav class="nav-mobile" aria-label="Κύρια πλοήγηση" data-mobile-nav>
         <ul class="nav-mobile__list">
+          <li class="nav-mobile__item"><a href="#" class="nav-mobile__link" data-home rel="home">Αρχική</a></li>
           <li class="nav-mobile__item"><a href="/index.html#about" class="nav-mobile__link">Σχετικά</a></li>
-
           <li class="nav-mobile__item"><a href="/index.html#process" class="nav-mobile__link">Πώς Λειτουργούμε</a></li>
           <li class="nav-mobile__item nav-mobile__item--projects"><a href="erga.html" class="nav-mobile__link">Έργα</a></li>
           <li class="nav-mobile__item"><a href="/index.html#gallery" class="nav-mobile__link">Gallery</a></li>

--- a/terms.html
+++ b/terms.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>FM Renovation – Όροι Χρήσης</title>
   <meta name="description" content="Όροι και προϋποθέσεις χρήσης του ιστότοπου anakainisou.gr της εταιρείας FM Renovation.">
-  <link rel="canonical" href="https://www.anakainisou.gr/terms.html">
+  <link rel="canonical" href="https://anakainisou.gr/terms">
   <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Roboto:wght@700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="assets/style.css">
@@ -33,8 +33,8 @@
       </button>
       <nav id="site-nav" class="nav" aria-label="Κύρια πλοήγηση">
         <ul class="nav__list">
+          <li class="nav__item"><a href="#" class="nav__link" data-home rel="home">Αρχική</a></li>
           <li class="nav__item"><a href="/index.html#about" class="nav__link">Σχετικά</a></li>
-
           <li class="nav__item"><a href="/index.html#process" class="nav__link">Πώς Λειτουργούμε</a></li>
           <li class="nav__item nav__item--projects"><a href="erga.html" class="nav__link">Έργα</a></li>
           <li class="nav__item"><a href="/index.html#gallery" class="nav__link">Gallery</a></li>
@@ -60,8 +60,8 @@
       </div>
       <nav class="nav-mobile" aria-label="Κύρια πλοήγηση" data-mobile-nav>
         <ul class="nav-mobile__list">
+          <li class="nav-mobile__item"><a href="#" class="nav-mobile__link" data-home rel="home">Αρχική</a></li>
           <li class="nav-mobile__item"><a href="/index.html#about" class="nav-mobile__link">Σχετικά</a></li>
-
           <li class="nav-mobile__item"><a href="/index.html#process" class="nav-mobile__link">Πώς Λειτουργούμε</a></li>
           <li class="nav-mobile__item nav-mobile__item--projects"><a href="erga.html" class="nav-mobile__link">Έργα</a></li>
           <li class="nav-mobile__item"><a href="/index.html#gallery" class="nav-mobile__link">Gallery</a></li>


### PR DESCRIPTION
## Summary
- add a dynamic helper so the “Αρχική” links resolve to the correct root on GitHub Pages and the custom domain, including smooth scrolling and aria-current handling
- mark desktop and mobile nav home items with data-home/rel="home" across all pages
- point legal page canonical tags to clean anakainisou.gr URLs

## Testing
- not run (static content changes)

------
https://chatgpt.com/codex/tasks/task_e_6907e97f64808320b9a24e5fe5d8f051