### PR TITLE
Update Google Maps embed on contact page

### DIFF
--- a/index.html
+++ b/index.html
@@ -495,8 +495,8 @@
           </form>
         </div>
         <div class="map">
-          <iframe title="Χάρτης" loading="lazy" referrerpolicy="no-referrer-when-downgrade"
-            src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3151!2d23.7275!3d37.9838!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x0%3A0x0!2zQXRoZW5z!5e0!3m2!1sel!2sgr!4v0000000000"></iframe>
+          <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3146.316254805402!2d23.698714476547654!3d37.94640100225389!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x66d032e1e4d0f22b%3A0x2808a708424de056!2zRk0gUmVub3ZhdGlvbiAtIM6Rzr3Osc66zrHOr869zrnPg863IM-Hz47Pgc6_z4U!5e0!3m2!1sel!2sgr!4v1764374951391!5m2!1sel!2sgr"
+            width="600" height="450" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- replace the contact page Google Maps iframe with the provided embed code

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692a3a588814832096c57151c94aee76)