### PR TITLE
Improve image alt text and sizing metadata

### DIFF
--- a/erga.html
+++ b/erga.html
@@ -27,7 +27,7 @@
     <div class="container header-inner">
       <div class="brand">
         <a href="/" class="logo-link" aria-label="Αρχική σελίδα">
-          <img class="brand-logo" src="images/logo.png" alt="FM Renovation λογότυπο">
+          <img class="brand-logo" src="images/logo.png" width="1024" height="1024" alt="FM Renovation λογότυπο">
         </a>
         <span class="brand-tagline"><strong>Ανακαίνιση χώρου</strong></span>
       </div>
@@ -93,7 +93,7 @@
     <figure class="lb-frame" role="dialog" aria-modal="true" aria-label="Προβολή εικόνας">
       <button class="lb-close" aria-label="Κλείσιμο" data-lb-close>×</button>
       <button class="lb-nav lb-prev" aria-label="Προηγούμενη">‹</button>
-      <img id="lb-img" class="lb-img" alt="">
+      <img id="lb-img" class="lb-img" alt="Προβολή έργου ανακαίνισης — FM Renovation">
       <button class="lb-nav lb-next" aria-label="Επόμενη">›</button>
       <figcaption class="lb-meta"><span id="lb-count">1/1</span></figcaption>
     </figure>
@@ -133,7 +133,7 @@
       <div class="footer-brand">
         <div class="brand brand--footer">
           <a href="/" class="logo-link" aria-label="Αρχική σελίδα">
-            <img class="brand-logo" src="images/logo.png" alt="FM Renovation λογότυπο">
+            <img class="brand-logo" src="images/logo.png" width="1024" height="1024" alt="FM Renovation λογότυπο">
           </a>
         </div>
         <nav class="footer-links" aria-label="Χρήσιμες σύνδεσμοι">

--- a/index.html
+++ b/index.html
@@ -87,7 +87,7 @@
     <div class="container header-inner">
       <div class="brand">
         <a href="/" class="logo-link" aria-label="Αρχική σελίδα">
-          <img class="brand-logo" src="images/logo.png" alt="FM Renovation λογότυπο">
+          <img class="brand-logo" src="images/logo.png" width="1024" height="1024" alt="FM Renovation λογότυπο">
         </a>
         <span class="brand-tagline"><strong>Ανακαίνιση χώρου</strong></span>
       </div>
@@ -309,7 +309,7 @@
               <h4>Επίσκεψη<br>στον χώρο</h4>
             </div>
             <p>Επισκεπτόμαστε παρουσία σας το χώρο που θέλετε να ανακαινίσετε.</p>
-            <img src="images/visit.jpg" width="1200" height="800" alt="Επίσκεψη τεχνικού της FM Renovation στον χώρο του πελάτη" loading="lazy">
+            <img src="images/visit.jpg" width="512" height="512" alt="Επίσκεψη τεχνικού της FM Renovation στον χώρο του πελάτη για μελέτη ανακαίνισης." loading="lazy">
           </div>
 
           <div class="step" data-animate="fade-up">
@@ -393,20 +393,20 @@
         <div class="carousel" data-carousel>
           <button class="car-btn prev" aria-label="Προηγούμενη">‹</button>
           <div class="car-track" data-track>
