### PR TITLE
Add Athens local SEO landing page (anakainiseis-athina.html)

### DIFF
--- a/anakainiseis-athina.html
+++ b/anakainiseis-athina.html
@@ -1,0 +1,550 @@
+<!doctype html>
+<html lang="el">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Ανακαινίσεις Αθήνα | Ολική & Μερική Ανακαίνιση | FM Renovation</title>
+  <meta name="description" content="Αναλαμβάνουμε ανακαινίσεις στην Αθήνα και όλη την Αττική. Κουζίνα, μπάνιο, δάπεδα, υδραυλικά, ηλεκτρολογικά. Ζητήστε δωρεάν προσφορά.">
+  <link rel="canonical" href="https://www.anakainisou.gr/anakainiseis-athina.html" />
+  <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Roboto:wght@700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="assets/style.css">
+  <link rel="icon" type="image/png" href="favicon/favicon-96x96.png" sizes="96x96">
+  <link rel="icon" type="image/svg+xml" href="favicon/favicon.svg">
+  <link rel="shortcut icon" href="favicon/favicon.ico">
+  <link rel="apple-touch-icon" sizes="180x180" href="favicon/apple-touch-icon.png">
+  <link rel="manifest" href="favicon/site.webmanifest">
+  <link rel="mask-icon" href="favicon/favicon.svg" color="#F59E0B">
+  <meta name="theme-color" content="#0F172A">
+  <meta property="og:type" content="website">
+  <meta property="og:locale" content="el_GR">
+  <meta property="og:title" content="Ανακαινίσεις Αθήνα | Ολική & Μερική Ανακαίνιση | FM Renovation">
+  <meta property="og:description" content="Ανακαινίσεις στην Αθήνα και σε όλη την Αττική με premium οργάνωση έργου, πιστοποιημένα υλικά και δωρεάν προσφορά.">
+  <meta property="og:url" content="https://www.anakainisou.gr/anakainiseis-athina.html">
+  <meta property="og:image" content="https://www.anakainisou.gr/photos/fm13.webp">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Ανακαινίσεις Αθήνα | Ολική & Μερική Ανακαίνιση | FM Renovation">
+  <meta name="twitter:description" content="Ανακαινίσεις στην Αθήνα και όλη την Αττική. Κουζίνα, μπάνιο, δάπεδα, υδραυλικά, ηλεκτρολογικά. Ζητήστε δωρεάν προσφορά.">
+  <meta name="twitter:image" content="https://www.anakainisou.gr/photos/fm13.webp">
+  <style>
+    .athens-page main{display:block}
+    .athens-hero{
+      position:relative;
+      min-height:clamp(420px,58vh,720px);
+      display:grid;
+      place-items:center;
+      text-align:center;
+      color:#fff;
+      background:
+        linear-gradient(135deg,rgba(15,23,42,.78),rgba(15,23,42,.48)),
+        url('photos/fm13.webp') center/cover no-repeat;
+      overflow:hidden;
+    }
+    .athens-hero__inner{position:relative;z-index:1;max-width:860px;padding:110px 20px 88px}
+    .athens-hero__eyebrow{display:inline-flex;align-items:center;gap:8px;padding:8px 14px;border:1px solid rgba(255,255,255,.22);border-radius:999px;background:rgba(255,255,255,.08);backdrop-filter:blur(8px);font-size:.95rem;margin-bottom:20px}
+    .athens-hero h1{margin:0 0 18px;font-size:clamp(2rem,4.6vw,3.7rem);line-height:1.12}
+    .athens-hero p{margin:0 auto;max-width:720px;font-size:clamp(1.02rem,2vw,1.18rem);line-height:1.7;color:rgba(255,255,255,.92)}
+    .athens-hero__actions{display:flex;flex-wrap:wrap;justify-content:center;gap:14px;margin-top:30px}
+    .athens-hero .btn--ghost{background:rgba(255,255,255,.12);color:#fff;border-color:rgba(255,255,255,.32)}
+    .athens-hero .btn--ghost:hover,.athens-hero .btn--ghost:focus-visible{background:#fff;color:#0F172A}
+    .athens-breadcrumbs{padding:18px 0 0}
+    .athens-breadcrumbs ol{list-style:none;display:flex;flex-wrap:wrap;gap:8px;margin:0;padding:0;color:#64748b;font-size:.96rem}
+    .athens-breadcrumbs a{color:inherit;text-decoration:none}
+    .athens-breadcrumbs a:hover,.athens-breadcrumbs a:focus-visible{color:var(--accent);outline:none}
+    .athens-grid{display:grid;gap:24px}
+    .athens-grid--2{grid-template-columns:repeat(auto-fit,minmax(280px,1fr))}
+    .athens-intro{padding-top:30px}
+    .athens-card,.athens-service,.athens-step,.athens-faq details{
+      background:#fff;border:1px solid rgba(15,23,42,.08);border-radius:22px;box-shadow:0 16px 32px rgba(15,23,42,.08)
+    }
+    .athens-card{padding:28px}
+    .athens-card h2,.athens-section h2{margin:0 0 14px;font-size:clamp(1.65rem,3vw,2.3rem);color:var(--accent-2)}
+    .athens-lead{font-size:1.08rem;line-height:1.8;color:#334155}
+    .athens-statlist{display:grid;gap:18px}
+    .athens-stat{padding:22px;border-radius:18px;background:linear-gradient(180deg,#fff 0%,#f8fafc 100%);border:1px solid rgba(15,23,42,.08)}
+    .athens-stat h3{margin:0 0 8px;font-size:1.08rem;color:var(--accent-2)}
+    .athens-stat p{margin:0;color:#475569;line-height:1.7}
+    .athens-section{padding:64px 0}
+    .athens-section--muted{background:linear-gradient(180deg,#ffffff 0%,#f5f7fa 100%)}
+    .athens-section__head{max-width:760px;margin:0 auto 30px;text-align:center}
+    .athens-section__head p{margin:0;color:#475569;line-height:1.75}
+    .athens-trust{grid-template-columns:repeat(auto-fit,minmax(220px,1fr))}
+    .athens-trust .athens-card{padding:24px;height:100%}
+    .athens-kicker{display:inline-block;margin-bottom:8px;color:#b45309;font-weight:700;letter-spacing:.04em;text-transform:uppercase;font-size:.84rem}
+    .athens-service{padding:26px;display:grid;gap:12px;height:100%}
+    .athens-service h3{margin:0;font-size:1.18rem;color:var(--accent-2)}
+    .athens-service p{margin:0;color:#475569;line-height:1.7}
+    .athens-service a{color:var(--accent-2);font-weight:700;text-decoration:none}
+    .athens-service a:hover,.athens-service a:focus-visible{color:var(--accent);outline:none}
+    .athens-local{display:grid;gap:26px;grid-template-columns:1.1fr .9fr;align-items:start}
+    .athens-areas{display:grid;grid-template-columns:repeat(auto-fit,minmax(140px,1fr));gap:12px}
+    .athens-chip{padding:14px 16px;border-radius:999px;background:#fff;border:1px solid rgba(15,23,42,.1);text-align:center;font-weight:600;color:#334155;box-shadow:0 10px 22px rgba(15,23,42,.06)}
+    .athens-steps{grid-template-columns:repeat(auto-fit,minmax(220px,1fr))}
+    .athens-step{padding:24px;display:grid;gap:12px}
+    .athens-step__num{width:42px;height:42px;border-radius:50%;display:grid;place-items:center;background:rgba(245,158,11,.16);color:#b45309;font-weight:800}
+    .athens-step h3{margin:0;font-size:1.06rem;color:var(--accent-2)}
+    .athens-step p{margin:0;color:#475569;line-height:1.7}
+    .athens-projects{display:grid;gap:24px;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));align-items:center}
+    .athens-projects__media{min-height:280px;border-radius:26px;background:linear-gradient(135deg,rgba(15,23,42,.12),rgba(245,158,11,.22)),url('erga/ampelokipoi12.webp') center/cover no-repeat;box-shadow:0 18px 36px rgba(15,23,42,.12)}
+    .athens-faq{display:grid;gap:14px;max-width:900px;margin:0 auto}
+    .athens-faq details{padding:0 22px}
+    .athens-faq summary{cursor:pointer;list-style:none;padding:20px 0;font-weight:700;color:var(--accent-2)}
+    .athens-faq summary::-webkit-details-marker{display:none}
+    .athens-faq p{margin:0 0 20px;color:#475569;line-height:1.75}
+    .athens-final{padding:0 0 64px}
+    .athens-final__box{padding:36px;border-radius:28px;background:linear-gradient(135deg,#0F172A 0%,#1E293B 65%,#334155 100%);color:#fff;box-shadow:0 22px 48px rgba(15,23,42,.22)}
+    .athens-final__box h2{color:#fff;margin:0 0 14px}
+    .athens-final__box p{margin:0;color:rgba(255,255,255,.86);line-height:1.8;max-width:760px}
+    .athens-final__actions{display:flex;flex-wrap:wrap;gap:14px;margin-top:24px}
+    .athens-final__actions .btn--ghost{background:rgba(255,255,255,.08);color:#fff;border-color:rgba(255,255,255,.24)}
+    .athens-final__actions .btn--ghost:hover,.athens-final__actions .btn--ghost:focus-visible{background:#fff;color:#0F172A}
+    @media (max-width: 900px){
+      .athens-local{grid-template-columns:1fr}
+    }
+    @media (max-width: 640px){
+      .athens-section{padding:52px 0}
+      .athens-card,.athens-service,.athens-step,.athens-faq details,.athens-final__box{padding:22px}
+      .athens-hero__actions,.athens-final__actions{flex-direction:column;align-items:stretch}
+      .athens-hero__actions .btn,.athens-final__actions .btn{width:100%}
+      .athens-chip{text-align:left;border-radius:16px}
+    }
+  </style>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "HomeAndConstructionBusiness",
+    "@id": "https://www.anakainisou.gr/anakainiseis-athina.html#business",
+    "name": "FM Renovation",
+    "url": "https://www.anakainisou.gr/anakainiseis-athina.html",
+    "image": "https://www.anakainisou.gr/photos/fm13.webp",
+    "logo": "https://www.anakainisou.gr/images/logo.webp",
+    "description": "Εταιρεία ανακαινίσεων στην Αθήνα και όλη την Αττική για ολική και μερική ανακαίνιση κατοικιών και επαγγελματικών χώρων.",
+    "telephone": "+30 211 404 4496",
+    "email": "fmren2021@gmail.com",
+    "address": {
+      "@type": "PostalAddress",
+      "streetAddress": "Δοϊράνης 180",
+      "addressLocality": "Καλλιθέα",
+      "postalCode": "17673",
+      "addressCountry": "GR"
+    },
+    "areaServed": [
+      {"@type": "City", "name": "Αθήνα"},
+      {"@type": "City", "name": "Πειραιάς"},
+      {"@type": "City", "name": "Γλυφάδα"},
+      {"@type": "City", "name": "Νέα Σμύρνη"},
+      {"@type": "City", "name": "Κηφισιά"},
+      {"@type": "City", "name": "Μαρούσι"},
+      {"@type": "City", "name": "Χαλάνδρι"},
+      {"@type": "City", "name": "Περιστέρι"},
+      {"@type": "AdministrativeArea", "name": "Αττική"}
+    ],
+    "serviceType": [
+      "Ανακαινίσεις Αθήνα",
+      "Ανακαίνιση σπιτιού Αθήνα",
+      "Ολική ανακαίνιση Αθήνα",
+      "Μερική ανακαίνιση Αθήνα",
+      "Ανακαινίσεις Αττική",
+      "Ανακαίνιση μπάνιου",
+      "Ανακαίνιση κουζίνας",
+      "Ηλεκτρολογικές εργασίες",
+      "Υδραυλικές εργασίες"
+    ],
+    "sameAs": [
+      "https://www.facebook.com/share/1CJUXM8xkk/",
+      "https://www.instagram.com/fm.renovation21/"
+    ]
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    "mainEntity": [
+      {
+        "@type": "Question",
+        "name": "Πόσο διαρκεί μια ανακαίνιση;",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Η διάρκεια εξαρτάται από το εύρος του έργου, τα τετραγωνικά και τις τεχνικές παρεμβάσεις. Μια μερική ανακαίνιση μπορεί να ολοκληρωθεί σε λίγες ημέρες ή εβδομάδες, ενώ μια ολική ανακαίνιση απαιτεί περισσότερο συντονισμό και σαφές χρονοδιάγραμμα."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Πώς βγαίνει η προσφορά;",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Η προσφορά προκύπτει μετά από επικοινωνία, αυτοψία και καταγραφή των αναγκών του χώρου. Έτσι μπορούμε να υπολογίσουμε σωστά εργασίες, υλικά, ειδικές απαιτήσεις και χρόνο υλοποίησης."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Αναλαμβάνετε όλη την Αθήνα;",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Ναι, εξυπηρετούμε περιοχές σε όλη την Αθήνα και την Αττική, όπως Πειραιά, Γλυφάδα, Νέα Σμύρνη, Κηφισιά, Μαρούσι, Χαλάνδρι και Περιστέρι."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Κάνετε ολικές και μερικές ανακαινίσεις;",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Αναλαμβάνουμε τόσο ολική ανακαίνιση κατοικίας όσο και στοχευμένες μερικές παρεμβάσεις, όπως κουζίνα, μπάνιο, ηλεκτρολογικά, υδραυλικά, δάπεδα και βαψίματα."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Μπορώ να ζητήσω δωρεάν εκτίμηση;",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Βεβαίως. Μπορείτε να επικοινωνήσετε μαζί μας για δωρεάν πρώτη εκτίμηση και προγραμματισμό αυτοψίας, ώστε να λάβετε εξατομικευμένη προσφορά για το έργο σας."
+        }
+      }
+    ]
+  }
+  </script>
+</head>
+<body class="athens-page">
+  <header class="site-header" id="top">
+    <div class="container header-inner">
+      <div class="brand">
+        <a href="index.html" class="logo-link" aria-label="Αρχική σελίδα">
+          <img class="brand-logo" src="images/logo.webp" alt="FM Renovation Ανακαινίσεις Αθήνα" width="180" height="60">
+        </a>
+        <span class="brand-tagline"><strong>Ανακαίνιση χώρου</strong></span>
+      </div>
+      <button class="nav-toggle" type="button" data-nav-toggle aria-expanded="false" aria-controls="mobile-menu" aria-label="Άνοιγμα μενού">
+        <span class="nav-toggle-bar"></span>
+        <span class="nav-toggle-bar"></span>
+        <span class="nav-toggle-bar"></span>
+      </button>
+      <nav id="site-nav" class="nav" aria-label="Κύρια πλοήγηση">
+        <ul class="nav__list">
+          <li class="nav__item"><a href="#" class="nav__link" data-home rel="home">Αρχική</a></li>
+          <li class="nav__item"><a href="#services" class="nav__link">Υπηρεσίες</a></li>
+          <li class="nav__item nav__item--projects"><a href="erga.html" class="nav__link">Έργα μας</a></li>
+          <li class="nav__item"><a href="index.html#contact" class="nav__link">Επικοινωνία</a></li>
+          <li class="nav__item nav__item--cta"><a href="index.html#contact" class="btn btn--sm nav-cta">Ζητήστε Προσφορά</a></li>
+        </ul>
+      </nav>
+      <div class="social">
+        <a href="https://www.facebook.com/share/1CJUXM8xkk/" aria-label="Facebook" class="icon fb" target="_blank" rel="noopener noreferrer"></a>
+        <a href="https://www.instagram.com/fm.renovation21/" aria-label="Instagram" class="icon ig" target="_blank" rel="noopener noreferrer"></a>
+      </div>
+    </div>
+  </header>
+
+  <div class="nav-backdrop" data-nav-backdrop hidden></div>
+  <div class="nav-overlay" id="mobile-menu" role="dialog" aria-modal="true" aria-labelledby="mobile-menu-title" hidden>
+    <div class="nav-overlay__inner" data-mobile-overlay>
+      <div class="nav-overlay__top">
+        <h2 id="mobile-menu-title" class="nav-overlay__title">Μενού</h2>
+        <button class="nav-close" type="button" data-nav-close aria-label="Κλείσιμο μενού">
+          <span class="nav-close-bar"></span>
+          <span class="nav-close-bar"></span>
+        </button>
+      </div>
+      <nav class="nav-mobile" aria-label="Κύρια πλοήγηση" data-mobile-nav>
+        <ul class="nav-mobile__list">
+          <li class="nav-mobile__item"><a href="#" class="nav-mobile__link" data-home rel="home">Αρχική</a></li>
+          <li class="nav-mobile__item"><a href="#services" class="nav-mobile__link">Υπηρεσίες</a></li>
+          <li class="nav-mobile__item nav-mobile__item--projects"><a href="erga.html" class="nav-mobile__link">Έργα μας</a></li>
+          <li class="nav-mobile__item"><a href="index.html#contact" class="nav-mobile__link">Επικοινωνία</a></li>
+          <li class="nav-mobile__item nav-mobile__item--cta"><a href="index.html#contact" class="btn btn--primary nav-mobile__cta">Ζητήστε Προσφορά</a></li>
+        </ul>
+      </nav>
+      <div class="nav-overlay__social">
+        <a href="https://www.facebook.com/share/1CJUXM8xkk/" aria-label="Facebook" class="icon fb" target="_blank" rel="noopener noreferrer"></a>
+        <a href="https://www.instagram.com/fm.renovation21/" aria-label="Instagram" class="icon ig" target="_blank" rel="noopener noreferrer"></a>
+      </div>
+    </div>
+  </div>
+
+  <main>
+    <nav class="athens-breadcrumbs" aria-label="Breadcrumb">
+      <div class="container">
+        <ol>
+          <li><a href="/">Αρχική</a></li>
+          <li aria-hidden="true">/</li>
+          <li><span aria-current="page">Ανακαινίσεις Αθήνα</span></li>
+        </ol>
+      </div>
+    </nav>
+
+    <section class="athens-hero" aria-labelledby="athens-hero-title">
+      <div class="athens-hero__inner container">
+        <span class="athens-hero__eyebrow">FM Renovation • Ανακαινίσεις Αθήνα &amp; Αττική</span>
+        <h1 id="athens-hero-title">Ανακαινίσεις στην Αθήνα με συνέπεια, ασφάλεια και ποιοτικά υλικά</h1>
+        <p>Αναλαμβάνουμε ανακαίνιση σπιτιού στην Αθήνα, ολικές και μερικές παρεμβάσεις, με σωστό συντονισμό συνεργείων, καθαρή κοστολόγηση και αποτέλεσμα που αναβαθμίζει ουσιαστικά την αξία και τη λειτουργικότητα του χώρου σας.</p>
+        <div class="athens-hero__actions">
+          <a href="index.html#contact" class="btn btn--primary">Ζητήστε Προσφορά</a>
+          <a href="erga.html" class="btn btn--ghost">Δείτε τα έργα μας</a>
+        </div>
+      </div>
+    </section>
+
+    <section class="athens-section athens-intro">
+      <div class="container athens-grid athens-grid--2">
+        <div class="athens-card reveal">
+          <span class="athens-kicker">Εταιρεία ανακαινίσεων Αθήνα</span>
+          <h2>Σχεδιάζουμε και υλοποιούμε έργα με ξεκάθαρη διαδικασία</h2>
+          <p class="athens-lead">Είτε πρόκειται για ολική ανακαίνιση στην Αθήνα είτε για στοχευμένες βελτιώσεις σε διαμέρισμα, κατοικία ή επαγγελματικό χώρο, η ομάδα της FM Renovation οργανώνει κάθε στάδιο με τεχνική συνέπεια και προσοχή στη λεπτομέρεια.</p>
+          <p class="athens-lead">Δίνουμε έμφαση στην πραγματική ανάγκη του ακινήτου, στο budget και στο χρονοδιάγραμμα, ώστε το έργο να παραδίδεται λειτουργικό, αισθητικά προσεγμένο και χωρίς δυσάρεστες εκπλήξεις.</p>
+        </div>
+        <div class="athens-statlist reveal">
+          <div class="athens-stat">
+            <h3>Ολική &amp; μερική ανακαίνιση Αθήνα</h3>
+            <p>Από πλήρη ανακατασκευή κατοικίας μέχρι μπάνιο, κουζίνα, δάπεδα και τεχνικές εργασίες με ενιαίο συντονισμό.</p>
+          </div>
+          <div class="athens-stat">
+            <h3>Premium υλικά &amp; καθαρή οργάνωση</h3>
+            <p>Επιλέγουμε λύσεις με αντοχή στον χρόνο και ενημερώνουμε έγκαιρα για φάσεις εργασιών, παραδόσεις και τελικά φινιρίσματα.</p>
+          </div>
+          <div class="athens-stat">
+            <h3>Τοπική εξυπηρέτηση σε Αθήνα και Αττική</h3>
+            <p>Γνωρίζουμε τις ιδιαιτερότητες των ακινήτων της Αττικής και οργανώνουμε έργα με γρήγορη ανταπόκριση και πρακτικές λύσεις.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="athens-section athens-section--muted" aria-labelledby="trust-title">
+      <div class="container">
+        <div class="athens-section__head reveal">
+          <span class="athens-kicker">Γιατί να μας επιλέξετε</span>
+          <h2 id="trust-title">Αξία που φαίνεται από την πρώτη αυτοψία μέχρι την παράδοση</h2>
+          <p>Η επιτυχία μίας ανακαίνισης δεν είναι μόνο το αισθητικό αποτέλεσμα, αλλά η σωστή οργάνωση, η ασφάλεια στις εργασίες και η σταθερή ποιότητα σε κάθε λεπτομέρεια.</p>
+        </div>
+        <div class="athens-grid athens-trust">
+          <article class="athens-card reveal"><h3>Πιστοποιημένα υλικά</h3><p>Επιλέγουμε αξιόπιστα υλικά και λύσεις με έμφαση στην αντοχή, την ασφάλεια και την καθημερινή λειτουργικότητα.</p></article>
+          <article class="athens-card reveal"><h3>Συνέπεια στα χρονοδιαγράμματα</h3><p>Οργανώνουμε κάθε φάση του έργου με σαφή planning, ώστε να περιορίζονται καθυστερήσεις και απρόβλεπτα.</p></article>
+          <article class="athens-card reveal"><h3>Εξειδικευμένα συνεργεία</h3><p>Συντονίζουμε τεχνίτες ανά ειδικότητα για άρτιο αποτέλεσμα σε οικοδομικά, ηλεκτρολογικά, υδραυλικά και φινιρίσματα.</p></article>
+          <article class="athens-card reveal"><h3>Εξυπηρέτηση σε όλη την Αττική</h3><p>Αναλαμβάνουμε ανακαινίσεις στην Αθήνα, στα νότια, βόρεια και δυτικά προάστια, καθώς και στον Πειραιά.</p></article>
+        </div>
+      </div>
+    </section>
+
+    <section class="athens-section" id="services" aria-labelledby="services-title">
+      <div class="container">
+        <div class="athens-section__head reveal">
+          <span class="athens-kicker">Υπηρεσίες ανακαίνισης</span>
+          <h2 id="services-title">Ολοκληρωμένες υπηρεσίες για κάθε τύπο ακινήτου</h2>
+          <p>Καλύπτουμε τις βασικές και εξειδικευμένες ανάγκες μιας σύγχρονης ανακαίνισης, είτε ζητάτε πλήρη μεταμόρφωση χώρου είτε συγκεκριμένες τεχνικές εργασίες.</p>
+        </div>
+        <div class="athens-grid athens-grid--2">
+          <article class="athens-service reveal" id="oliki-anakainisi">
+            <h3>Ολική ανακαίνιση κατοικίας</h3>
+            <p>Αναλαμβάνουμε πλήρη ανασχεδιασμό διαμερίσματος ή κατοικίας, από αποξηλώσεις και νέες διαρρυθμίσεις έως τελικά υλικά και παραδοτέο έτοιμο προς χρήση.</p>
+            <a href="index.html#services">Δείτε και τις υπόλοιπες υπηρεσίες μας</a>
+          </article>
+          <article class="athens-service reveal" id="anakainisi-baniou">
+            <h3>Ανακαίνιση μπάνιου</h3>
+            <p>Λειτουργική και αισθητική αναβάθμιση με έμφαση στη στεγάνωση, τα σωστά υδραυλικά, τα πλακίδια και τις εργονομικές λύσεις αποθήκευσης.</p>
+            <a href="index.html#ydravlikes-ergasies">Υδραυλικές λύσεις για μπάνιο</a>
+          </article>
+          <article class="athens-service reveal" id="anakainisi-kouzinas">
+            <h3>Ανακαίνιση κουζίνας</h3>
+            <p>Σχεδιάζουμε κουζίνες που βελτιώνουν τη ροή της καθημερινότητας, με έξυπνη εργονομία, ανανεωμένες παροχές και ποιοτικά φινιρίσματα.</p>
+            <a href="erga.html">Δείτε πρόσφατα έργα ανακαίνισης</a>
+          </article>
+          <article class="athens-service reveal" id="ilektrologikes-ergasies">
+            <h3>Ηλεκτρολογικές εργασίες</h3>
+            <p>Αντικατάσταση ή αναβάθμιση ηλεκτρολογικών εγκαταστάσεων, νέος φωτισμός, πίνακες και ασφαλείς υποδομές με βάση τις απαιτήσεις του χώρου.</p>
+            <a href="index.html#ilektrologikes-ergasies">Περισσότερα για τις ηλεκτρολογικές εργασίες</a>
+          </article>
+          <article class="athens-service reveal" id="ydravlikes-ergasies-local">
+            <h3>Υδραυλικές εργασίες</h3>
+            <p>Εγκαταστάσεις και αντικαταστάσεις σωληνώσεων, επεμβάσεις σε κουζίνα και μπάνιο, καθώς και λύσεις που μειώνουν μελλοντικές βλάβες και κόστη.</p>
+            <a href="index.html#ydravlikes-ergasies">Περισσότερα για τις υδραυλικές εργασίες</a>
+          </article>
+          <article class="athens-service reveal" id="dapeda-koufwmata">
+            <h3>Δάπεδα / πλακίδια / βαψίματα / κουφώματα</h3>
+            <p>Ολοκληρωμένα τελειώματα που ανεβάζουν την εικόνα και την αξία του ακινήτου: πλακίδια, δάπεδα, ελαιοχρωματισμοί και νέες κατασκευές κουφωμάτων.</p>
+            <a href="index.html#koufomata-alouminiou-pvc">Δείτε σχετικές υπηρεσίες</a>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section class="athens-section athens-section--muted" aria-labelledby="local-title">
+      <div class="container athens-local">
+        <div class="reveal">
+          <span class="athens-kicker">Local SEO landing page</span>
+          <h2 id="local-title">Ανακαινίσεις σε Αθήνα και όλη την Αττική με άμεση ανταπόκριση</h2>
+          <p class="athens-lead">Η FM Renovation εξυπηρετεί ιδιοκτήτες και επαγγελματίες που χρειάζονται αξιόπιστη εταιρεία ανακαινίσεων στην Αθήνα, με εμπειρία σε παλιά διαμερίσματα, νεότερες κατοικίες και επαγγελματικούς χώρους. Αναλαμβάνουμε έργα σε κεντρικές περιοχές της Αθήνας αλλά και σε όλη την Αττική, προσαρμόζοντας το πλάνο εργασιών στις ανάγκες κάθε ακινήτου.</p>
+          <p class="athens-lead">Εάν αναζητάτε ανακαίνιση σπιτιού στην Αθήνα, μερική ανακαίνιση για αναβάθμιση συγκεκριμένων χώρων ή ολική ανακαίνιση στην Αττική για πλήρη μεταμόρφωση, μπορούμε να οργανώσουμε το έργο από την αυτοψία μέχρι την παράδοση. Με πρακτική γνώση των τοπικών αναγκών, των υφιστάμενων κατασκευών και της καθημερινής λειτουργίας της πόλης, προσφέρουμε λύσεις που είναι ρεαλιστικές, κοστολογημένες και αποδοτικές.</p>
+        </div>
+        <div class="athens-areas reveal" aria-label="Περιοχές εξυπηρέτησης">
+          <span class="athens-chip">Αθήνα</span>
+          <span class="athens-chip">Πειραιάς</span>
+          <span class="athens-chip">Γλυφάδα</span>
+          <span class="athens-chip">Νέα Σμύρνη</span>
+          <span class="athens-chip">Κηφισιά</span>
+          <span class="athens-chip">Μαρούσι</span>
+          <span class="athens-chip">Χαλάνδρι</span>
+          <span class="athens-chip">Περιστέρι</span>
+        </div>
+      </div>
+    </section>
+
+    <section class="athens-section" aria-labelledby="process-title">
+      <div class="container">
+        <div class="athens-section__head reveal">
+          <span class="athens-kicker">How we work</span>
+          <h2 id="process-title">Πώς δουλεύουμε μαζί σας</h2>
+          <p>Διατηρούμε τη διαδικασία απλή, διαφανή και οργανωμένη, ώστε να γνωρίζετε ακριβώς τι περιλαμβάνει κάθε στάδιο της συνεργασίας.</p>
+        </div>
+        <div class="athens-grid athens-steps">
+          <article class="athens-step reveal"><span class="athens-step__num">1</span><h3>Επικοινωνία</h3><p>Λαμβάνουμε το αίτημά σας και συζητάμε τον τύπο ακινήτου, τις ανάγκες και το ζητούμενο αποτέλεσμα.</p></article>
+          <article class="athens-step reveal"><span class="athens-step__num">2</span><h3>Αυτοψία / καταγραφή αναγκών</h3><p>Επισκεπτόμαστε τον χώρο για ακριβή αποτύπωση, τεχνικό έλεγχο και ιεράρχηση εργασιών.</p></article>
+          <article class="athens-step reveal"><span class="athens-step__num">3</span><h3>Προσφορά</h3><p>Παρουσιάζουμε πρόταση με εύρος εργασιών, υλικά, χρονικό πλάνο και σαφή κοστολόγηση.</p></article>
+          <article class="athens-step reveal"><span class="athens-step__num">4</span><h3>Υλοποίηση έργου</h3><p>Συντονίζουμε όλα τα συνεργεία και παρακολουθούμε την πρόοδο με έμφαση στην ποιότητα και την καθαριότητα.</p></article>
+          <article class="athens-step reveal"><span class="athens-step__num">5</span><h3>Παράδοση</h3><p>Παραδίδουμε τον χώρο λειτουργικό, ολοκληρωμένο και έτοιμο να χρησιμοποιηθεί χωρίς εκκρεμότητες.</p></article>
+        </div>
+      </div>
+    </section>
+
+    <section class="athens-section athens-section--muted" aria-labelledby="projects-title">
+      <div class="container athens-projects">
+        <div class="reveal">
+          <span class="athens-kicker">Portfolio</span>
+          <h2 id="projects-title">Δείτε έργα που αποτυπώνουν την ποιότητα της δουλειάς μας</h2>
+          <p class="athens-lead">Πραγματικά έργα ανακαίνισης σε κατοικίες και επαγγελματικούς χώρους, με εικόνες που δείχνουν την προσοχή μας στη λεπτομέρεια, στα υλικά και στη συνολική αισθητική.</p>
+          <div class="athens-final__actions">
+            <a href="erga.html" class="btn btn--primary">Μετάβαση στα έργα</a>
+            <a href="/" class="btn btn--ghost">Επιστροφή στην αρχική</a>
+          </div>
+        </div>
+        <div class="athens-projects__media reveal" aria-hidden="true"></div>
+      </div>
+    </section>
+
+    <section class="athens-section" aria-labelledby="faq-title">
+      <div class="container">
+        <div class="athens-section__head reveal">
+          <span class="athens-kicker">FAQ</span>
+          <h2 id="faq-title">Συχνές ερωτήσεις για ανακαινίσεις στην Αθήνα</h2>
+        </div>
+        <div class="athens-faq">
+          <details class="reveal" open>
+            <summary>Πόσο διαρκεί μια ανακαίνιση;</summary>
+            <p>Η διάρκεια εξαρτάται από το μέγεθος του ακινήτου, το εύρος παρεμβάσεων και το αν πρόκειται για μερική ή ολική ανακαίνιση στην Αθήνα. Μετά την αυτοψία μπορούμε να σας δώσουμε πιο ακριβές και ρεαλιστικό χρονοδιάγραμμα.</p>
+          </details>
+          <details class="reveal">
+            <summary>Πώς βγαίνει η προσφορά;</summary>
+            <p>Η προσφορά προκύπτει μετά από επικοινωνία και επιτόπια καταγραφή, ώστε να εκτιμηθούν σωστά εργασίες, υλικά, ιδιαιτερότητες του χώρου και το ζητούμενο αισθητικό αποτέλεσμα.</p>
+          </details>
+          <details class="reveal">
+            <summary>Αναλαμβάνετε όλη την Αθήνα;</summary>
+            <p>Ναι, εξυπηρετούμε περιοχές σε όλη την Αθήνα και την Αττική, από κεντρικά διαμερίσματα μέχρι έργα σε Πειραιά, Γλυφάδα, Νέα Σμύρνη, Κηφισιά, Μαρούσι, Χαλάνδρι και Περιστέρι.</p>
+          </details>
+          <details class="reveal">
+            <summary>Κάνετε ολικές και μερικές ανακαινίσεις;</summary>
+            <p>Αναλαμβάνουμε και τα δύο. Μπορούμε να οργανώσουμε πλήρη ανακαίνιση κατοικίας ή πιο στοχευμένες εργασίες, όπως μπάνιο, κουζίνα, ηλεκτρολογικά, υδραυλικά, δάπεδα και βαψίματα.</p>
+          </details>
+          <details class="reveal">
+            <summary>Μπορώ να ζητήσω δωρεάν εκτίμηση;</summary>
+            <p>Βεβαίως. Μπορείτε να στείλετε αίτημα για δωρεάν πρώτη εκτίμηση και να προγραμματίσουμε αυτοψία, ώστε να προχωρήσουμε σε εξατομικευμένη προσφορά.</p>
+          </details>
+        </div>
+      </div>
+    </section>
+
+    <section class="athens-final">
+      <div class="container">
+        <div class="athens-final__box reveal">
+          <span class="athens-kicker" style="color:#fbbf24">Έτοιμοι να ξεκινήσουμε;</span>
+          <h2>Συζητήστε το έργο σας με μια ομάδα που γνωρίζει τις ανακαινίσεις στην Αθήνα</h2>
+          <p>Αν θέλετε σοβαρή προσέγγιση, τεχνική καθοδήγηση και καθαρό πλάνο για το ακίνητό σας, επικοινωνήστε μαζί μας για δωρεάν εκτίμηση. Θα σας προτείνουμε λύσεις που συνδυάζουν αισθητική, πρακτικότητα και σωστή επένδυση.</p>
+          <div class="athens-final__actions">
+            <a href="index.html#contact" class="btn btn--primary">Μετάβαση στην επικοινωνία</a>
+            <a href="tel:+302114044496" class="btn btn--ghost">Καλέστε μας τώρα</a>
+          </div>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container footer-inner">
+      <div class="footer-contact">
+        <h3 class="footer-heading">Εξυπηρετούμε όλη την Αττική</h3>
+        <ul class="footer-list">
+          <li class="footer-list__item"><span class="footer-list__icon" aria-hidden="true"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M6.62 10.79a15.05 15.05 0 0 0 6.59 6.59l2.2-2.2a1 1 0 0 1 1.01-.24 11.36 11.36 0 0 0 3.56.57 1 1 0 0 1 1 1v3.52a1 1 0 0 1-1 1C10.29 21.03 3 13.74 3 4.02a1 1 0 0 1 1-1h3.52a1 1 0 0 1 1 1c0 1.22.2 2.43.57 3.56a1 1 0 0 1-.25 1.01l-2.2 2.2Z" fill="currentColor"/></svg></span><span><a href="tel:+302114044496">+30 211 404 4496</a></span></li>
+          <li class="footer-list__item"><span class="footer-list__icon" aria-hidden="true"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M6.62 10.79a15.05 15.05 0 0 0 6.59 6.59l2.2-2.2a1 1 0 0 1 1.01-.24 11.36 11.36 0 0 0 3.56.57 1 1 0 0 1 1 1v3.52a1 1 0 0 1-1 1C10.29 21.03 3 13.74 3 4.02a1 1 0 0 1 1-1h3.52a1 1 0 0 1 1 1c0 1.22.2 2.43.57 3.56a1 1 0 0 1-.25 1.01l-2.22 2.2Z" fill="currentColor"/></svg></span><span><a href="tel:+306939500950">+30 693 950 0950</a></span></li>
+          <li class="footer-list__item"><span class="footer-list__icon" aria-hidden="true"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M4 6c-1.1 0-2 .9-2 2v8c0 1.1.9 2 2 2h16a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2H4Zm0 2 8 5 8-5v-.01L12 13 4 7.99V8Z" fill="currentColor"/></svg></span><span><a href="mailto:fmren2021@gmail.com">fmren2021@gmail.com</a></span></li>
+          <li class="footer-list__item"><span class="footer-list__icon" aria-hidden="true"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M12 2a7 7 0 0 0-7 7c0 4.67 4.24 9.87 6.34 12.09a1 1 0 0 0 1.32 0C14.76 18.87 19 13.67 19 9a7 7 0 0 0-7-7Zm0 10a3 3 0 1 1 0-6 3 3 0 0 1 0 6Z" fill="currentColor"/></svg></span><span>Δοϊράνης 180, Καλλιθέα Τ.Κ. 17673</span></li>
+        </ul>
+      </div>
+      <div class="footer-brand">
+        <div class="brand brand--footer">
+          <a href="index.html" class="logo-link" aria-label="Αρχική σελίδα">
+            <img class="brand-logo" src="images/logo.webp" alt="FM Renovation Ανακαινίσεις Αθήνα" width="180" height="60">
+          </a>
+        </div>
+        <nav class="footer-links" aria-label="Χρήσιμες σύνδεσμοι">
+          <a href="terms.html">Όροι &amp; Προϋποθέσεις</a>
+          <a href="privacy-policy.html">Πολιτική Απορρήτου</a>
+          <a href="cookie-policy.html">Πολιτική Cookies</a>
+        </nav>
+        <p class="footer-copy">© <span id="year"></span> FM Renovation • <a href="https://anakainisou.gr/">anakainisou.gr</a></p>
+      </div>
+      <div class="footer-social">
+        <h3 class="footer-heading">Ακολουθήστε μας</h3>
+        <div class="social">
+          <a href="https://www.facebook.com/share/1CJUXM8xkk/" aria-label="Facebook" class="icon fb" target="_blank" rel="noopener noreferrer"></a>
+          <a href="https://www.instagram.com/fm.renovation21/" aria-label="Instagram" class="icon ig" target="_blank" rel="noopener noreferrer"></a>
+        </div>
+        <p class="footer-hours">Δευ–Παρ: 08:00–16:00<br>Σάβ: 09:00–15:00<br>Κυρ: Κλειστά</p>
+      </div>
+    </div>
+  </footer>
+
+  <button id="backToTop" class="back-to-top" type="button" aria-label="Επιστροφή στην αρχή" title="Προς τα πάνω">
+    <span class="back-to-top__icon" aria-hidden="true"></span>
+  </button>
+
+  <div class="contact-widget" aria-label="Γρήγορη επικοινωνία">
+    <div id="contactWidgetPanel" class="contact-widget__panel" aria-hidden="true">
+      <a class="contact-widget__link" href="mailto:fmren2021@gmail.com"><span class="contact-widget__icon" aria-hidden="true"><img src="images/icons/email.svg" width="36" height="36" alt="" loading="lazy"></span><span>Email</span></a>
+      <a class="contact-widget__link" href="viber://chat?number=+306939500950"><span class="contact-widget__icon" aria-hidden="true"><img src="images/icons/viber.svg" width="36" height="36" alt="" loading="lazy"></span><span>Viber</span></a>
+    </div>
+    <button class="contact-widget__toggle" type="button" aria-expanded="false" aria-controls="contactWidgetPanel" aria-label="Άνοιγμα επιλογών επικοινωνίας">
+      <svg aria-hidden="true" width="28" height="28" viewBox="0 0 24 24" fill="none"><path d="M12 3C7.03 3 3 6.58 3 11c0 2.35 1.16 4.47 3 5.96V21l3.07-1.64c.96.27 1.99.42 3.08.42 4.97 0 9-3.58 9-8s-4.03-8-9-8Zm-.14 11.91h-.02c-.31 0-.6-.03-.88-.08-.76.52-1.6.95-2.49 1.26.47-.69.76-1.32.88-1.94-1.11-.74-1.81-1.82-1.81-3.05 0-2.22 2.09-4.02 4.67-4.02s4.67 1.8 4.67 4.02-2.09 4.03-4.66 4.03Z" fill="currentColor"/></svg>
+      <span class="visually-hidden">Contact</span>
+    </button>
+  </div>
+
+  <div class="cookie-banner" id="cookieBanner">
+    <div class="cookie-banner__inner">
+      <p class="cookie-banner__text">Χρησιμοποιούμε cookies για να βελτιώσουμε την εμπειρία σας. Συνεχίζοντας αποδέχεστε τη χρήση τους. <a href="/cookie-policy.html" class="cookie-banner__link">Μάθετε περισσότερα</a>.</p>
+      <div class="cookie-banner__actions">
+        <button type="button" class="cookie-banner__btn cookie-banner__btn--secondary" id="cookieReject">Μόνο τα απαραίτητα</button>
+        <button type="button" class="cookie-banner__btn cookie-banner__btn--primary" id="cookieAccept">Αποδοχή</button>
+      </div>
+    </div>
+  </div>
+
+  <script>
+  (function(){
+    const banner = document.getElementById('cookieBanner');
+    const accept = document.getElementById('cookieAccept');
+    const reject = document.getElementById('cookieReject');
+    if (!banner || !accept || !reject) return;
+    if (!localStorage.getItem('cookieConsent')) {
+      banner.style.display = 'block';
+    }
+    accept.addEventListener('click', () => {
+      localStorage.setItem('cookieConsent', 'accepted');
+      banner.style.display = 'none';
+    });
+    reject.addEventListener('click', () => {
+      localStorage.setItem('cookieConsent', 'minimal');
+      banner.style.display = 'none';
+    });
+  })();
+  </script>
+  <script src="assets/app.js" defer></script>
+</body>
+</html>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -9,6 +9,10 @@
   </url>
 
   <url>
+    <loc>https://www.anakainisou.gr/anakainiseis-athina.html</loc>
+  </url>
+
+  <url>
     <loc>https://www.anakainisou.gr/terms.html</loc>
   </url>
 


### PR DESCRIPTION
### Motivation
- Provide a focused, local-SEO landing page targeting “ανακαινίσεις αθήνα” and related local queries while preserving the existing site design system and global styles. 
- Keep changes isolated and safe so header, footer, mobile menu, forms and shared CSS are not modified or broken.

### Description
- Added a new static page `anakainiseis-athina.html` that reuses the existing site header, footer, contact widget and global CSS and includes a page-scoped responsive style block for the landing layout. 
- Implemented a full-width hero banner (background image from `photos/` + dark overlay), centered H1, short subtitle and two CTAs (`Ζητήστε Προσφορά`, `Δείτε τα έργα μας`).
- Added content sections: Trust (4 benefits), Services (cards for requested services), Local SEO (areas served like Αθήνα, Πειραιάς, Γλυφάδα, Νέα Σμύρνη, Κηφισιά, Μαρούσι, Χαλάνδρι, Περιστέρι, Περιστέρι), How We Work (5 steps), Projects CTA linking to `erga.html`, FAQ (5 Q&A), and a strong final CTA linking to contact. 
- Inserted full SEO elements including `<title>`, meta description, `canonical` for `https://www.anakainisou.gr/anakainiseis-athina.html`, Open Graph and Twitter card tags, and page-scoped JSON-LD `HomeAndConstructionBusiness` and `FAQPage` schemas. 
- Updated `sitemap.xml` to include the new page and used safe internal links to `/`, `/erga.html` and the contact anchor `index.html#contact` and existing service anchors (no other site files were modified). 

### Testing
- Ran an automated HTML content check (Python) that verified presence of `title`, `canonical`, the H1, at least 5 FAQ entries, `HomeAndConstructionBusiness` and `FAQPage` schema, and Open Graph/Twitter tags, and the check passed. 
- Validated `sitemap.xml` by parsing the XML programmatically and the file parsed successfully. 
- Performed repository checks for whitespace/lint/diff issues and no blocking issues were found after the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfe8c984308320a9fdc79005cb717f)