### PR TITLE
Add cookie policy page and update banner links

### DIFF
--- a/cookie-policy.html
+++ b/cookie-policy.html
@@ -3,9 +3,9 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>FM Renovation – Πολιτική Απορρήτου</title>
-  <meta name="description" content="Πολιτική απορρήτου της FM Renovation σύμφωνα με τον Γενικό Κανονισμό Προστασίας Δεδομένων (GDPR).">
-  <link rel="canonical" href="https://anakainisou.gr/privacy-policy">
+  <title>FM Renovation – Πολιτική Cookies</title>
+  <meta name="description" content="Πολιτική cookies της FM Renovation: τι είναι τα cookies, πώς τα χρησιμοποιούμε και πώς μπορείτε να διαχειριστείτε τις ρυθμίσεις σας.">
+  <link rel="canonical" href="https://anakainisou.gr/cookie-policy.html">
   <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Roboto:wght@700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="assets/style.css">
@@ -31,7 +31,7 @@
         <span class="nav-toggle-bar"></span>
         <span class="nav-toggle-bar"></span>
       </button>
-      <nav id="site-nav" class="nav" aria-label="Κύρια πλοήγηση">
+      <nav id="site-nav" class="nav" aria-label="Κύρια πλοήηση">
         <ul class="nav__list">
           <li class="nav__item"><a href="#" class="nav__link" data-home rel="home">Αρχική</a></li>
           <li class="nav__item"><a href="/index.html#about" class="nav__link">Σχετικά</a></li>
@@ -58,14 +58,16 @@
           <span class="nav-close-bar"></span>
         </button>
       </div>
-      <nav class="nav-mobile" aria-label="Κύρια πλοήγηση" data-mobile-nav>
+      <nav class="nav-mobile" aria-label="Πλοήγηση κινητού">
         <ul class="nav-mobile__list">
-          <li class="nav-mobile__item"><a href="#" class="nav-mobile__link" data-home rel="home">Αρχική</a></li>
-          <li class="nav-mobile__item"><a href="/index.html#about" class="nav-mobile__link">Σχετικά</a></li>
-          <li class="nav-mobile__item"><a href="/index.html#process" class="nav-mobile__link">Πώς Λειτουργούμε</a></li>
-          <li class="nav-mobile__item nav-mobile__item--projects"><a href="erga.html" class="nav-mobile__link">Έργα</a></li>
-          <li class="nav-mobile__item"><a href="/index.html#gallery" class="nav-mobile__link">Gallery</a></li>
-          <li class="nav-mobile__item nav-mobile__item--cta"><a href="/index.html#contact" class="btn btn--primary nav-mobile__cta">Ζητήστε Προσφορά</a></li>
+          <li><a class="nav-mobile__link" href="/index.html#hero"><span>Αρχική</span><span aria-hidden="true">→</span></a></li>
+          <li><a class="nav-mobile__link" href="/index.html#about"><span>Σχετικά</span><span aria-hidden="true">→</span></a></li>
+          <li><a class="nav-mobile__link" href="/index.html#process"><span>Πώς Λειτουργούμε</span><span aria-hidden="true">→</span></a></li>
+          <li><a class="nav-mobile__link" href="/index.html#services"><span>Υπηρεσίες</span><span aria-hidden="true">→</span></a></li>
+          <li><a class="nav-mobile__link" href="erga.html"><span>Έργα</span><span aria-hidden="true">→</span></a></li>
+          <li><a class="nav-mobile__link" href="/index.html#gallery"><span>Gallery</span><span aria-hidden="true">→</span></a></li>
+          <li><a class="nav-mobile__link" href="/index.html#faq"><span>FAQ</span><span aria-hidden="true">→</span></a></li>
+          <li><a class="nav-mobile__link" href="/index.html#contact"><span>Επικοινωνία</span><span aria-hidden="true">→</span></a></li>
         </ul>
       </nav>
       <div class="nav-overlay__social">
@@ -78,25 +80,34 @@
   <main>
     <section class="section">
       <div class="container">
