### PR TITLE
Add standalone cookie consent demo page

### DIFF
--- a/cookie-test.html
+++ b/cookie-test.html
@@ -1,0 +1,211 @@
+<!DOCTYPE html>
+<html lang="el">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Cookie Consent Demo</title>
+  <style>
+    :root {
+      --brand-color: #2B0042;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      background: #f7f7f7;
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 24px;
+      color: #222;
+    }
+
+    main {
+      max-width: 720px;
+      width: 100%;
+      background: #fff;
+      padding: 24px;
+      border-radius: 16px;
+      box-shadow: 0 12px 40px rgba(0, 0, 0, 0.08);
+    }
+
+    h1 {
+      margin-top: 0;
+      color: var(--brand-color);
+    }
+
+    p {
+      line-height: 1.6;
+    }
+
+    /* Cookie banner */
+    #cookie-banner {
+      position: fixed;
+      bottom: 16px;
+      left: 50%;
+      transform: translateX(-50%);
+      width: min(360px, calc(100% - 24px));
+      background: #fff;
+      border-radius: 14px;
+      box-shadow: 0 10px 32px rgba(0, 0, 0, 0.18);
+      padding: 16px 18px;
+      display: none;
+      gap: 12px;
+      z-index: 1000;
+    }
+
+    #cookie-banner.show {
+      display: grid;
+    }
+
+    #cookie-banner .title {
+      font-weight: 700;
+      margin: 0 0 6px;
+      color: var(--brand-color);
+    }
+
+    #cookie-banner .message {
+      margin: 0 0 12px;
+      font-size: 14px;
+      line-height: 1.5;
+      color: #333;
+    }
+
+    #cookie-banner .actions {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+      gap: 10px;
+    }
+
+    #cookie-banner button {
+      border: 1px solid var(--brand-color);
+      border-radius: 10px;
+      padding: 10px 12px;
+      font-size: 14px;
+      font-weight: 600;
+      cursor: pointer;
+      transition: all 0.2s ease;
+    }
+
+    #accept-all {
+      background: var(--brand-color);
+      color: #fff;
+    }
+
+    #accept-all:hover {
+      background: #3a0060;
+      border-color: #3a0060;
+    }
+
+    #necessary-only {
+      background: #fff;
+      color: var(--brand-color);
+    }
+
+    #necessary-only:hover {
+      background: #f4e9ff;
+    }
+
+    @media (max-width: 520px) {
+      body {
+        padding: 12px;
+      }
+
+      main {
+        padding: 18px;
+      }
+
+      #cookie-banner {
+        bottom: 12px;
+        padding: 14px 16px;
+      }
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>Καλώς ήρθατε!</h1>
+    <p>
+      Αυτό είναι ένα παράδειγμα στατικής σελίδας με banner συγκατάθεσης cookies.
+      Κλείστε και ανοίξτε ξανά τη σελίδα για να δοκιμάσετε την αποθήκευση της επιλογής.
+    </p>
+  </main>
+
+  <section id="cookie-banner" role="dialog" aria-live="polite" aria-label="Cookie consent">
+    <div class="title">Χρησιμοποιούμε cookies</div>
+    <div class="message">Χρησιμοποιούμε cookies για να βελτιώσουμε την εμπειρία σας. Επιλέξτε πώς θέλετε να συνεχίσετε.</div>
+    <div class="actions">
+      <button id="accept-all" type="button">Αποδοχή όλων</button>
+      <button id="necessary-only" type="button">Μόνο απαραίτητα</button>
+    </div>
+  </section>
+
+  <script>
+    (function() {
+      const STORAGE_KEY = "cookieConsent";
+
+      function getConsent() {
+        try {
+          return localStorage.getItem(STORAGE_KEY);
+        } catch (err) {
+          console.error("Δεν ήταν δυνατή η πρόσβαση στο localStorage", err);
+          return null;
+        }
+      }
+
+      function saveConsent(value) {
+        try {
+          localStorage.setItem(STORAGE_KEY, value);
+        } catch (err) {
+          console.error("Δεν ήταν δυνατή η αποθήκευση στο localStorage", err);
+        }
+      }
+
+      function hideBanner() {
+        document.getElementById("cookie-banner").classList.remove("show");
+      }
+
+      function showBanner() {
+        document.getElementById("cookie-banner").classList.add("show");
+      }
+
+      function initCookieBanner() {
+        const existingConsent = getConsent();
+        if (existingConsent) {
+          hideBanner();
+          return;
+        }
+        showBanner();
+      }
+
+      document.addEventListener("DOMContentLoaded", function() {
+        const acceptAllBtn = document.getElementById("accept-all");
+        const necessaryOnlyBtn = document.getElementById("necessary-only");
+
+        acceptAllBtn.addEventListener("click", function() {
+          saveConsent("accepted");
+          console.log("Analytics ENABLED");
+          hideBanner();
+        });
+
+        necessaryOnlyBtn.addEventListener("click", function() {
+          saveConsent("necessary");
+          console.log("Analytics DISABLED");
+          hideBanner();
+        });
+
+        initCookieBanner();
+      });
+
+      window.getConsent = getConsent;
+      window.saveConsent = saveConsent;
+      window.initCookieBanner = initCookieBanner;
+    })();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add self-contained HTML page demonstrating cookie consent banner behavior
- include responsive styling and localStorage persistence for consent choices

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928ca13ede08320a4d24215ab8498ec)