### PR TITLE
Normalize sitemap to canonical domain URLs

### DIFF
--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,18 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://anakainisou.gr/</loc>
+    <loc>https://www.anakainisou.gr/</loc>
   </url>
+
   <url>
-    <loc>https://anakainisou.gr/erga.html</loc>
+    <loc>https://www.anakainisou.gr/erga.html</loc>
   </url>
+
   <url>
-    <loc>https://anakainisou.gr/terms.html</loc>
+    <loc>https://www.anakainisou.gr/terms.html</loc>
   </url>
+
   <url>
-    <loc>https://anakainisou.gr/privacy-policy.html</loc>
+    <loc>https://www.anakainisou.gr/privacy-policy.html</loc>
   </url>
+
   <url>
-    <loc>https://anakainisou.gr/cookie-policy.html</loc>
+    <loc>https://www.anakainisou.gr/cookie-policy.html</loc>
   </url>
 </urlset>


### PR DESCRIPTION
## Summary
- ensure sitemap entries use only the canonical https://www.anakainisou.gr domain
- keep the required set of pages without duplicates

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693edf4368848320947ed3dd6928c8c9)