### PR TITLE
Add canonical link to erga page

### DIFF
--- a/erga.html
+++ b/erga.html
@@ -8,6 +8,7 @@
   <link rel="stylesheet" href="assets/style.css">
   <link rel="stylesheet" href="assets/css/erga.css">
   <link rel="stylesheet" href="assets/css/lightbox.css">
+  <link rel="canonical" href="https://anakainisou.gr/erga.html" />
   <link rel="icon" type="image/png" href="favicon/favicon-96x96.png" sizes="96x96">
   <link rel="icon" type="image/svg+xml" href="favicon/favicon.svg">
   <link rel="shortcut icon" href="favicon/favicon.ico">


### PR DESCRIPTION
## Summary
- add the canonical URL to erga.html so it is explicitly defined

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ec607be4483209f8302628c40220b)