### PR TITLE
Normalize SEO metadata

### DIFF
--- a/cookie-policy.html
+++ b/cookie-policy.html
@@ -16,6 +16,12 @@
   <link rel="manifest" href="favicon/site.webmanifest">
   <link rel="mask-icon" href="favicon/favicon.svg" color="#F59E0B">
   <meta name="theme-color" content="#F59E0B">
+  <meta property="og:type" content="website">
+  <meta property="og:locale" content="el_GR">
+  <meta property="og:title" content="FM Renovation – Πολιτική Cookies">
+  <meta property="og:description" content="Πολιτική cookies της FM Renovation: τι είναι τα cookies, πώς τα χρησιμοποιούμε και πώς μπορείτε να διαχειριστείτε τις ρυθμίσεις σας.">
+  <meta property="og:url" content="https://anakainisou.gr/cookie-policy.html">
+  <meta property="og:image" content="https://images.unsplash.com/photo-1505691723518-36a5ac3b2d55?q=80&w=1600&auto=format&fit=crop">
 </head>
 <body>
   <header class="site-header" id="top">

--- a/erga.html
+++ b/erga.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Έργα Ανακαινίσεων | FM Renovation</title>
   <meta name="description" content="Δείτε αντιπροσωπευτικά έργα ανακαινίσεων σε κουζίνες, μπάνια και εσωτερικούς χώρους. Φωτογραφίες, περιγραφές και λεπτομέρειες.">
-  <link rel="canonical" href="https://anakainisou.gr/erga">
+  <link rel="canonical" href="https://anakainisou.gr/erga.html">
   <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Roboto:wght@700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="assets/style.css">
@@ -22,7 +22,8 @@
   <meta property="og:locale" content="el_GR">
   <meta property="og:title" content="Έργα Ανακαινίσεων | FM Renovation">
   <meta property="og:description" content="Case studies από ανακαινίσεις κατοικιών & επαγγελματικών χώρων της FM Renovation.">
-  <meta property="og:url" content="https://anakainisou.gr/erga">
+  <meta property="og:url" content="https://anakainisou.gr/erga.html">
+  <meta property="og:image" content="https://images.unsplash.com/photo-1505691723518-36a5ac3b2d55?q=80&w=1600&auto=format&fit=crop">
 </head>
 <body>
   <header class="site-header" id="top">

--- a/index.html
+++ b/index.html
@@ -29,9 +29,9 @@
     "@context": "https://schema.org",
     "@type": "HomeAndConstructionBusiness",
     "name": "Anakainisou",
-    "url": "https://www.anakainisou.gr",
-    "image": "https://www.anakainisou.gr/images/hero.webp",
-    "logo": "https://www.anakainisou.gr/images/logo.png",
+    "url": "https://anakainisou.gr",
+    "image": "https://anakainisou.gr/images/hero.webp",
+    "logo": "https://anakainisou.gr/images/logo.png",
     "description": "Ολική ή μερική ανακαίνιση οικίας και επαγγελματικού χώρου — με τεχνική ακρίβεια, συνέπεια και διαφάνεια.",
     "telephone": "+30 211 404 4496",
     "email": "fmren2021@gmail.com",
@@ -67,7 +67,7 @@
     "@context": "https://schema.org",
     "@type": "WebSite",
     "name": "Anakainisou",
-    "url": "https://www.anakainisou.gr",
+    "url": "https://anakainisou.gr",
     "inLanguage": "el-GR"
   }
   </script>
@@ -76,8 +76,8 @@
     "@context": "https://schema.org",
     "@type": "BreadcrumbList",
     "itemListElement": [
-      {"@type": "ListItem", "position": 1, "name": "Αρχική", "item": "https://www.anakainisou.gr/"},
-      {"@type": "ListItem", "position": 2, "name": "Υπηρεσίες", "item": "https://www.anakainisou.gr/#services"}
+      {"@type": "ListItem", "position": 1, "name": "Αρχική", "item": "https://anakainisou.gr/"},
+      {"@type": "ListItem", "position": 2, "name": "Υπηρεσίες", "item": "https://anakainisou.gr/#services"}
     ]
   }
   </script>

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>FM Renovation – Πολιτική Απορρήτου</title>
   <meta name="description" content="Πολιτική απορρήτου της FM Renovation σύμφωνα με τον Γενικό Κανονισμό Προστασίας Δεδομένων (GDPR).">
-  <link rel="canonical" href="https://anakainisou.gr/privacy-policy">
+  <link rel="canonical" href="https://anakainisou.gr/privacy-policy.html">
   <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Roboto:wght@700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="assets/style.css">
@@ -16,6 +16,12 @@
   <link rel="manifest" href="favicon/site.webmanifest">
   <link rel="mask-icon" href="favicon/favicon.svg" color="#F59E0B">
   <meta name="theme-color" content="#F59E0B">
+  <meta property="og:type" content="website">
+  <meta property="og:locale" content="el_GR">
+  <meta property="og:title" content="FM Renovation – Πολιτική Απορρήτου">
+  <meta property="og:description" content="Πολιτική απορρήτου της FM Renovation σύμφωνα με τον Γενικό Κανονισμό Προστασίας Δεδομένων (GDPR).">
+  <meta property="og:url" content="https://anakainisou.gr/privacy-policy.html">
+  <meta property="og:image" content="https://images.unsplash.com/photo-1505691723518-36a5ac3b2d55?q=80&w=1600&auto=format&fit=crop">
 </head>
 <body>
   <header class="site-header" id="top">

--- a/terms.html
+++ b/terms.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>FM Renovation – Όροι Χρήσης</title>
   <meta name="description" content="Όροι και προϋποθέσεις χρήσης του ιστότοπου anakainisou.gr της εταιρείας FM Renovation.">
-  <link rel="canonical" href="https://anakainisou.gr/terms">
+  <link rel="canonical" href="https://anakainisou.gr/terms.html">
   <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Roboto:wght@700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="assets/style.css">
@@ -16,6 +16,12 @@
   <link rel="manifest" href="favicon/site.webmanifest">
   <link rel="mask-icon" href="favicon/favicon.svg" color="#F59E0B">
   <meta name="theme-color" content="#F59E0B">
+  <meta property="og:type" content="website">
+  <meta property="og:locale" content="el_GR">
+  <meta property="og:title" content="FM Renovation – Όροι Χρήσης">
+  <meta property="og:description" content="Όροι και προϋποθέσεις χρήσης του ιστότοπου anakainisou.gr της εταιρείας FM Renovation.">
+  <meta property="og:url" content="https://anakainisou.gr/terms.html">
+  <meta property="og:image" content="https://images.unsplash.com/photo-1505691723518-36a5ac3b2d55?q=80&w=1600&auto=format&fit=crop">
 </head>
 <body>
   <header class="site-header" id="top">


### PR DESCRIPTION
## Summary
- align canonical and Open Graph metadata across public pages to the non-www domain
- add missing og:image entries using the primary hero visual
- update homepage JSON-LD entries to use https://anakainisou.gr with consistent breadcrumb targets

## Testing
- Not run (static site changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693389a67d248320ac0e8053a53fa42d)