-        <h1>Πολιτική Απορρήτου</h1>
+        <h1>Πολιτική Cookies</h1>
         <p><strong>Τελευταία ενημέρωση:</strong> Οκτώβριος 2025</p>
-        <p>Η FM Renovation σέβεται την ιδιωτικότητα των επισκεπτών της και συμμορφώνεται με τον Γενικό Κανονισμό Προστασίας Δεδομένων (ΕΕ 2016/679).</p>
+        <p>Η FM Renovation χρησιμοποιεί cookies για να προσφέρει ασφαλή και προσαρμοσμένη εμπειρία πλοήγησης. Η παρούσα πολιτική εξηγεί τι είναι τα cookies, ποια χρησιμοποιούμε και πώς μπορείτε να τα διαχειριστείτε.</p>
         <ol>
-          <li><strong>Ποια δεδομένα συλλέγουμε</strong><br>Μέσω της φόρμας επικοινωνίας συλλέγουμε ονοματεπώνυμο, email, τηλέφωνο και μήνυμα. Χρησιμοποιούνται αποκλειστικά για επικοινωνία με τον πελάτη.</li>
-          <li><strong>Χρήση δεδομένων</strong><br>Τα στοιχεία χρησιμοποιούνται για απάντηση σε αιτήματα, παροχή πληροφοριών ή βελτίωση υπηρεσιών. Δεν κοινοποιούνται σε τρίτους εκτός αν απαιτείται από τον νόμο.</li>
-          <li><strong>Cookies &amp; Analytics</strong><br>Η ιστοσελίδα μπορεί να χρησιμοποιεί cookies και εργαλεία ανάλυσης (π.χ. Google Analytics). Οι επισκέπτες μπορούν να απενεργοποιήσουν τα cookies μέσω του browser τους.</li>
-          <li><strong>Ασφάλεια δεδομένων</strong><br>Η εταιρεία λαμβάνει κατάλληλα τεχνικά και οργανωτικά μέτρα για την προστασία των δεδομένων από μη εξουσιοδοτημένη πρόσβαση ή απώλεια.</li>
-          <li><strong>Δικαιώματα χρηστών</strong><br>Οι χρήστες έχουν δικαίωμα πρόσβασης, διόρθωσης, διαγραφής και εναντίωσης στην επεξεργασία. Για αιτήματα, επικοινωνήστε στο <a href="mailto:fmren2021@gmail.com">fmren2021@gmail.com</a>.</li>
-          <li><strong>Διατήρηση δεδομένων</strong><br>Τα δεδομένα διατηρούνται μόνο για όσο είναι απαραίτητα και διαγράφονται με ασφάλεια μετά το πέρας του σκοπού συλλογής τους.</li>
-          <li><strong>Τροποποιήσεις</strong><br>Η εταιρεία μπορεί να ενημερώνει την Πολιτική Απορρήτου. Η τελευταία έκδοση θα δημοσιεύεται στη σελίδα anakainisou.gr/privacy-policy.html.</li>
+          <li><strong>Τι είναι τα cookies</strong><br>Τα cookies είναι μικρά αρχεία κειμένου που αποθηκεύονται στον browser σας όταν επισκέπτεστε έναν ιστότοπο. Χρησιμοποιούνται για βασικές λειτουργίες, βελτίωση απόδοσης και απομνημόνευση προτιμήσεων.</li>
+          <li><strong>Κατηγορίες cookies που χρησιμοποιούμε</strong><br>
+            <ul>
+              <li><strong>Απαραίτητα</strong>: Επιτρέπουν την ασφαλή λειτουργία του ιστότοπου και την αποθήκευση της επιλογής συναίνεσης στο banner cookies.</li>
+              <li><strong>Λειτουργικότητας</strong>: Βοηθούν να θυμόμαστε βασικές ρυθμίσεις (π.χ. προτιμήσεις γλώσσας ή προβολής), ώστε η εμπειρία σας να είναι συνεπής.</li>
+              <li><strong>Στατιστικών (Analytics)</strong>: Μπορεί να ενεργοποιηθούν για τη μέτρηση επισκεψιμότητας και τη βελτίωση του περιεχομένου. Ενεργοποιούνται μόνο μετά από ρητή αποδοχή.</li>
+              <li><strong>Διαφημιστικά</strong>: Δεν χρησιμοποιούμε cookies διαφήμισης ή παρακολούθησης συμπεριφοράς. Αν προστεθούν στο μέλλον, θα ενημερώσουμε την παρούσα πολιτική.</li>
+            </ul>
+          </li>
+          <li><strong>Πώς χρησιμοποιούμε τα cookies</strong><br>Χρησιμοποιούμε cookies για να διασφαλίσουμε την ομαλή λειτουργία της πλοήγησης, να προστατεύσουμε τον ιστότοπο από κακόβουλη χρήση και, όπου έχετε συναινέσει, για να λαμβάνουμε συγκεντρωτικές στατιστικές επισκεψιμότητας.</li>
+          <li><strong>Συναίνεση &amp; ρυθμίσεις</strong><br>Κατά την πρώτη επίσκεψη εμφανίζεται το banner cookies, όπου μπορείτε να επιλέξετε «Αποδοχή» ή «Μόνο τα απαραίτητα». Η επιλογή σας αποθηκεύεται τοπικά και μπορείτε να την τροποποιήσετε ανά πάσα στιγμή διαγράφοντας τα cookies ή την τοπική αποθήκευση (localStorage) του browser σας για τον ιστότοπό μας.</li>
+          <li><strong>Διαχείριση cookies στον browser</strong><br>Οι περισσότεροι browsers σας επιτρέπουν να ελέγχετε ή να αποκλείετε cookies. Μπορείτε να ρυθμίσετε:
+            <ul>
+              <li>αποδοχή ή απόρριψη όλων των cookies,</li>
+              <li>διαγραφή αποθηκευμένων cookies και localStorage,</li>
+              <li>λήψη ειδοποίησης πριν από την αποθήκευση νέων cookies.</li>
+            </ul>
+            Οι διαθέσιμες ρυθμίσεις διαφέρουν ανά browser (π.χ. Chrome, Firefox, Safari, Edge). Ανατρέξτε στις οδηγίες υποστήριξης του προγράμματος περιήγησης που χρησιμοποιείτε.
+          </li>
+          <li><strong>Διάρκεια αποθήκευσης</strong><br>Τα απαραίτητα cookies και η επιλογή συναίνεσης διατηρούνται για όσο χρειάζεται για να θυμόμαστε την προτίμησή σας ή μέχρι να τα διαγράψετε χειροκίνητα.</li>
+          <li><strong>Τρίτοι πάροχοι</strong><br>Δεν μοιραζόμαστε δεδομένα cookies με τρίτους για διαφημιστικούς σκοπούς. Εάν προστεθούν εργαλεία ανάλυσης (π.χ. Google Analytics), η χρήση τους θα βασίζεται στη συγκατάθεσή σας και τα δεδομένα θα συλλέγονται σε ανώνυμη ή συγκεντρωτική μορφή.</li>
+          <li><strong>Ενημερώσεις πολιτικής</strong><br>Ενδέχεται να αναθεωρούμε την παρούσα πολιτική ώστε να αντανακλά αλλαγές στη νομοθεσία ή στις πρακτικές μας. Η πιο πρόσφατη έκδοση δημοσιεύεται στη σελίδα anakainisou.gr/cookie-policy.html.</li>
         </ol>
