### PR TITLE
Reorder before/after photo for Piraeus renovation gallery

### DIFF
--- a/data/projects.json
+++ b/data/projects.json
@@ -23,26 +23,26 @@
     "gallery": [
       {
         "title": "Μετά",
-        "images": [
-          "renovation6*.jpg",
-          "renovation2.jpg",
-          "renovation**.jpg",
-          "renovation88.jpg",
-          "renovation4*.jpg",
-          "renovation2*.jpg",
-          "renovation1*.jpg"
-        ]
-      },
-      {
-        "title": "Πριν",
-        "images": [
-          "renovation3.jpg",
-          "renovation4.jpg",
-          "renovation5.jpg",
-          "renovation7.jpg",
-          "renovation8*.jpg"
-        ]
-      }
+      "images": [
+        "renovation6*.jpg",
+        "renovation2.jpg",
+        "renovation**.jpg",
+        "renovation88.jpg",
+        "renovation4*.jpg",
+        "renovation2*.jpg",
+        "renovation1*.jpg",
+        "renovation8*.jpg"
+      ]
+    },
+    {
+      "title": "Πριν",
+      "images": [
+        "renovation3.jpg",
+        "renovation4.jpg",
+        "renovation5.jpg",
+        "renovation7.jpg"
+      ]
+    }
     ]
   },
   {


### PR DESCRIPTION
## Summary
- move the final "Πριν" photo for the Piraeus ground floor renovation gallery into the "Μετά" set so it appears last in the after section

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6908e6380ad8832080491bda6a62887b