### PR TITLE
Update erga image references to .webp and add safe image dimensions

### DIFF
--- a/assets/js/erga.js
+++ b/assets/js/erga.js
@@ -1,4 +1,89 @@
 (function () {
+  const IMAGE_DIMENSIONS = {
+    "ampelokipoi.webp": [600, 600],
+    "ampelokipoi1.webp": [600, 600],
+    "ampelokipoi10.webp": [600, 600],
+    "ampelokipoi11.webp": [600, 600],
+    "ampelokipoi12.webp": [600, 600],
+    "ampelokipoi13.webp": [600, 600],
+    "ampelokipoi14.webp": [600, 600],
+    "ampelokipoi2.webp": [600, 600],
+    "ampelokipoi3.webp": [600, 600],
+    "ampelokipoi4.webp": [600, 600],
+    "ampelokipoi5.webp": [600, 600],
+    "ampelokipoi6.webp": [600, 600],
+    "ampelokipoi7.webp": [600, 600],
+    "ampelokipoi8.webp": [600, 600],
+    "ampelokipoi9.webp": [600, 600],
+    "faliro1.webp": [800, 800],
+    "faliro10.webp": [800, 800],
+    "faliro11.webp": [800, 800],
+    "faliro12.webp": [800, 800],
+    "faliro13.webp": [800, 800],
+    "faliro2.webp": [800, 800],
+    "faliro3.webp": [800, 800],
+    "faliro4.webp": [800, 800],
+    "faliro5.webp": [800, 800],
+    "faliro6.webp": [800, 800],
+    "faliro7.webp": [800, 800],
+    "faliro8.webp": [800, 800],
+    "faliro9.webp": [800, 800],
+    "floor1.webp": [791, 600],
+    "floor2.webp": [600, 600],
+    "guardrail10.webp": [779, 973],
+    "guardrail11.webp": [771, 976],
+    "guardrail5.webp": [1600, 1205],
+    "guardrail6.webp": [3000, 4000],
+    "guardrail7.webp": [3000, 4000],
+    "guardrail8.webp": [3000, 4000],
+    "guardrail9.webp": [3000, 4000],
+    "guardrailpiraeus1.webp": [450, 600],
+    "guardrailpiraeus10.webp": [1600, 1205],
+    "guardrailpiraeus2.webp": [450, 600],
+    "guardrailpiraeus3.webp": [3000, 4000],
+    "guardrailpiraeus4.webp": [3000, 4000],
+    "guardrailpiraeus5.webp": [3000, 4000],
+    "guardrailpiraeus6.webp": [460, 600],
+    "guardrailpiraeus7.webp": [800, 600],
+    "guardrailpiraeus8.webp": [455, 600],
+    "guardrailpiraeus9.webp": [1600, 1205],
+    "insulation1.webp": [600, 600],
+    "insulation2.webp": [600, 600],
+    "insulation3.webp": [600, 600],
+    "masaiko1.webp": [450, 600],
+    "masaiko2.webp": [450, 600],
+    "masaiko3.webp": [450, 600],
+    "masaiko4.webp": [450, 600],
+    "metal1.webp": [670, 512],
+    "metal2.webp": [693, 512],
+    "metal3.webp": [662, 512],
+    "metal4.webp": [677, 512],
+    "renovation**.webp": [600, 600],
+    "renovation1*.webp": [800, 900],
+    "renovation1.webp": [800, 900],
+    "renovation2*.webp": [800, 900],
+    "renovation2.webp": [800, 900],
+    "renovation3*.webp": [800, 900],
+    "renovation3.webp": [800, 900],
+    "renovation4*.webp": [800, 900],
+    "renovation4.webp": [800, 900],
+    "renovation5*.webp": [800, 900],
+    "renovation5.webp": [800, 900],
+    "renovation6*.webp": [800, 900],
+    "renovation6.webp": [800, 900],
+    "renovation7*.webp": [800, 900],
+    "renovation7.webp": [800, 900],
+    "renovation8*.webp": [800, 900],
+    "renovation8.webp": [600, 600],
+    "renovation88.webp": [600, 600],
+    "windows1.webp": [396, 298],
+    "windows2.webp": [396, 298],
+    "windows3.webp": [413, 600],
+    "windows4.webp": [451, 600],
+    "windows5.webp": [451, 600],
+    "windows6.webp": [451, 600]
+  };
+
   const mount = document.getElementById('projects');
   if (!mount) {
     return;
@@ -127,6 +212,8 @@
     const aspect = String(project.aspect || '4:3').trim();
     const folder = typeof project.folder === 'string' ? project.folder : '';
     const cover = toSrcset(folder, project.cover);
+    const coverDimensions = getImageDimensions(project.cover, cover.best);
+    const coverDimensionAttrs = formatDimensionAttributes(coverDimensions);
     const layout = typeof project.layout === 'string' ? project.layout.trim().toLowerCase() : '';
     const isMinimalGrid = layout === 'minimal-grid';
     const cardClasses = ['card'];
@@ -155,6 +242,8 @@
         const imagesMarkup = group.images
           .map((image, imageIndex) => {
             const srcset = toSrcset(folder, image.file);
+            const dimensions = getImageDimensions(image.file, srcset.best);
+            const dimensionAttrs = formatDimensionAttributes(dimensions);
             const thumbAlt = image.alt
               ? image.alt
               : `${project.title || 'Project'}${group.title ? ` – ${group.title}` : ''} – φωτογραφία ${imageIndex + 1}`;
@@ -163,7 +252,7 @@
               ${srcset.webp ? `<source type="image/webp" srcset="${escapeAttr(srcset.webp)}" sizes="140px">` : ''}
               <source type="${escapeAttr(srcset.type || 'image/jpeg')}" srcset="${escapeAttr(srcset.jpg)}" sizes="140px">
               <img src="${escapeAttr(srcset.jpg800)}" srcset="${escapeAttr(srcset.jpg)}" sizes="140px"
-                   alt="${escapeAttr(thumbAlt)}" loading="lazy" decoding="async"
+                   alt="${escapeAttr(thumbAlt)}"${dimensionAttrs} loading="lazy" decoding="async"
                    data-full="${escapeAttr(srcset.best)}" data-lightbox-thumb>
             </picture>`;
           })
@@ -205,7 +294,7 @@
             ${cover.webp ? `<source type="image/webp" srcset="${escapeAttr(cover.webp)}" sizes="(min-width: 980px) 50vw, 100vw">` : ''}
             <source type="${escapeAttr(cover.type || 'image/jpeg')}" srcset="${escapeAttr(cover.jpg)}" sizes="(min-width: 980px) 50vw, 100vw">
             <img src="${escapeAttr(cover.jpg800)}" srcset="${escapeAttr(cover.jpg)}" sizes="(min-width: 980px) 50vw, 100vw"
-                 alt="${escapeAttr(project.title || 'Project cover')}" loading="lazy" decoding="async"
+                 alt="${escapeAttr(project.title || 'Project cover')}"${coverDimensionAttrs} loading="lazy" decoding="async"
                  data-full="${escapeAttr(cover.best)}">
           </picture>
           ${badgeMarkup ? `<div class="badges">${badgeMarkup}</div>` : ''}
@@ -426,6 +515,31 @@
     }
 
     return `${safeFolder}/${safeFile}`;
+  }
+
+  function getImageDimensions(filename, fallbackPath) {
+    const candidates = [filename, fallbackPath]
+      .filter((value) => typeof value === 'string' && value.trim())
+      .map((value) => value.trim().split('/').pop());
+
+    for (const candidate of candidates) {
+      if (candidate && IMAGE_DIMENSIONS[candidate]) {
+        const [width, height] = IMAGE_DIMENSIONS[candidate];
+        if (Number.isFinite(width) && Number.isFinite(height)) {
+          return { width, height };
+        }
+      }
+    }
+
+    return null;
+  }
+
+  function formatDimensionAttributes(dimensions) {
+    if (!dimensions) {
+      return '';
+    }
+
+    return ` width="${escapeAttr(dimensions.width)}" height="${escapeAttr(dimensions.height)}"`;
   }
 
   function normalizeDate(dateString) {

--- a/data/projects.json
+++ b/data/projects.json
@@ -8,7 +8,7 @@
     "summary": "Ολική ανακαίνιση σε ισόγεια, πολύ παλαιά κατοικία με νέες εγκαταστάσεις, κουζίνα και μπάνιο.",
     "aspect": "4:3",
     "folder": "erga/",
-    "cover": "renovation2*.jpg",
+    "cover": "renovation2*.webp",
     "details": [
       "Αποξηλώθηκαν και απομακρύνθηκαν με κάδους η κουζίνα και το μπάνιο.",
       "Δημιουργήθηκαν εξ ολοκλήρου νέες υδραυλικές και ηλεκτρολογικές εγκαταστάσεις.",
@@ -23,23 +23,23 @@
       {
         "title": "Μετά",
         "images": [
-          "renovation6*.jpg",
-          "renovation2.jpg",
-          "renovation**.jpg",
-          "renovation88.jpg",
-          "renovation4*.jpg",
-          "renovation2*.jpg",
-          "renovation1*.jpg",
-          "renovation8*.jpg"
+          "renovation6*.webp",
+          "renovation2.webp",
+          "renovation**.webp",
+          "renovation88.webp",
+          "renovation4*.webp",
+          "renovation2*.webp",
+          "renovation1*.webp",
+          "renovation8*.webp"
         ]
       },
       {
         "title": "Πριν",
         "images": [
-          "renovation3.jpg",
-          "renovation4.jpg",
-          "renovation5.jpg",
-          "renovation7.jpg"
+          "renovation3.webp",
+          "renovation4.webp",
+          "renovation5.webp",
+          "renovation7.webp"
         ]
       }
     ]
@@ -52,7 +52,7 @@
     "summary": "Ανακαίνιση διαμερίσματος με νέο δεύτερο υπνοδωμάτιο, μικρή κουζίνα εισόδου και πλήρως ανανεωμένο μπάνιο.",
     "aspect": "4:3",
     "folder": "erga/",
-    "cover": "faliro5.jpg",
+    "cover": "faliro5.webp",
     "details": [
       "Στο διαμέρισμα 3ου ορόφου δημιουργήθηκε δεύτερο υπνοδωμάτιο στον χώρο της πρώην κουζίνας.",
       "Κατασκευάστηκε νέα, μικρή κουζίνα στην είσοδο, σύμφωνα με την επιθυμία του πελάτη.",
@@ -64,19 +64,19 @@
       {
         "title": "Gallery",
         "images": [
-          "faliro1.jpg",
-          "faliro2.jpg",
-          "faliro3.jpg",
-          "faliro4.jpg",
-          "faliro5.jpg",
-          "faliro6.jpg",
-          "faliro7.jpg",
-          "faliro8.jpg",
-          "faliro9.jpg",
-          "faliro10.jpg",
-          "faliro11.jpg",
-          "faliro12.jpg",
-          "faliro13.jpg"
+          "faliro1.webp",
+          "faliro2.webp",
+          "faliro3.webp",
+          "faliro4.webp",
+          "faliro5.webp",
+          "faliro6.webp",
+          "faliro7.webp",
+          "faliro8.webp",
+          "faliro9.webp",
+          "faliro10.webp",
+          "faliro11.webp",
+          "faliro12.webp",
+          "faliro13.webp"
         ]
       }
     ]
@@ -89,7 +89,7 @@
     "summary": "Ολική ανακαίνιση υπογείου διαμερίσματος με νέες εγκαταστάσεις, κουζίνα, μπάνιο και ντουλάπες.",
     "aspect": "4:3",
     "folder": "erga/",
-    "cover": "ampelokipoi6.jpg",
+    "cover": "ampelokipoi6.webp",
     "details": [
       "Αποξηλώθηκαν και απομακρύνθηκαν με κάδους η κουζίνα, το μπάνιο, οι εσωτερικές πόρτες και η πόρτα εισόδου.",
       "Δημιουργήθηκαν νέες ηλεκτρολογικές και υδραυλικές εγκαταστάσεις.",
@@ -103,24 +103,24 @@
       {
         "title": "Μετά",
         "images": [
-          "ampelokipoi6.jpg",
-          "ampelokipoi5.jpg",
-          "ampelokipoi8.jpg",
-          "ampelokipoi10.jpg",
-          "ampelokipoi13.jpg",
-          "ampelokipoi14.jpg",
-          "ampelokipoi7.jpg",
-          "ampelokipoi11.jpg",
-          "ampelokipoi9.jpg",
-          "ampelokipoi12.jpg"
+          "ampelokipoi6.webp",
+          "ampelokipoi5.webp",
+          "ampelokipoi8.webp",
+          "ampelokipoi10.webp",
+          "ampelokipoi13.webp",
+          "ampelokipoi14.webp",
+          "ampelokipoi7.webp",
+          "ampelokipoi11.webp",
+          "ampelokipoi9.webp",
+          "ampelokipoi12.webp"
         ]
       },
       {
         "title": "Πριν",
         "images": [
-          "ampelokipoi3.jpg",
-          "ampelokipoi2.jpg",
-          "ampelokipoi1.jpg"
+          "ampelokipoi3.webp",
+          "ampelokipoi2.webp",
+          "ampelokipoi1.webp"
         ]
       }
     ]
@@ -133,7 +133,7 @@
     "summary": "Κουφώματα αλουμινίου - pvc: Συρόμενα ή ανοιγόμενα με ανάκλιση, με σήτα, με ρολό ή παντζούρι, με ιμάντα ή button, τα κουφώματα προσφέρουν θερμομόνωση, ηχομόνωση και ασφάλεια.",
     "aspect": "4:3",
     "folder": "erga/",
-    "cover": "windows1.jpg",
+    "cover": "windows1.webp",
     "details": [
       "Επιλογές σε συρόμενα ή ανοιγόμενα κουφώματα με ανάκλιση ανάλογα με το δωμάτιο.",
       "Ενσωμάτωση σίτας, ρολού ή παντζουριού με χειρισμό ιμάντα ή button.",
@@ -143,12 +143,12 @@
       {
         "title": "Gallery",
         "images": [
-          "windows1.jpg",
-          "windows2.jpg",
-          "windows3.jpg",
-          "windows4.jpg",
-          "windows5.jpg",
-          "windows6.jpg"
+          "windows1.webp",
+          "windows2.webp",
+          "windows3.webp",
+          "windows4.webp",
+          "windows5.webp",
+          "windows6.webp"
         ]
       }
     ]
@@ -223,7 +223,7 @@
     "summary": "Νέα τοποθέτηση, επισκευή ή τρίψιμο σε ξύλινα, laminate και μωσαϊκά δάπεδα. Επαγγελματικό φινίρισμα, ανθεκτικά υλικά και καθαρή παράδοση.",
     "aspect": "4:3",
     "folder": "erga/",
-    "cover": "floor2.jpg",
+    "cover": "floor2.webp",
     "details": [
       "Νέα τοποθέτηση ή αντικατάσταση ξύλινων και laminate δαπέδων με προσοχή στη λεπτομέρεια.",
       "Επισκευές και τριψίματα για ανανέωση μωσαϊκών και ξύλινων επιφανειών.",
@@ -233,8 +233,8 @@
       {
         "title": "Gallery",
         "images": [
-          "floor1.jpg",
-          "floor2.jpg"
+          "floor1.webp",
+          "floor2.webp"
         ]
       }
     ]
@@ -247,7 +247,7 @@
     "summary": "Τα μωσαϊκά δάπεδα τρίφτηκαν με ειδικό μηχάνημα και λουστραρίστηκαν. Το αποτέλεσμα εντυπωσιακό!",
     "aspect": "4:3",
     "folder": "erga/",
-    "cover": "masaiko3.jpg",
+    "cover": "masaiko3.webp",
     "details": [
       "Τα μωσαϊκά δάπεδα τρίφτηκαν προσεκτικά με ειδικό μηχάνημα για να απομακρυνθούν οι φθορές.",
       "Εφαρμόστηκε λουστράρισμα που ανέδειξε τα χρώματα και την υφή του μωσαϊκού.",
@@ -257,10 +257,10 @@
       {
         "title": "Gallery",
         "images": [
-          "masaiko1.jpg",
-          "masaiko2.jpg",
-          "masaiko4.jpg",
-          "renovation2.jpg"
+          "masaiko1.webp",
+          "masaiko2.webp",
+          "masaiko4.webp",
+          "renovation2.webp"
         ]
       }
     ]
@@ -273,7 +273,7 @@
     "summary": "Μόνωση ταράτσας με υγρομονωτικό, fibran 7cm και τελική στρώση ελαφρού τσιμεντοειδούς.",
     "aspect": "4:3",
     "folder": "erga/",
-    "cover": "insulation1.jpg",
+    "cover": "insulation1.webp",
     "details": [
       "Η ταράτσα αρχικά καθαρίστηκε σχολαστικά από τις ενανθρακώσεις.",
       "Τα προβληματικά σημεία αποκαταστάθηκαν με ρητινούχο τσιμεντοειδές.",
@@ -286,9 +286,9 @@
       {
         "title": "Gallery",
         "images": [
-          "insulation3.jpg",
-          "insulation2.jpg",
-          "insulation1.jpg"
+          "insulation3.webp",
+          "insulation2.webp",
+          "insulation1.webp"
         ]
       }
     ]
@@ -301,7 +301,7 @@
     "summary": "Εργασίες αποκατάστασης στηθαίων σε πολυκατοικία μετά την έκδοση των απαραίτητων αδειών.",
     "aspect": "4:3",
     "folder": "erga/",
-    "cover": "guardrailpiraeus1.jpg",
+    "cover": "guardrailpiraeus1.webp",
     "details": [
       "Κατόπιν εκδόσεως των απαραίτητων αδειών από την οικεία ΥΔΟΜ και τον Δήμο, τοποθετήθηκε πιστοποιημένη σκαλωσιά.",
       "Αποξηλώθηκαν οι γυψόπλακες από τα στηθαία και απομακρύνθηκαν με κάδους.",
@@ -312,16 +312,16 @@
       {
         "title": "Gallery",
         "images": [
-          "guardrailpiraeus1.jpg",
-          "guardrailpiraeus2.jpg",
-          "guardrailpiraeus3.jpg",
-          "guardrailpiraeus4.jpg",
-          "guardrailpiraeus5.jpg",
-          "guardrailpiraeus6.jpg",
-          "guardrailpiraeus7.jpg",
-          "guardrailpiraeus8.jpg",
-          "guardrailpiraeus9.jpg",
-          "guardrailpiraeus10.jpg"
+          "guardrailpiraeus1.webp",
+          "guardrailpiraeus2.webp",
+          "guardrailpiraeus3.webp",
+          "guardrailpiraeus4.webp",
+          "guardrailpiraeus5.webp",
+          "guardrailpiraeus6.webp",
+          "guardrailpiraeus7.webp",
+          "guardrailpiraeus8.webp",
+          "guardrailpiraeus9.webp",
+          "guardrailpiraeus10.webp"
         ]
       }
     ]
@@ -334,7 +334,7 @@
     "summary": "Αποκατάσταση στηθαίων και κιόνων σε παραθαλάσσιο συγκρότημα κατοικιών.",
     "aspect": "4:3",
     "folder": "erga/",
-    "cover": "guardrail6.jpg",
+    "cover": "guardrail6.webp",
     "details": [
       "Τοποθετήθηκαν πιστοποιημένα ικριώματα σταδιακά και στα τέσσερα κτίρια του συγκροτήματος.",
       "Απομακρύνθηκαν όλα τα σαθρά υλικά και καθαρίστηκαν οι εκτεθειμένοι οπλισμοί από τη σκουριά.",
@@ -345,12 +345,12 @@
       {
         "title": "Gallery",
         "images": [
-          "guardrail11.jpg",
-          "guardrail10.jpg",
-          "guardrail6.jpg",
-          "guardrail8.jpg",
-          "guardrail9.jpg",
-          "guardrail7.jpg"
+          "guardrail11.webp",
+          "guardrail10.webp",
+          "guardrail6.webp",
+          "guardrail8.webp",
+          "guardrail9.webp",
+          "guardrail7.webp"
         ]
       }
     ]
@@ -363,7 +363,7 @@
     "summary": "Ενδεικτικές μεταλλικές κατασκευές για οικιακά και επαγγελματικά έργα με έμφαση στην αντοχή και την προσαρμογή στις ανάγκες του χώρου.",
     "aspect": "4:3",
     "folder": "erga/",
-    "cover": "metal1.jpg",
+    "cover": "metal1.webp",
     "details": [
       "Κατασκευές κιγκλιδωμάτων, σκελετών και βοηθητικών δομών με ακρίβεια κοπής και συγκόλλησης.",
       "Εφαρμογή αντισκωριακής προστασίας και βαφής για αντοχή σε εξωτερικές συνθήκες.",
@@ -373,10 +373,10 @@
       {
         "title": "Gallery",
         "images": [
-          "metal1.jpg",
-          "metal2.jpg",
-          "metal3.jpg",
-          "metal4.jpg"
+          "metal1.webp",
+          "metal2.webp",
+          "metal3.webp",
+          "metal4.webp"
         ]
       }
     ]

--- a/index.html
+++ b/index.html
@@ -396,19 +396,19 @@
           <button class="car-btn prev" aria-label="Προηγούμενη">‹</button>
           <div class="car-track" data-track>
             <img class="car-img" src="photos/fm13.webp" width="600" height="600" loading="lazy" alt="Ανακαίνιση σαλονιού σύγχρονου διαμερίσματος στην Αθήνα">
-            <img class="car-img" src="erga/renovation2*.jpg" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – ανακαίνιση διαμερίσματος με νέες επιφάνειες και φωτισμό.">
-            <img class="car-img" src="erga/windows1.jpg" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – αντικατάσταση κουφωμάτων με ενεργειακά αποδοτικά παράθυρα.">
-            <img class="car-img" src="erga/windows2.jpg" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – τοποθέτηση νέων αλουμινίων σε μπαλκονόπορτα.">
-            <img class="car-img" src="erga/windows4.jpg" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – αναβάθμιση παραθύρων με θερμομόνωση.">
-            <img class="car-img" src="erga/windows5.jpg" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – παράθυρο αλουμινίου με σύγχρονο σχεδιασμό.">
-            <img class="car-img" src="erga/masaiko1.jpg" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – εφαρμογή μωσαϊκού δαπέδου σε σαλόνι.">
-            <img class="car-img" src="erga/masaiko2.jpg" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – λεπτομέρεια τοποθέτησης μωσαϊκού δαπέδου.">
-            <img class="car-img" src="erga/masaiko3.jpg" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – ολοκληρωμένο μωσαϊκό δάπεδο σε εσωτερικό χώρο.">
-            <img class="car-img" src="erga/masaiko4.jpg" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – μωσαϊκό δάπεδο με κομψές λεπτομέρειες.">
-            <img class="car-img" src="erga/floor1.jpg" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – ανακαίνιση δαπέδου με ξύλινη υφή.">
-            <img class="car-img" src="erga/floor2.jpg" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – τοποθέτηση νέου δαπέδου σε χώρο υποδοχής.">
-            <img class="car-img" src="erga/insulation1.jpg" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – εργασίες μόνωσης με εξειδικευμένα υλικά.">
-            <img class="car-img" src="erga/insulation3.jpg" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – λεπτομέρεια εφαρμογής θερμομόνωσης εξωτερικού τοίχου.">
+            <img class="car-img" src="erga/renovation2*.webp" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – ανακαίνιση διαμερίσματος με νέες επιφάνειες και φωτισμό.">
+            <img class="car-img" src="erga/windows1.webp" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – αντικατάσταση κουφωμάτων με ενεργειακά αποδοτικά παράθυρα.">
+            <img class="car-img" src="erga/windows2.webp" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – τοποθέτηση νέων αλουμινίων σε μπαλκονόπορτα.">
+            <img class="car-img" src="erga/windows4.webp" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – αναβάθμιση παραθύρων με θερμομόνωση.">
+            <img class="car-img" src="erga/windows5.webp" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – παράθυρο αλουμινίου με σύγχρονο σχεδιασμό.">
+            <img class="car-img" src="erga/masaiko1.webp" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – εφαρμογή μωσαϊκού δαπέδου σε σαλόνι.">
+            <img class="car-img" src="erga/masaiko2.webp" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – λεπτομέρεια τοποθέτησης μωσαϊκού δαπέδου.">
+            <img class="car-img" src="erga/masaiko3.webp" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – ολοκληρωμένο μωσαϊκό δάπεδο σε εσωτερικό χώρο.">
+            <img class="car-img" src="erga/masaiko4.webp" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – μωσαϊκό δάπεδο με κομψές λεπτομέρειες.">
+            <img class="car-img" src="erga/floor1.webp" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – ανακαίνιση δαπέδου με ξύλινη υφή.">
+            <img class="car-img" src="erga/floor2.webp" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – τοποθέτηση νέου δαπέδου σε χώρο υποδοχής.">
+            <img class="car-img" src="erga/insulation1.webp" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – εργασίες μόνωσης με εξειδικευμένα υλικά.">
+            <img class="car-img" src="erga/insulation3.webp" width="600" height="600" loading="lazy" alt="Έργο FM Renovation – λεπτομέρεια εφαρμογής θερμομόνωσης εξωτερικού τοίχου.">
           </div>
           <button class="car-btn next" aria-label="Επόμενη">›</button>
         </div>


### PR DESCRIPTION
### Motivation
- The project’s `erga/` assets were converted to `.webp` and the site must reference the new extensions without changing paths, filenames, gallery order or functionality.
- Add safe `width`/`height` attributes where dimensions can be reliably determined from the actual `.webp` files to improve layout stability and CLS without touching visual layout or lightbox logic.

### Description
- Replaced `.jpg`/`.png` references pointing into `erga/` with `.webp` in `data/projects.json` and the homepage carousel in `index.html` while preserving filenames, paths, order, captions and titles. (Files modified: `data/projects.json`, `index.html`, `assets/js/erga.js`).
- Added a read-only dimension map (derived from the on-disk `.webp` files) and safe lookup functions inside `assets/js/erga.js`, and used them to insert `width` and `height` attributes into generated project cover images and gallery thumbnail `<img>` markup only when dimensions are known. 
- Did not change classes, ids, element order, gallery/lightbox logic or existing alt text; the runtime fallback in `assets/js/erga.js` still provides descriptive `alt` values for generated images if missing.
- Total image path replacements: 96 references updated from `.jpg`/`.png` to `.webp` (only for paths under `erga/`).

### Testing
- Ran static checks `node --check assets/js/erga.js && node --check assets/js/lightbox.js` and both succeeded. 
- Validated JSON with `python -m json.tool data/projects.json` and it passed. 
- Verified there are no remaining `erga/` references to `.jpg` or `.png` using a repository search (`rg`) and found no matches. 

Modified files:
- `data/projects.json`
- `index.html`
- `assets/js/erga.js`

Summary of changes applied:
- Image path replacements performed: 96
- Alt attributes added: none (no manual alt insertions; existing descriptive alts preserved and runtime fallback remains in `erga.js`)
- `width`/`height` attributes added: applied to generated project cover images and gallery thumbnail images in `assets/js/erga.js` where exact dimensions were available from the `.webp` assets
- `loading="lazy"` additions: none (images that should be lazy already had `loading="lazy"` and hero images were not made lazy)

I confirm no other code, layout, classes, ids, gallery ordering or lightbox behavior was changed outside of the image path updates and the safe addition of image dimension attributes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfe794e2a08320be63e52a3e3242cd)