### PR TITLE
Fix Formspree contact form validation handling

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -443,10 +443,22 @@ document.querySelectorAll('.logo-link').forEach(function(link){
 (()=>{
   const form=document.getElementById('contactForm');
   if(!form){return;}
-  const status=document.getElementById('formStatus');
+  const status=document.getElementById('form-status');
 
   form.addEventListener('submit',async event=>{
     event.preventDefault();
+    if(!form.checkValidity()){
+      if(status){
+        status.hidden=false;
+        status.textContent='Παρακαλώ συμπληρώστε τα απαραίτητα πεδία.';
+      }
+      if(typeof form.reportValidity==='function'){
+        form.reportValidity();
+      }
+      setTimeout(()=>{if(status){status.hidden=true;}},7000);
+      return;
+    }
+
     if(status){status.hidden=false;status.textContent='Αποστολή...';}
 
     try{

--- a/index.html
+++ b/index.html
@@ -434,7 +434,7 @@
           <h2>Επικοινωνία</h2>
           <p class="contact-intro">Στείλτε μας ένα μήνυμα και θα επικοινωνήσουμε μαζί σας το συντομότερο.</p>
 
-          <form id="contactForm" action="https://formspree.io/f/mkgqykrp" method="POST" novalidate>
+          <form id="contactForm" action="https://formspree.io/f/mkgqykrp" method="POST">
             <div class="form-group">
               <label for="name">Ονοματεπώνυμο</label>
               <input id="name" name="name" type="text" placeholder="Πλήρες όνομα" required>
@@ -489,7 +489,7 @@
             <button type="submit" class="btn-submit">Αποστολή Μηνύματος</button>
 
             <!-- Inline feedback -->
-            <p id="formStatus" class="form-status" aria-live="polite" hidden></p>
+            <p id="form-status" class="form-status" aria-live="polite" hidden></p>
           </form>
         </div>
         <div class="map">


### PR DESCRIPTION
## Summary
- remove the `novalidate` attribute and add a dedicated status element for inline feedback
- gate Formspree submissions behind native form validation and surface localized messages

## Testing
- not run (static site changes)


------
https://chatgpt.com/codex/tasks/task_e_6908fde660088320a6bc91fe3e5da6e1