### PR TITLE
Make Google Maps embed responsive

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -337,3 +337,19 @@ body.nav-open{overflow:hidden}
   .services-chip,.services-mobile-controls,.service__toggle,.service__panel,.service__panel-inner{transition:none !important}
   [data-animate="fade-up"],[data-animate="fade-up"].visible{transition:none !important;transform:none !important}
 }
+
+/* Responsive Google Map */
+.map {
+  position: relative;
+  width: 100%;
+  padding-bottom: 56.25%; /* 16:9 */
+  height: 0;
+}
+.map iframe {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  border: 0;
+}


### PR DESCRIPTION
## Summary
- add responsive styling for the Google Maps embed to maintain 16:9 aspect ratio

## Testing
- not run (not necessary for CSS-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692a400a6944832080613e7e40763081)