### PR TITLE
Add internal links to Athens renovations page

### DIFF
--- a/anakainiseis-athina.html
+++ b/anakainiseis-athina.html
@@ -487,6 +487,7 @@
           <a href="terms.html">Όροι &amp; Προϋποθέσεις</a>
           <a href="privacy-policy.html">Πολιτική Απορρήτου</a>
           <a href="cookie-policy.html">Πολιτική Cookies</a>
+          <a href="/anakainiseis-athina.html">Ανακαινίσεις Αθήνα</a>
         </nav>
         <p class="footer-copy">© <span id="year"></span> FM Renovation • <a href="https://anakainisou.gr/">anakainisou.gr</a></p>
       </div>

--- a/cookie-policy.html
+++ b/cookie-policy.html
@@ -124,7 +124,7 @@
           <img class="brand-logo" src="images/logo.webp" alt="FM Renovation Ανακαινίσεις Αθήνα" width="180" height="60">
         </a>
       </div>
-      <p>© <span id="year"></span> FM Renovation • <a href="https://anakainisou.gr/">anakainisou.gr</a></p>
+      <p>© <span id="year"></span> FM Renovation • <a href="https://anakainisou.gr/">anakainisou.gr</a> • <a href="/anakainiseis-athina.html">Ανακαινίσεις Αθήνα</a></p>
       <div class="social">
         <a href="https://www.facebook.com/share/1CJUXM8xkk/" aria-label="Facebook" class="icon fb" target="_blank" rel="noopener noreferrer"></a>
         <a href="https://www.instagram.com/fm.renovation21/" aria-label="Instagram" class="icon ig"></a>

--- a/erga.html
+++ b/erga.html
@@ -149,6 +149,7 @@
           <a href="terms.html">Όροι &amp; Προϋποθέσεις</a>
           <a href="privacy-policy.html">Πολιτική Απορρήτου</a>
           <a href="cookie-policy.html">Πολιτική Cookies</a>
+          <a href="/anakainiseis-athina.html">Ανακαινίσεις Αθήνα</a>
         </nav>
         <p class="footer-copy">© <span id="year"></span> FM Renovation • <a href="https://anakainisou.gr/">anakainisou.gr</a></p>
       </div>

--- a/index.html
+++ b/index.html
@@ -294,6 +294,7 @@
 
       <div class="section-cta">
         <a href="#contact" class="btn btn--primary">Ζητήστε Προσφορά</a>
+        <a href="/anakainiseis-athina.html" class="btn">Ανακαινίσεις στην Αθήνα</a>
       </div>
     </section>
 
@@ -569,6 +570,7 @@
           <a href="terms.html">Όροι &amp; Προϋποθέσεις</a>
           <a href="privacy-policy.html">Πολιτική Απορρήτου</a>
           <a href="cookie-policy.html">Πολιτική Cookies</a>
+          <a href="/anakainiseis-athina.html">Ανακαινίσεις Αθήνα</a>
         </nav>
         <p class="footer-copy">© <span id="year"></span> FM Renovation • <a href="https://anakainisou.gr/">anakainisou.gr</a></p>
       </div>

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -113,7 +113,7 @@
           <img class="brand-logo" src="images/logo.webp" alt="FM Renovation Ανακαινίσεις Αθήνα" width="180" height="60">
         </a>
       </div>
-      <p>© <span id="year"></span> FM Renovation • <a href="https://anakainisou.gr/">anakainisou.gr</a></p>
+      <p>© <span id="year"></span> FM Renovation • <a href="https://anakainisou.gr/">anakainisou.gr</a> • <a href="/anakainiseis-athina.html">Ανακαινίσεις Αθήνα</a></p>
       <div class="social">
         <a href="https://www.facebook.com/share/1CJUXM8xkk/" aria-label="Facebook" class="icon fb" target="_blank" rel="noopener noreferrer"></a>
         <a href="https://www.instagram.com/fm.renovation21/" aria-label="Instagram" class="icon ig"></a>

--- a/terms.html
+++ b/terms.html
@@ -112,7 +112,7 @@
           <img class="brand-logo" src="images/logo.webp" alt="FM Renovation Ανακαινίσεις Αθήνα" width="180" height="60">
         </a>
       </div>
-      <p>© <span id="year"></span> FM Renovation • <a href="https://anakainisou.gr/">anakainisou.gr</a></p>
+      <p>© <span id="year"></span> FM Renovation • <a href="https://anakainisou.gr/">anakainisou.gr</a> • <a href="/anakainiseis-athina.html">Ανακαινίσεις Αθήνα</a></p>
       <div class="social">
         <a href="https://www.facebook.com/share/1CJUXM8xkk/" aria-label="Facebook" class="icon fb" target="_blank" rel="noopener noreferrer"></a>
         <a href="https://www.instagram.com/fm.renovation21/" aria-label="Instagram" class="icon ig"></a>


### PR DESCRIPTION
### Motivation
- Improve internal linking and SEO for the existing `/anakainiseis-athina.html` page while keeping site navigation, layout and styles untouched.

### Description
- Added a homepage CTA button in the existing `section-cta` (services area) linking to `/anakainiseis-athina.html` with the exact anchor text `Ανακαινίσεις στην Αθήνα` using existing button classes. 
- Inserted a simple footer link `Ανακαινίσεις Αθήνα` into the existing `nav.footer-links` where present and, for pages with a simpler footer, appended the same link into the footer copyright line to avoid layout changes. 
- Changes are minimal HTML-only edits and do not modify any classes, ids, CSS, JS, or header/mobile navigation structure. 
- Modified files: `index.html`, `erga.html`, `anakainiseis-athina.html`, `privacy-policy.html`, `cookie-policy.html`, `terms.html`.

### Testing
- Ran `rg -n "Ανακαινίσεις στην Αθήνα|Ανακαινίσεις Αθήνα|anakainiseis-athina\.html" index.html erga.html privacy-policy.html cookie-policy.html terms.html anakainiseis-athina.html` and confirmed the new links are present; test succeeded. 
- Ran `rg -n "nav__|nav-mobile__" index.html` to verify header and mobile navigation were not changed; test succeeded. 
- Verified the homepage CTA was added to the services `section-cta` and footer links were added only in footer areas; verification commands succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bff139a0d883208f21b4e2624db1ce)