-            <img class="car-img" src="photos/fm13.jpg" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – σύγχρονος χώρος διαβίωσης με καθαρές γραμμές.">
-            <img class="car-img" src="erga/renovation2.jpg" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – ανακαίνιση διαμερίσματος με νέες επιφάνειες και φωτισμό.">
-            <img class="car-img" src="erga/windows1.jpg" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – αντικατάσταση κουφωμάτων με ενεργειακά αποδοτικά παράθυρα.">
-            <img class="car-img" src="erga/windows2.jpg" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – τοποθέτηση νέων αλουμινίων σε μπαλκονόπορτα.">
-            <img class="car-img" src="erga/windows4.jpg" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – αναβάθμιση παραθύρων με θερμομόνωση.">
-            <img class="car-img" src="erga/windows5.jpg" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – παράθυρο αλουμινίου με σύγχρονο σχεδιασμό.">
-            <img class="car-img" src="erga/masaiko1.jpg" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – εφαρμογή μωσαϊκού δαπέδου σε σαλόνι.">
-            <img class="car-img" src="erga/masaiko2.jpg" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – λεπτομέρεια τοποθέτησης μωσαϊκού δαπέδου.">
-            <img class="car-img" src="erga/masaiko3.jpg" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – ολοκληρωμένο μωσαϊκό δάπεδο σε εσωτερικό χώρο.">
-            <img class="car-img" src="erga/masaiko4.jpg" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – μωσαϊκό δάπεδο με κομψές λεπτομέρειες.">
-            <img class="car-img" src="erga/floor1.jpg" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – ανακαίνιση δαπέδου με ξύλινη υφή.">
-            <img class="car-img" src="erga/floor2.jpg" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – τοποθέτηση νέου δαπέδου σε χώρο υποδοχής.">
-            <img class="car-img" src="erga/insulation1.jpg" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – εργασίες μόνωσης με εξειδικευμένα υλικά.">
-            <img class="car-img" src="erga/insulation3.jpg" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – λεπτομέρεια εφαρμογής θερμομόνωσης εξωτερικού τοίχου.">
+            <img class="car-img" src="photos/fm13.jpg" width="810" height="1079" loading="lazy" alt="Έργο ανακαίνισης σαλονιού — FM Renovation με σύγχρονο χώρο διαβίωσης και καθαρές γραμμές.">
+            <img class="car-img" src="erga/renovation2.jpg" width="800" height="900" loading="lazy" alt="Έργο ανακαίνισης διαμερίσματος — FM Renovation με νέες επιφάνειες και ζεστό φωτισμό.">
+            <img class="car-img" src="erga/windows1.jpg" width="396" height="298" loading="lazy" alt="Έργο αντικατάστασης κουφωμάτων — FM Renovation με ενεργειακά αποδοτικά παράθυρα.">
+            <img class="car-img" src="erga/windows2.jpg" width="396" height="298" loading="lazy" alt="Έργο αντικατάστασης κουφωμάτων — FM Renovation με νέες μπαλκονόπορτες αλουμινίου.">
+            <img class="car-img" src="erga/windows4.jpg" width="451" height="600" loading="lazy" alt="Έργο θερμομονωτικής αναβάθμισης κουφωμάτων — FM Renovation.">
+            <img class="car-img" src="erga/windows5.jpg" width="451" height="600" loading="lazy" alt="Έργο αντικατάστασης παραθύρου αλουμινίου — FM Renovation με σύγχρονο σχεδιασμό.">
+            <img class="car-img" src="erga/masaiko1.jpg" width="450" height="600" loading="lazy" alt="Έργο ανακαίνισης δαπέδου — FM Renovation με εφαρμογή μωσαϊκού σε σαλόνι.">
+            <img class="car-img" src="erga/masaiko2.jpg" width="450" height="600" loading="lazy" alt="Έργο ανακαίνισης δαπέδου — FM Renovation με λεπτομέρεια μωσαϊκού δαπέδου.">
+            <img class="car-img" src="erga/masaiko3.jpg" width="450" height="600" loading="lazy" alt="Έργο ανακαίνισης δαπέδου — FM Renovation ολοκληρωμένο μωσαϊκό εσωτερικού χώρου.">
+            <img class="car-img" src="erga/masaiko4.jpg" width="450" height="600" loading="lazy" alt="Έργο ανακαίνισης δαπέδου — FM Renovation μωσαϊκό με κομψές λεπτομέρειες.">
+            <img class="car-img" src="erga/floor1.jpg" width="791" height="600" loading="lazy" alt="Έργο ανακαίνισης δαπέδου — FM Renovation με επιφάνεια ξύλινης υφής.">
+            <img class="car-img" src="erga/floor2.jpg" width="600" height="600" loading="lazy" alt="Έργο ανακαίνισης υποδοχής — FM Renovation με νέο ανθεκτικό δάπεδο.">
+            <img class="car-img" src="erga/insulation1.jpg" width="600" height="600" loading="lazy" alt="Έργο θερμομόνωσης — FM Renovation με εφαρμογή εξειδικευμένων υλικών.">
+            <img class="car-img" src="erga/insulation3.jpg" width="600" height="600" loading="lazy" alt="Έργο θερμομόνωσης — FM Renovation λεπτομέρεια εφαρμογής εξωτερικού τοίχου.">
           </div>
           <button class="car-btn next" aria-label="Επόμενη">›</button>
         </div>
