### PR TITLE
Update contact widget email address

### DIFF
--- a/erga.html
+++ b/erga.html
@@ -160,7 +160,7 @@
 
   <div class="contact-widget" aria-label="Γρήγορη επικοινωνία">
     <div id="contactWidgetPanel" class="contact-widget__panel" aria-hidden="true">
-      <a class="contact-widget__link" href="mailto:info@example.com">
+      <a class="contact-widget__link" href="mailto:fmren2021@gmail.com">
         <span class="contact-widget__icon" aria-hidden="true">
           <img src="images/icons/email.svg" width="36" height="36" alt="" loading="lazy">
         </span>

--- a/index.html
+++ b/index.html
@@ -576,7 +576,7 @@
 
   <div class="contact-widget" aria-label="Γρήγορη επικοινωνία">
     <div id="contactWidgetPanel" class="contact-widget__panel" aria-hidden="true">
-      <a class="contact-widget__link" href="mailto:info@example.com">
+      <a class="contact-widget__link" href="mailto:fmren2021@gmail.com">
         <span class="contact-widget__icon" aria-hidden="true">
           <img src="images/icons/email.svg" width="36" height="36" alt="" loading="lazy">
         </span>

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -122,7 +122,7 @@
 
   <div class="contact-widget" aria-label="Γρήγορη επικοινωνία">
     <div id="contactWidgetPanel" class="contact-widget__panel" aria-hidden="true">
-      <a class="contact-widget__link" href="mailto:info@example.com">
+      <a class="contact-widget__link" href="mailto:fmren2021@gmail.com">
         <span class="contact-widget__icon" aria-hidden="true">
           <img src="images/icons/email.svg" width="36" height="36" alt="" loading="lazy">
         </span>

--- a/terms.html
+++ b/terms.html
@@ -121,7 +121,7 @@
 
   <div class="contact-widget" aria-label="Γρήγορη επικοινωνία">
     <div id="contactWidgetPanel" class="contact-widget__panel" aria-hidden="true">
-      <a class="contact-widget__link" href="mailto:info@example.com">
+      <a class="contact-widget__link" href="mailto:fmren2021@gmail.com">
         <span class="contact-widget__icon" aria-hidden="true">
           <img src="images/icons/email.svg" width="36" height="36" alt="" loading="lazy">
         </span>


### PR DESCRIPTION
## Summary
- update the contact widget email link on all pages to use fmren2021@gmail.com

## Testing
- no tests were run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_6908fcf76fac8320b82b514c7fb40015