### PR TITLE
Add footer operating hours under social media links

### DIFF
--- a/erga.html
+++ b/erga.html
@@ -150,6 +150,11 @@
           <a href="https://www.facebook.com/share/1CJUXM8xkk/" aria-label="Facebook" class="icon fb" target="_blank" rel="noopener noreferrer"></a>
           <a href="https://www.instagram.com/fm.renovation21/" aria-label="Instagram" class="icon ig"></a>
         </div>
+        <p class="footer-hours">
+          Δευ–Παρ: 08:00–16:00<br>
+          Σάβ: 09:00–15:00<br>
+          Κυρ: Κλειστά
+        </p>
       </div>
     </div>
   </footer>

--- a/index.html
+++ b/index.html
@@ -576,6 +576,11 @@
           <a href="https://www.facebook.com/share/1CJUXM8xkk/" aria-label="Facebook" class="icon fb" target="_blank" rel="noopener noreferrer"></a>
           <a href="https://www.instagram.com/fm.renovation21/" aria-label="Instagram" class="icon ig"></a>
         </div>
+        <p class="footer-hours">
+          Δευ–Παρ: 08:00–16:00<br>
+          Σάβ: 09:00–15:00<br>
+          Κυρ: Κλειστά
+        </p>
       </div>
     </div>
   </footer>


### PR DESCRIPTION
## Summary
- display operating hours below the social media icons in the footers of the home and projects pages

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914f40a6f3c8320bda5914118d63e9f)