-        <p><strong>Υπεύθυνος επεξεργασίας:</strong></p>
-        <address>
-          FM Renovation<br>
-          Δοϊράνης 180, Καλλιθέα Τ.Κ. 17673<br>
-          Τηλ: +30 211 404 4496, +30 693 950 0950<br>
-          Email: <a href="mailto:fmren2021@gmail.com">fmren2021@gmail.com</a>
-        </address>
+        <p><strong>Επικοινωνία</strong><br>Για ερωτήσεις σχετικά με τα cookies, μπορείτε να επικοινωνήσετε με το <a href="mailto:fmren2021@gmail.com">fmren2021@gmail.com</a> ή στο +30 693 950 0950.</p>
       </div>
     </section>
   </main>

--- a/erga.html
+++ b/erga.html
@@ -149,6 +149,7 @@
         <nav class="footer-links" aria-label="Χρήσιμες σύνδεσμοι">
           <a href="terms.html">Όροι &amp; Προϋποθέσεις</a>
           <a href="privacy-policy.html">Πολιτική Απορρήτου</a>
+          <a href="cookie-policy.html">Πολιτική Cookies</a>
         </nav>
         <p class="footer-copy">© <span id="year"></span> FM Renovation • <a href="https://anakainisou.gr/">anakainisou.gr</a></p>
       </div>
