### PR TITLE
Add outline to projects header CTA

### DIFF
--- a/assets/css/erga.css
+++ b/assets/css/erga.css
@@ -10,6 +10,11 @@
   text-align: center;
 }
 
+.site-header .nav__item--cta .nav-cta {
+  outline: 2px solid #f59e0b;
+  outline-offset: 2px;
+}
+
 .page-hero h1 {
   margin: 0 0 12px;
   font-size: clamp(28px, 4vw, 46px);


### PR DESCRIPTION
## Summary
- add a persistent amber outline to the header CTA button on the projects page for improved emphasis

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6908e0ca9e548320adbfae970c08d7d0