### PR TITLE
Add address to erga footer contact info

### DIFF
--- a/erga.html
+++ b/erga.html
@@ -130,6 +130,14 @@
             </span>
             <span><a href="mailto:fmren2021@gmail.com">fmren2021@gmail.com</a></span>
           </li>
+          <li class="footer-list__item">
+            <span class="footer-list__icon" aria-hidden="true">
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path d="M12 2a7 7 0 0 0-7 7c0 4.67 4.24 9.87 6.34 12.09a1 1 0 0 0 1.32 0C14.76 18.87 19 13.67 19 9a7 7 0 0 0-7-7Zm0 10a3 3 0 1 1 0-6 3 3 0 0 1 0 6Z" fill="currentColor"/>
+              </svg>
+            </span>
+            <span>Δοϊράνης 180, Καλλιθέα Τ.Κ. 17673</span>
+          </li>
         </ul>
       </div>
       <div class="footer-brand">


### PR DESCRIPTION
## Summary
- add the physical address to the contact details in the erga page footer

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914f44ab564832097d1b4082eb24fac)