### PR TITLE
Keep lightbox navigation arrows fixed with larger hit area

### DIFF
--- a/assets/css/lightbox.css
+++ b/assets/css/lightbox.css
@@ -28,6 +28,7 @@
   position: absolute;
   inset: 0;
   background: var(--lb-bg);
+  z-index: 1;
 }
 
 .lb-frame {
@@ -39,6 +40,7 @@
   align-items: center;
   justify-content: center;
   gap: 0.5rem;
+  z-index: 2;
 }
 
 .lb-img {
@@ -67,21 +69,40 @@
 }
 
 .lb-nav {
-  position: absolute;
+  position: fixed;
   top: 50%;
   transform: translateY(-50%);
+  width: 96px;
+  height: 100px;
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  z-index: 3;
+}
+
+.lb-nav::before {
+  content: attr(data-symbol);
+  display: flex;
+  align-items: center;
+  justify-content: center;
   width: 44px;
   height: 44px;
   border-radius: 999px;
-  border: 0;
-  cursor: pointer;
   background: #fff;
   box-shadow: 0 2px 10px rgba(0, 0, 0, 0.18);
   font-size: 26px;
   line-height: 1;
   color: var(--lb-fg);
-  display: grid;
-  place-items: center;
+  pointer-events: none;
+}
+
+.lb-nav:focus-visible::before,
+.lb-nav:hover::before {
+  box-shadow: 0 0 0 3px rgba(15, 23, 42, 0.12), 0 2px 10px rgba(0, 0, 0, 0.18);
 }
 
 .lb-nav:disabled {
@@ -90,11 +111,11 @@
 }
 
 .lb-prev {
-  left: -52px;
+  left: 8px;
 }
 
 .lb-next {
-  right: -52px;
+  right: 8px;
 }
 
 .lb-meta {
@@ -118,12 +139,15 @@
     right: 0;
   }
 
-  .lb-prev {
-    left: 8px;
+  .lb-nav {
+    width: 72px;
+    height: 72px;
   }
 
-  .lb-next {
-    right: 8px;
+  .lb-nav::before {
+    width: 34px;
+    height: 34px;
+    font-size: 22px;
   }
 }
 

--- a/assets/js/lightbox.js
+++ b/assets/js/lightbox.js
@@ -13,7 +13,10 @@
   const prevBtn = lightbox.querySelector('.lb-prev');
   const nextBtn = lightbox.querySelector('.lb-next');
   const dialogFrame = lightbox.querySelector('.lb-frame');
-  const closeTriggers = lightbox.querySelectorAll('[data-lb-close]');
+  const closeTriggers = Array.from(
+    lightbox.querySelectorAll('[data-lb-close]')
+  ).filter((el) => !el.classList.contains('lb-backdrop'));
+  const backdrop = lightbox.querySelector('.lb-backdrop');
   const html = document.documentElement;
 
   if (!imageEl || !countEl || !prevBtn || !nextBtn || !dialogFrame) {
@@ -179,6 +182,14 @@
   closeTriggers.forEach((trigger) => {
     trigger.addEventListener('click', close);
   });
+
+  if (backdrop) {
+    backdrop.addEventListener('click', (event) => {
+      if (event.target === backdrop) {
+        close();
+      }
+    });
+  }
 
   document.addEventListener('keydown', (event) => {
     if (!lightbox.classList.contains('on')) {

--- a/erga.html
+++ b/erga.html
@@ -94,9 +94,9 @@
     <div class="lb-backdrop" data-lb-close></div>
     <figure class="lb-frame" role="dialog" aria-modal="true" aria-label="Προβολή εικόνας">
       <button class="lb-close" aria-label="Κλείσιμο" data-lb-close>×</button>
-      <button class="lb-nav lb-prev" aria-label="Προηγούμενη">‹</button>
+      <button class="lb-nav lb-prev" aria-label="Προηγούμενη εικόνα" data-symbol="‹"></button>
       <img id="lb-img" class="lb-img" alt="">
-      <button class="lb-nav lb-next" aria-label="Επόμενη">›</button>
+      <button class="lb-nav lb-next" aria-label="Επόμενη εικόνα" data-symbol="›"></button>
       <figcaption class="lb-meta"><span id="lb-count">1/1</span></figcaption>
     </figure>
   </div>

--- a/index.html
+++ b/index.html
@@ -507,9 +507,9 @@
     <figure class="lb-frame" role="dialog" aria-modal="true" aria-label="Προβολή εικόνας">
       <button class="lb-close" aria-label="Κλείσιμο" data-lb-close>×</button>
 
-      <button class="lb-nav lb-prev" aria-label="Προηγούμενη εικόνα">‹</button>
+      <button class="lb-nav lb-prev" aria-label="Προηγούμενη εικόνα" data-symbol="‹"></button>
       <img id="lb-img" class="lb-img" alt="">
-      <button class="lb-nav lb-next" aria-label="Επόμενη εικόνα">›</button>
+      <button class="lb-nav lb-next" aria-label="Επόμενη εικόνα" data-symbol="›"></button>
 
       <figcaption class="lb-meta">
         <span class="lb-count" id="lb-count">1/1</span>


### PR DESCRIPTION
## Summary
- fix the lightbox navigation controls in place with larger click zones and viewport-centered positioning
- expose the arrow icons via data attributes in the HTML templates for the home and projects pages
- ensure backdrop clicks only close the lightbox when the backdrop itself is the direct target

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_6908fb1c419083208076bcc833dbb19c