@@ -510,7 +510,7 @@
       <button class="lb-close" aria-label="Κλείσιμο" data-lb-close>×</button>
 
       <button class="lb-nav lb-prev" aria-label="Προηγούμενη εικόνα">‹</button>
-      <img id="lb-img" class="lb-img" alt="">
+      <img id="lb-img" class="lb-img" alt="Προβολή έργου ανακαίνισης — FM Renovation">
       <button class="lb-nav lb-next" aria-label="Επόμενη εικόνα">›</button>
 
       <figcaption class="lb-meta">
@@ -553,7 +553,7 @@
       <div class="footer-brand">
         <div class="brand brand--footer">
           <a href="/" class="logo-link" aria-label="Αρχική σελίδα">
-            <img class="brand-logo" src="images/logo.png" alt="FM Renovation λογότυπο">
+            <img class="brand-logo" src="images/logo.png" width="1024" height="1024" alt="FM Renovation λογότυπο">
           </a>
         </div>
         <nav class="footer-links" aria-label="Χρήσιμες σύνδεσμοι">

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -20,7 +20,7 @@
     <div class="container header-inner">
       <div class="brand">
         <a href="/" class="logo-link" aria-label="Αρχική σελίδα">
-          <img class="brand-logo" src="images/logo.png" alt="FM Renovation λογότυπο">
+          <img class="brand-logo" src="images/logo.png" width="1024" height="1024" alt="FM Renovation λογότυπο">
         </a>
         <span class="brand-tagline"><strong>Ανακαίνιση χώρου</strong></span>
       </div>
@@ -97,7 +97,7 @@
     <div class="container footer-inner">
       <div class="brand brand--footer">
         <a href="/" class="logo-link" aria-label="Αρχική σελίδα">
-          <img class="brand-logo" src="images/logo.png" alt="FM Renovation λογότυπο">
+          <img class="brand-logo" src="images/logo.png" width="1024" height="1024" alt="FM Renovation λογότυπο">
         </a>
       </div>
       <p>© <span id="year"></span> FM Renovation • <a href="https://anakainisou.gr/">anakainisou.gr</a></p>

--- a/terms.html
+++ b/terms.html
@@ -20,7 +20,7 @@
     <div class="container header-inner">
       <div class="brand">
         <a href="/" class="logo-link" aria-label="Αρχική σελίδα">
-          <img class="brand-logo" src="images/logo.png" alt="FM Renovation λογότυπο">
+          <img class="brand-logo" src="images/logo.png" width="1024" height="1024" alt="FM Renovation λογότυπο">
         </a>
         <span class="brand-tagline"><strong>Ανακαίνιση χώρου</strong></span>
       </div>
@@ -96,7 +96,7 @@
     <div class="container footer-inner">
       <div class="brand brand--footer">
         <a href="/" class="logo-link" aria-label="Αρχική σελίδα">
-          <img class="brand-logo" src="images/logo.png" alt="FM Renovation λογότυπο">
+          <img class="brand-logo" src="images/logo.png" width="1024" height="1024" alt="FM Renovation λογότυπο">
         </a>
       </div>
       <p>© <span id="year"></span> FM Renovation • <a href="https://anakainisou.gr/">anakainisou.gr</a></p>


### PR DESCRIPTION
## Summary
- add explicit dimensions to the site logo and gallery imagery
- refresh gallery and process imagery alt text with descriptive Greek copy
- supply descriptive fallback text for lightbox previews on the home and projects pages

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914d27417908320930da5be7b5c9d87)