### PR TITLE
Improve SEO alt text for gallery image (photos/fm13.webp)

### DIFF
--- a/index.html
+++ b/index.html
@@ -395,7 +395,7 @@
         <div class="carousel" data-carousel>
           <button class="car-btn prev" aria-label="Προηγούμενη">‹</button>
           <div class="car-track" data-track>
-            <img class="car-img" src="photos/fm13.webp" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – σύγχρονος χώρος διαβίωσης με καθαρές γραμμές.">
+            <img class="car-img" src="photos/fm13.webp" width="600" height="600" loading="lazy" alt="Ανακαίνιση σαλονιού σύγχρονου διαμερίσματος στην Αθήνα">
             <img class="car-img" src="erga/renovation2*.jpg" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – ανακαίνιση διαμερίσματος με νέες επιφάνειες και φωτισμό.">
             <img class="car-img" src="erga/windows1.jpg" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – αντικατάσταση κουφωμάτων με ενεργειακά αποδοτικά παράθυρα.">
             <img class="car-img" src="erga/windows2.jpg" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – τοποθέτηση νέων αλουμινίων σε μπαλκονόπορτα.">


### PR DESCRIPTION
### Motivation
- Improve SEO and accessibility by adding a descriptive Greek `alt` for images in `photos/fm1.webp`–`photos/fm15.webp`, focusing on renovation-related keywords while not altering layout or functionality.

### Description
- Updated the `alt` attribute for the gallery `<img>` that references `photos/fm13.webp` in `index.html` to `Ανακαίνιση σαλονιού σύγχρονου διαμερίσματος στην Αθήνα`, keeping `src`, `class`, `width/height`, `loading`, IDs and structure unchanged, and committed the change.

### Testing
- Executed automated checks including `rg` for references, a small `python` script to list `photos/fm*.webp`, `nl` to inspect the modified lines, `git diff` / `git status`, and committed the change; all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfddd2aeec8320b524264a32881f6b)