### PR TITLE
Remove duplicate cover image from after gallery

### DIFF
--- a/data/projects.json
+++ b/data/projects.json
@@ -68,7 +68,6 @@
         "images": [
           "ampelokipoi6.jpg",
           "ampelokipoi5.jpg",
-          "ampelokipoi6.jpg",
           "ampelokipoi7.jpg",
           "ampelokipoi8.jpg",
           "ampelokipoi9.jpg",


### PR DESCRIPTION
## Summary
- remove the duplicate cover photo from the "Μετά" gallery for the basement renovation project

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912308206e0832084f008e6f1aedf4e)