### PR TITLE
Add canonical link to cookie policy page

### DIFF
--- a/cookie-policy.html
+++ b/cookie-policy.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="canonical" href="https://anakainisou.gr/cookie-policy.html" />
 
   <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Roboto:wght@700&display=swap" rel="stylesheet">


### PR DESCRIPTION
## Summary
- add the canonical URL tag to cookie-policy.html using the anakainisou.gr address

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ed009426c83209c0bc7add6509dbe)