### PR TITLE
Reorder before gallery images for basement renovation

### DIFF
--- a/data/projects.json
+++ b/data/projects.json
@@ -81,9 +81,9 @@
       {
         "title": "Πριν",
         "images": [
-          "ampelokipoi1.jpg",
+          "ampelokipoi3.jpg",
           "ampelokipoi2.jpg",
-          "ampelokipoi3.jpg"
+          "ampelokipoi1.jpg"
         ]
       }
     ]


### PR DESCRIPTION
## Summary
- reorder the "Πριν" gallery images for the basement renovation project so the former third photo appears first while the middle entry remains unchanged

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912325a1d648320b17c14f79267bb4b)