### PR TITLE
Adjust lightbox navigation arrows to viewport edges

### DIFF
--- a/assets/css/lightbox.css
+++ b/assets/css/lightbox.css
@@ -67,7 +67,7 @@
 }
 
 .lb-nav {
-  position: absolute;
+  position: fixed;
   top: 50%;
   transform: translateY(-50%);
   width: 44px;
@@ -82,6 +82,7 @@
   color: var(--lb-fg);
   display: grid;
   place-items: center;
+  z-index: 1;
 }
 
 .lb-nav:disabled {
@@ -90,11 +91,11 @@
 }
 
 .lb-prev {
-  left: -52px;
+  left: 16px;
 }
 
 .lb-next {
-  right: -52px;
+  right: 16px;
 }
 
 .lb-meta {


### PR DESCRIPTION
## Summary
- fix the lightbox navigation buttons to the viewport so they stay vertically centered at the screen edges
- keep the existing button dimensions and styling while ensuring visibility above the backdrop

## Testing
- Manually verified the lightbox navigation arrows stay fixed at the edges while browsing images

------
https://chatgpt.com/codex/tasks/task_e_690b679f0aec83208f750dd37f861f68