### PR TITLE
Remove duplicate wardrobe gallery cover image

### DIFF
--- a/data/projects.json
+++ b/data/projects.json
@@ -250,7 +250,6 @@
       {
         "title": "Gallery",
         "images": [
-          "fm2.jpg",
           "fm4.jpg",
           "fm6.jpg",
           "fm8.jpg",


### PR DESCRIPTION
## Summary
- remove the fm2.jpg entry from the wardrobe project gallery to avoid duplicating the cover image

## Testing
- Not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_6908e2a6b79483209d7796fa70bc02c4