### PR TITLE
Add canonical tag to terms page

### DIFF
--- a/terms.html
+++ b/terms.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="canonical" href="https://anakainisou.gr/terms.html" />
 
   <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Roboto:wght@700&display=swap" rel="stylesheet">


### PR DESCRIPTION
## Summary
- add canonical link referencing terms page to consolidate canonical URL

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ecdf0de7483209c281e1da77cd19b)