@@ -200,7 +201,7 @@
       <p class="cookie-banner__text">
         Χρησιμοποιούμε cookies για να βελτιώσουμε την εμπειρία σας.
         Συνεχίζοντας αποδέχεστε τη χρήση τους.
-        <a href="/privacy-policy/" class="cookie-banner__link">Μάθετε περισσότερα</a>.
+        <a href="/cookie-policy.html" class="cookie-banner__link">Μάθετε περισσότερα</a>.
       </p>
       <div class="cookie-banner__actions">
         <button type="button" class="cookie-banner__btn cookie-banner__btn--secondary" id="cookieReject">

--- a/index.html
+++ b/index.html
@@ -566,6 +566,7 @@
         <nav class="footer-links" aria-label="Χρήσιμες σύνδεσμοι">
           <a href="terms.html">Όροι &amp; Προϋποθέσεις</a>
           <a href="privacy-policy.html">Πολιτική Απορρήτου</a>
+          <a href="cookie-policy.html">Πολιτική Cookies</a>
         </nav>
         <p class="footer-copy">© <span id="year"></span> FM Renovation • <a href="https://anakainisou.gr/">anakainisou.gr</a></p>
       </div>
@@ -617,7 +618,7 @@
       <p class="cookie-banner__text">
         Χρησιμοποιούμε cookies για να βελτιώσουμε την εμπειρία σας.
         Συνεχίζοντας αποδέχεστε τη χρήση τους.
-        <a href="/privacy-policy/" class="cookie-banner__link">Μάθετε περισσότερα</a>.
+        <a href="/cookie-policy.html" class="cookie-banner__link">Μάθετε περισσότερα</a>.
       </p>
       <div class="cookie-banner__actions">
         <button type="button" class="cookie-banner__btn cookie-banner__btn--secondary" id="cookieReject">

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -16,6 +16,11 @@
     <priority>0.4</priority>
   </url>
   <url>
+    <loc>https://www.anakainisou.gr/cookie-policy.html</loc>
+    <changefreq>yearly</changefreq>
+    <priority>0.4</priority>
+  </url>
+  <url>
     <loc>https://anakainisou.gr/erga</loc>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>

--- a/terms.html
+++ b/terms.html
@@ -148,7 +148,7 @@
       <p class="cookie-banner__text">
         Χρησιμοποιούμε cookies για να βελτιώσουμε την εμπειρία σας.
         Συνεχίζοντας αποδέχεστε τη χρήση τους.
-        <a href="/privacy-policy/" class="cookie-banner__link">Μάθετε περισσότερα</a>.
+        <a href="/cookie-policy.html" class="cookie-banner__link">Μάθετε περισσότερα</a>.
       </p>
       <div class="cookie-banner__actions">
         <button type="button" class="cookie-banner__btn cookie-banner__btn--secondary" id="cookieReject">


### PR DESCRIPTION
## Summary
- add dedicated cookie policy page detailing categories, consent options, and contact information
- point cookie banner learn-more links and footer links to the new policy page
- include the cookie policy page in the sitemap for discovery

## Testing
- not run (static site)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c8ec234608320ab2ab57917463eaa)