### PR TITLE
Add upcoming projects queue section to works page

### DIFF
--- a/assets/css/erga.css
+++ b/assets/css/erga.css
@@ -39,6 +39,52 @@
   min-width: 220px;
 }
 
+.projects-queue {
+  background: #f8fafc;
+  padding: 48px 16px;
+}
+
+.projects-queue__inner {
+  max-width: 960px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.projects-queue h2 {
+  margin: 0;
+  font-size: clamp(26px, 4vw, 34px);
+  color: var(--erga-slate);
+  text-align: center;
+}
+
+.projects-queue p {
+  margin: 0;
+  color: #475569;
+  font-size: 17px;
+  text-align: center;
+}
+
+.projects-queue__list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.projects-queue__list li {
+  background: #ffffff;
+  border-radius: 12px;
+  padding: 14px 18px;
+  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.08);
+  color: #0f172a;
+  font-weight: 600;
+  text-align: center;
+}
+
 .projects {
   max-width: 1200px;
   margin: 0 auto;

--- a/erga.html
+++ b/erga.html
@@ -88,6 +88,26 @@
     </div>
   </header>
 
+  <section class="projects-queue" aria-labelledby="projects-queue-title">
+    <div class="container projects-queue__inner">
+      <h2 id="projects-queue-title">Έργα σε αναμονή</h2>
+      <p>Τα παρακάτω projects βρίσκονται στο πρόγραμμα και θα παρουσιαστούν αναλυτικά σύντομα.</p>
+      <ul class="projects-queue__list">
+        <li>Ολική Ανακαίνιση Ισόγειας Κατοικίας</li>
+        <li>Ολική Ανακαίνιση Υπογείου Διαμερίσματος</li>
+        <li>Κουφώματα αλουμινίου - PVC</li>
+        <li>Κουζίνες</li>
+        <li>Ντουλάπες</li>
+        <li>Αποκατάσταση - Τοποθέτηση Δαπέδων</li>
+        <li>Αποκατάσταση μωσαϊκών δαπέδων</li>
+        <li>Μόνωση ταράτσας</li>
+        <li>Αποκατάσταση στηθαίων πολυκατοικίας, Πειραιάς</li>
+        <li>Αποκατάσταση στηθαίων - κιόνων μπαλκονιών σε συγκρότημα κατοικιών στο Καβούρι Αττικής</li>
+        <li>Μεταλλικές Κατασκευές</li>
+      </ul>
+    </div>
+  </section>
+
   <main id="projects" class="projects" data-json="data/projects.json"></main>
 
   <div class="lb" id="lightbox" aria-hidden="true" tabindex="-1">


### PR DESCRIPTION
## Summary
- add an "Έργα σε αναμονή" section on the works page to list upcoming projects
- style the new queue list with responsive cards matching the page aesthetics

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69122040ebb48320aad4b550eed3a0b2)