### PR TITLE
Add cookie consent banner

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -353,3 +353,52 @@ body.nav-open{overflow:hidden}
   height: 100%;
   border: 0;
 }
+
+/* Cookie Banner */
+.cookie-banner {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background: #1f1f1f;
+  color: #fff;
+  padding: 16px 20px;
+  z-index: 9999;
+  display: none;
+  box-shadow: 0 -4px 20px rgba(0,0,0,0.25);
+}
+.cookie-banner__inner {
+  max-width: 960px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.cookie-banner__text {
+  margin: 0;
+  font-size: 15px;
+  line-height: 1.5;
+}
+.cookie-banner__link {
+  color: var(--accent-color, #F59E0B);
+  text-decoration: underline;
+}
+.cookie-banner__actions {
+  display: flex;
+  gap: 10px;
+}
+.cookie-banner__btn {
+  padding: 10px 16px;
+  border: none;
+  cursor: pointer;
+  border-radius: 6px;
+  font-size: 14px;
+}
+.cookie-banner__btn--primary {
+  background: var(--accent-color, #F59E0B);
+  color: #000;
+}
+.cookie-banner__btn--secondary {
+  background: #444;
+  color: #fff;
+}

--- a/erga.html
+++ b/erga.html
@@ -194,6 +194,50 @@
     </button>
   </div>
 
+  <!-- Cookie Banner -->
+  <div class="cookie-banner" id="cookieBanner">
+    <div class="cookie-banner__inner">
+      <p class="cookie-banner__text">
+        Χρησιμοποιούμε cookies για να βελτιώσουμε την εμπειρία σας.
+        Συνεχίζοντας αποδέχεστε τη χρήση τους.
+        <a href="/privacy-policy/" class="cookie-banner__link">Μάθετε περισσότερα</a>.
+      </p>
+      <div class="cookie-banner__actions">
+        <button type="button" class="cookie-banner__btn cookie-banner__btn--secondary" id="cookieReject">
+          Μόνο τα απαραίτητα
+        </button>
+        <button type="button" class="cookie-banner__btn cookie-banner__btn--primary" id="cookieAccept">
+          Αποδοχή
+        </button>
+      </div>
+    </div>
+  </div>
+
+  <script>
+  (function(){
+    const banner = document.getElementById('cookieBanner');
+    const accept = document.getElementById('cookieAccept');
+    const reject = document.getElementById('cookieReject');
+
+    if (!banner || !accept || !reject) return;
+
+    // Show only if not previously set
+    if (!localStorage.getItem('cookieConsent')) {
+      banner.style.display = 'block';
+    }
+
+    accept.addEventListener('click', () => {
+      localStorage.setItem('cookieConsent', 'accepted');
+      banner.style.display = 'none';
+    });
+
+    reject.addEventListener('click', () => {
+      localStorage.setItem('cookieConsent', 'minimal');
+      banner.style.display = 'none';
+    });
+  })();
+  </script>
+
   <script src="assets/app.js" defer></script>
   <script src="assets/js/lightbox.js" defer></script>
   <script src="assets/js/erga.js" defer></script>

--- a/index.html
+++ b/index.html
@@ -611,6 +611,50 @@
     </button>
   </div>
 
+  <!-- Cookie Banner -->
+  <div class="cookie-banner" id="cookieBanner">
+    <div class="cookie-banner__inner">
+      <p class="cookie-banner__text">
+        Χρησιμοποιούμε cookies για να βελτιώσουμε την εμπειρία σας.
+        Συνεχίζοντας αποδέχεστε τη χρήση τους.
+        <a href="/privacy-policy/" class="cookie-banner__link">Μάθετε περισσότερα</a>.
+      </p>
+      <div class="cookie-banner__actions">
+        <button type="button" class="cookie-banner__btn cookie-banner__btn--secondary" id="cookieReject">
+          Μόνο τα απαραίτητα
+        </button>
+        <button type="button" class="cookie-banner__btn cookie-banner__btn--primary" id="cookieAccept">
+          Αποδοχή
+        </button>
+      </div>
+    </div>
+  </div>
+
+  <script>
+  (function(){
+    const banner = document.getElementById('cookieBanner');
+    const accept = document.getElementById('cookieAccept');
+    const reject = document.getElementById('cookieReject');
+
+    if (!banner || !accept || !reject) return;
+
+    // Show only if not previously set
+    if (!localStorage.getItem('cookieConsent')) {
+      banner.style.display = 'block';
+    }
+
+    accept.addEventListener('click', () => {
+      localStorage.setItem('cookieConsent', 'accepted');
+      banner.style.display = 'none';
+    });
+
+    reject.addEventListener('click', () => {
+      localStorage.setItem('cookieConsent', 'minimal');
+      banner.style.display = 'none';
+    });
+  })();
+  </script>
+
   <script src="assets/js/lightbox.js" defer></script>
   <script src="assets/app.js" defer></script>
 </body>

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -143,6 +143,50 @@
     </button>
   </div>
 
+  <!-- Cookie Banner -->
+  <div class="cookie-banner" id="cookieBanner">
+    <div class="cookie-banner__inner">
+      <p class="cookie-banner__text">
+        Χρησιμοποιούμε cookies για να βελτιώσουμε την εμπειρία σας.
+        Συνεχίζοντας αποδέχεστε τη χρήση τους.
+        <a href="/privacy-policy/" class="cookie-banner__link">Μάθετε περισσότερα</a>.
+      </p>
+      <div class="cookie-banner__actions">
+        <button type="button" class="cookie-banner__btn cookie-banner__btn--secondary" id="cookieReject">
+          Μόνο τα απαραίτητα
+        </button>
+        <button type="button" class="cookie-banner__btn cookie-banner__btn--primary" id="cookieAccept">
+          Αποδοχή
+        </button>
+      </div>
+    </div>
+  </div>
+
+  <script>
+  (function(){
+    const banner = document.getElementById('cookieBanner');
+    const accept = document.getElementById('cookieAccept');
+    const reject = document.getElementById('cookieReject');
+
+    if (!banner || !accept || !reject) return;
+
+    // Show only if not previously set
+    if (!localStorage.getItem('cookieConsent')) {
+      banner.style.display = 'block';
+    }
+
+    accept.addEventListener('click', () => {
+      localStorage.setItem('cookieConsent', 'accepted');
+      banner.style.display = 'none';
+    });
+
+    reject.addEventListener('click', () => {
+      localStorage.setItem('cookieConsent', 'minimal');
+      banner.style.display = 'none';
+    });
+  })();
+  </script>
+
   <script src="assets/app.js" defer></script>
 </body>
 </html>

--- a/terms.html
+++ b/terms.html
@@ -142,6 +142,50 @@
     </button>
   </div>
 
+  <!-- Cookie Banner -->
+  <div class="cookie-banner" id="cookieBanner">
+    <div class="cookie-banner__inner">
+      <p class="cookie-banner__text">
+        Χρησιμοποιούμε cookies για να βελτιώσουμε την εμπειρία σας.
+        Συνεχίζοντας αποδέχεστε τη χρήση τους.
+        <a href="/privacy-policy/" class="cookie-banner__link">Μάθετε περισσότερα</a>.
+      </p>
+      <div class="cookie-banner__actions">
+        <button type="button" class="cookie-banner__btn cookie-banner__btn--secondary" id="cookieReject">
+          Μόνο τα απαραίτητα
+        </button>
+        <button type="button" class="cookie-banner__btn cookie-banner__btn--primary" id="cookieAccept">
+          Αποδοχή
+        </button>
+      </div>
+    </div>
+  </div>
+
+  <script>
+  (function(){
+    const banner = document.getElementById('cookieBanner');
+    const accept = document.getElementById('cookieAccept');
+    const reject = document.getElementById('cookieReject');
+
+    if (!banner || !accept || !reject) return;
+
+    // Show only if not previously set
+    if (!localStorage.getItem('cookieConsent')) {
+      banner.style.display = 'block';
+    }
+
+    accept.addEventListener('click', () => {
+      localStorage.setItem('cookieConsent', 'accepted');
+      banner.style.display = 'none';
+    });
+
+    reject.addEventListener('click', () => {
+      localStorage.setItem('cookieConsent', 'minimal');
+      banner.style.display = 'none';
+    });
+  })();
+  </script>
+
   <script src="assets/app.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add reusable cookie consent banner markup to main site pages
- style the banner and buttons for accessibility and visibility
- implement localStorage-based consent handling script across pages

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c8641018883208b54577f4dfd004a)