### PR TITLE
Add business address to footer contact information

### DIFF
--- a/index.html
+++ b/index.html
@@ -548,6 +548,14 @@
             </span>
             <span><a href="mailto:fmren2021@gmail.com">fmren2021@gmail.com</a></span>
           </li>
+          <li class="footer-list__item">
+            <span class="footer-list__icon" aria-hidden="true">
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path d="M12 2a7 7 0 0 0-7 7c0 4.67 4.24 9.87 6.34 12.09a1 1 0 0 0 1.32 0C14.76 18.87 19 13.67 19 9a7 7 0 0 0-7-7Zm0 10a3 3 0 1 1 0-6 3 3 0 0 1 0 6Z" fill="currentColor"/>
+              </svg>
+            </span>
+            <span>Δοϊράνης 180, Καλλιθέα Τ.Κ. 17673</span>
+          </li>
         </ul>
       </div>
       <div class="footer-brand">


### PR DESCRIPTION
## Summary
- add the company address to the footer contact list alongside the existing phone and email details

## Testing
- not run (static content update)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914ed21c52c8320a7951d0d1ebc595c)