### PR TITLE
Add lastmod metadata to sitemap entries

### DIFF
--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,21 +2,25 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://anakainisou.gr/</loc>
+    <lastmod>2024-05-01</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://anakainisou.gr/erga/</loc>
+    <lastmod>2024-05-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://anakainisou.gr/privacy-policy/</loc>
+    <lastmod>2024-05-01</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.4</priority>
   </url>
   <url>
     <loc>https://anakainisou.gr/terms/</loc>
+    <lastmod>2024-05-01</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.4</priority>
   </url>


### PR DESCRIPTION
## Summary
- add ISO-formatted `lastmod` values for every URL in the sitemap to meet protocol expectations

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914d1b7f20083208524407d3525d563)