### PR TITLE
Add standalone contact.html with Formspree form, map, SEO and LocalBusiness schema

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -1,0 +1,477 @@
+<!doctype html>
+<html lang="el">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Επικοινωνία | Ανακαινίσεις Αθήνα - FM Renovation</title>
+  <meta name="description" content="Επικοινωνήστε με την FM Renovation για ανακαινίσεις στην Αθήνα και Αττική. Καλέστε μας ή στείλτε μήνυμα για δωρεάν εκτίμηση.">
+  <link rel="canonical" href="https://www.anakainisou.gr/contact.html">
+
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Roboto:wght@700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="assets/style.css">
+  <link rel="icon" type="image/png" href="favicon-96x96.png" sizes="96x96">
+  <link rel="icon" type="image/svg+xml" href="favicon.svg">
+  <link rel="shortcut icon" href="favicon.ico">
+  <link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png">
+  <link rel="manifest" href="site.webmanifest">
+  <meta name="theme-color" content="#F59E0B">
+  <meta property="og:type" content="website">
+  <meta property="og:locale" content="el_GR">
+  <meta property="og:title" content="Επικοινωνία | Ανακαινίσεις Αθήνα - FM Renovation">
+  <meta property="og:description" content="Επικοινωνήστε με την FM Renovation για ανακαινίσεις στην Αθήνα και Αττική. Καλέστε μας ή στείλτε μήνυμα για δωρεάν εκτίμηση.">
+  <meta property="og:url" content="https://www.anakainisou.gr/contact.html">
+  <meta property="og:image" content="https://www.anakainisou.gr/images/hero.webp">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Επικοινωνία | Ανακαινίσεις Αθήνα - FM Renovation">
+  <meta name="twitter:description" content="Επικοινωνήστε με την FM Renovation για ανακαινίσεις στην Αθήνα και Αττική. Καλέστε μας ή στείλτε μήνυμα για δωρεάν εκτίμηση.">
+  <style>
+    .contact-page main {
+      background: linear-gradient(180deg, #ffffff 0%, #f8fafc 100%);
+    }
+
+    .contact-hero {
+      position: relative;
+      min-height: 320px;
+      display: grid;
+      place-items: center;
+      overflow: hidden;
+      color: #fff;
+      text-align: center;
+      isolation: isolate;
+    }
+
+    .contact-hero::before {
+      content: "";
+      position: absolute;
+      inset: 0;
+      background: linear-gradient(180deg, rgba(15, 23, 42, 0.58) 0%, rgba(15, 23, 42, 0.72) 100%);
+      z-index: 1;
+    }
+
+    .contact-hero__image {
+      position: absolute;
+      inset: 0;
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      z-index: 0;
+    }
+
+    .contact-hero__content {
+      position: relative;
+      z-index: 2;
+      padding: 96px 16px 72px;
+      max-width: 760px;
+    }
+
+    .contact-hero__content h1 {
+      margin: 0 0 14px;
+      font-size: clamp(2rem, 5vw, 3.4rem);
+      color: #fff;
+    }
+
+    .contact-hero__content p {
+      margin: 0;
+      font-size: clamp(1rem, 2vw, 1.2rem);
+      color: rgba(255, 255, 255, 0.92);
+    }
+
+    .contact-details {
+      display: grid;
+      gap: 28px;
+      align-items: start;
+    }
+
+    .contact-card,
+    .map-card,
+    .cta-card {
+      background: #fff;
+      border: 1px solid #e8edf4;
+      border-radius: 20px;
+      box-shadow: var(--shadow);
+    }
+
+    .contact-card {
+      padding: clamp(24px, 4vw, 36px);
+    }
+
+    .contact-card h2,
+    .map-card h2,
+    .cta-card h2 {
+      margin-top: 0;
+      margin-bottom: 12px;
+      color: #0f172a;
+    }
+
+    .contact-card p,
+    .contact-card li,
+    .map-card p,
+    .cta-card p {
+      color: #475569;
+    }
+
+    .contact-list,
+    .hours-list {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+      display: grid;
+      gap: 16px;
+    }
+
+    .contact-list strong,
+    .hours-title {
+      display: block;
+      margin-bottom: 4px;
+      color: #0f172a;
+    }
+
+    .contact-list a {
+      color: inherit;
+      text-decoration: none;
+    }
+
+    .contact-list a:hover,
+    .contact-list a:focus-visible {
+      color: var(--accent);
+      outline: none;
+    }
+
+    .contact-form {
+      max-width: none;
+      margin: 0;
+    }
+
+    .contact-form h2 {
+      margin-bottom: 8px;
+    }
+
+    #contactForm {
+      display: grid;
+      gap: 16px;
+    }
+
+    .form-status {
+      margin: 0;
+      font-weight: 600;
+      color: #0f172a;
+    }
+
+    .map-card {
+      padding: clamp(24px, 4vw, 36px);
+    }
+
+    .map-card .map {
+      margin-top: 18px;
+    }
+
+    .cta-wrap {
+      padding-top: 0;
+    }
+
+    .cta-card {
+      padding: clamp(28px, 5vw, 40px);
+      text-align: center;
+      background: linear-gradient(135deg, #fff7ed 0%, #ffffff 100%);
+    }
+
+    .cta-card .btn {
+      min-width: 220px;
+    }
+
+    @media (min-width: 900px) {
+      .contact-details {
+        grid-template-columns: minmax(0, 0.9fr) minmax(0, 1.1fr);
+      }
+    }
+  </style>
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "LocalBusiness",
+      "name": "FM Renovation",
+      "url": "https://www.anakainisou.gr/contact.html",
+      "telephone": "+30 211 404 4496",
+      "email": "fmren2021@gmail.com",
+      "areaServed": "Athens",
+      "address": {
+        "@type": "PostalAddress",
+        "streetAddress": "Doiranis 180",
+        "addressLocality": "Kallithea",
+        "addressRegion": "Attica",
+        "addressCountry": "GR"
+      }
+    }
+  </script>
+</head>
+<body class="contact-page">
+  <header class="site-header" id="top">
+    <div class="container header-inner">
+      <div class="brand">
+        <a href="index.html" class="logo-link" aria-label="Αρχική σελίδα">
+          <img class="brand-logo" src="images/logo.webp" alt="FM Renovation Ανακαινίσεις Αθήνα" width="180" height="60">
+        </a>
+        <span class="brand-tagline"><strong>Ανακαίνιση χώρου</strong></span>
+      </div>
+      <button class="nav-toggle" type="button" data-nav-toggle aria-expanded="false" aria-controls="mobile-menu" aria-label="Άνοιγμα μενού">
+        <span class="nav-toggle-bar"></span>
+        <span class="nav-toggle-bar"></span>
+        <span class="nav-toggle-bar"></span>
+      </button>
+      <nav id="site-nav" class="nav" aria-label="Κύρια πλοήγηση">
+        <ul class="nav__list">
+          <li class="nav__item"><a href="index.html" class="nav__link" rel="home">Αρχική</a></li>
+          <li class="nav__item"><a href="index.html#services" class="nav__link">Υπηρεσίες</a></li>
+          <li class="nav__item nav__item--projects"><a href="erga.html" class="nav__link">Έργα μας</a></li>
+          <li class="nav__item"><a href="index.html#contact" class="nav__link">Επικοινωνία</a></li>
+          <li class="nav__item nav__item--cta"><a href="index.html#contact" class="btn btn--sm nav-cta">Ζητήστε Προσφορά</a></li>
+        </ul>
+      </nav>
+      <div class="social">
+        <a href="https://www.facebook.com/share/1CJUXM8xkk/" aria-label="Facebook" class="icon fb" target="_blank" rel="noopener noreferrer"></a>
+        <a href="https://www.instagram.com/fm.renovation21/" aria-label="Instagram" class="icon ig" target="_blank" rel="noopener noreferrer"></a>
+      </div>
+    </div>
+  </header>
+
+  <div class="nav-backdrop" data-nav-backdrop hidden></div>
+  <div class="nav-overlay" id="mobile-menu" role="dialog" aria-modal="true" aria-labelledby="mobile-menu-title" hidden>
+    <div class="nav-overlay__inner" data-mobile-overlay>
+      <div class="nav-overlay__top">
+        <h2 id="mobile-menu-title" class="nav-overlay__title">Μενού</h2>
+        <button class="nav-close" type="button" data-nav-close aria-label="Κλείσιμο μενού">
+          <span class="nav-close-bar"></span>
+          <span class="nav-close-bar"></span>
+        </button>
+      </div>
+      <nav class="nav-mobile" aria-label="Κύρια πλοήγηση" data-mobile-nav>
+        <ul class="nav-mobile__list">
+          <li class="nav-mobile__item"><a href="index.html" class="nav-mobile__link" rel="home">Αρχική</a></li>
+          <li class="nav-mobile__item"><a href="index.html#services" class="nav-mobile__link">Υπηρεσίες</a></li>
+          <li class="nav-mobile__item nav-mobile__item--projects"><a href="erga.html" class="nav-mobile__link">Έργα μας</a></li>
+          <li class="nav-mobile__item"><a href="index.html#contact" class="nav-mobile__link">Επικοινωνία</a></li>
+          <li class="nav-mobile__item nav-mobile__item--cta"><a href="index.html#contact" class="btn btn--primary nav-mobile__cta">Ζητήστε Προσφορά</a></li>
+        </ul>
+      </nav>
+      <div class="nav-overlay__social">
+        <a href="https://www.facebook.com/share/1CJUXM8xkk/" aria-label="Facebook" class="icon fb" target="_blank" rel="noopener noreferrer"></a>
+        <a href="https://www.instagram.com/fm.renovation21/" aria-label="Instagram" class="icon ig" target="_blank" rel="noopener noreferrer"></a>
+      </div>
+    </div>
+  </div>
+
+  <main>
+    <section class="contact-hero" aria-labelledby="contact-hero-title">
+      <img class="contact-hero__image" src="images/hero.webp" alt="FM Renovation ανακαινίσεις στην Αθήνα" width="1600" height="900" loading="lazy">
+      <div class="container contact-hero__content">
+        <h1 id="contact-hero-title">Επικοινωνία</h1>
+        <p>Επικοινωνήστε μαζί μας για ανακαινίσεις στην Αθήνα &amp; Αττική</p>
+      </div>
+    </section>
+
+    <section class="section contact-section" aria-labelledby="contact-info-title">
+      <div class="container contact-details">
+        <div class="contact-card">
+          <h2 id="contact-info-title">Στοιχεία Επικοινωνίας</h2>
+          <p class="contact-intro">Μιλήστε μαζί μας για το έργο σας και λάβετε άμεσα δωρεάν εκτίμηση για κατοικίες και επαγγελματικούς χώρους.</p>
+          <ul class="contact-list">
+            <li>
+              <strong>Τηλέφωνο</strong>
+              <a href="tel:+302114044496">+30 211 404 4496</a><br>
+              <a href="tel:+306939500950">+30 693 950 0950</a>
+            </li>
+            <li>
+              <strong>Email</strong>
+              <a href="mailto:fmren2021@gmail.com">fmren2021@gmail.com</a>
+            </li>
+            <li>
+              <strong>Διεύθυνση</strong>
+              <span>Doiranis 180, Kallithea</span>
+            </li>
+            <li>
+              <span class="hours-title">Ώρες λειτουργίας</span>
+              <ul class="hours-list">
+                <li>Δευτέρα – Παρασκευή: 08:00 – 16:00</li>
+                <li>Σάββατο: 09:00 – 15:00</li>
+                <li>Κυριακή: Κλειστά</li>
+              </ul>
+            </li>
+          </ul>
+        </div>
+
+        <div class="contact-form" aria-labelledby="contact-form-title">
+          <h2 id="contact-form-title">Στείλτε μας μήνυμα</h2>
+          <p class="contact-intro">Συμπληρώστε τη φόρμα και θα επικοινωνήσουμε μαζί σας το συντομότερο δυνατό.</p>
+          <form id="contactForm" action="https://formspree.io/f/mkgqykrp" method="POST">
+            <div class="form-group">
+              <label for="name">Όνομα</label>
+              <input id="name" name="name" type="text" placeholder="Το όνομά σας" required>
+            </div>
+
+            <div class="form-group">
+              <label for="phone">Τηλέφωνο</label>
+              <input id="phone" name="phone" type="tel" inputmode="tel" placeholder="Π.χ. 2101234567" required>
+            </div>
+
+            <div class="form-group">
+              <label for="email">Email</label>
+              <input id="email" name="email" type="email" placeholder="Το email σας" required>
+            </div>
+
+            <div class="form-group">
+              <label for="message">Μήνυμα</label>
+              <textarea id="message" name="message" rows="6" placeholder="Πείτε μας λίγα λόγια για το έργο σας" required></textarea>
+            </div>
+
+            <input type="text" name="_gotcha" style="display:none">
+            <input type="hidden" name="_subject" value="Νέο μήνυμα από τη φόρμα επικοινωνίας – FM Renovation">
+            <input type="hidden" name="_replyto" value="{{email}}">
+
+            <button type="submit" class="btn-submit">Αποστολή</button>
+            <p id="form-status" class="form-status" aria-live="polite" hidden></p>
+          </form>
+        </div>
+      </div>
+    </section>
+
+    <section class="section" aria-labelledby="map-title">
+      <div class="container">
+        <div class="map-card">
+          <h2 id="map-title">Βρείτε μας στον χάρτη</h2>
+          <p>Επισκεφθείτε μας στη Δοϊράνης 180, Καλλιθέα ή επικοινωνήστε για να προγραμματίσουμε ραντεβού στον χώρο σας.</p>
+          <div class="map">
+            <iframe src="https://www.google.com/maps?q=Doiranis%20180%2C%20Kallithea&z=15&output=embed" title="Χάρτης για Doiranis 180, Kallithea" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="section cta-wrap" aria-labelledby="cta-title">
+      <div class="container">
+        <div class="cta-card">
+          <h2 id="cta-title">Ζητήστε Δωρεάν Εκτίμηση</h2>
+          <p>Καλέστε μας σήμερα για να συζητήσουμε την ανακαίνιση που σχεδιάζετε στην Αθήνα και την Αττική.</p>
+          <a href="tel:+302114044496" class="btn btn--primary">Καλέστε τώρα</a>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container footer-inner">
+      <div class="footer-contact">
+        <h3 class="footer-heading">Εξυπηρετούμε όλη την Αττική</h3>
+        <ul class="footer-list">
+          <li class="footer-list__item">
+            <span class="footer-list__icon" aria-hidden="true">
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M6.62 10.79a15.05 15.05 0 0 0 6.59 6.59l2.2-2.2a1 1 0 0 1 1.01-.24 11.36 11.36 0 0 0 3.56.57 1 1 0 0 1 1 1v3.52a1 1 0 0 1-1 1C10.29 21.03 3 13.74 3 4.02a1 1 0 0 1 1-1h3.52a1 1 0 0 1 1 1c0 1.22.2 2.43.57 3.56a1 1 0 0 1-.25 1.01l-2.2 2.2Z" fill="currentColor"/></svg>
+            </span>
+            <span><a href="tel:+302114044496">+30 211 404 4496</a></span>
+          </li>
+          <li class="footer-list__item">
+            <span class="footer-list__icon" aria-hidden="true">
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M6.62 10.79a15.05 15.05 0 0 0 6.59 6.59l2.2-2.2a1 1 0 0 1 1.01-.24 11.36 11.36 0 0 0 3.56.57 1 1 0 0 1 1 1v3.52a1 1 0 0 1-1 1C10.29 21.03 3 13.74 3 4.02a1 1 0 0 1 1-1h3.52a1 1 0 0 1 1 1c0 1.22.2 2.43.57 3.56a1 1 0 0 1-.25 1.01l-2.2 2.2Z" fill="currentColor"/></svg>
+            </span>
+            <span><a href="tel:+306939500950">+30 693 950 0950</a></span>
+          </li>
+          <li class="footer-list__item">
+            <span class="footer-list__icon" aria-hidden="true">
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M4 6c-1.1 0-2 .9-2 2v8c0 1.1.9 2 2 2h16a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2H4Zm0 2 8 5 8-5v-.01L12 13 4 7.99V8Z" fill="currentColor"/></svg>
+            </span>
+            <span><a href="mailto:fmren2021@gmail.com">fmren2021@gmail.com</a></span>
+          </li>
+          <li class="footer-list__item">
+            <span class="footer-list__icon" aria-hidden="true">
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M12 2a7 7 0 0 0-7 7c0 4.67 4.24 9.87 6.34 12.09a1 1 0 0 0 1.32 0C14.76 18.87 19 13.67 19 9a7 7 0 0 0-7-7Zm0 10a3 3 0 1 1 0-6 3 3 0 0 1 0 6Z" fill="currentColor"/></svg>
+            </span>
+            <span>Δοϊράνης 180, Καλλιθέα Τ.Κ. 17673</span>
+          </li>
+        </ul>
+      </div>
+      <div class="footer-brand">
+        <div class="brand brand--footer">
+          <a href="index.html" class="logo-link" aria-label="Αρχική σελίδα">
+            <img class="brand-logo" src="images/logo.webp" alt="FM Renovation Ανακαινίσεις Αθήνα" width="180" height="60">
+          </a>
+        </div>
+        <nav class="footer-links" aria-label="Χρήσιμοι σύνδεσμοι">
+          <a href="contact.html">Επικοινωνία</a>
+          <a href="terms.html">Όροι &amp; Προϋποθέσεις</a>
+          <a href="privacy-policy.html">Πολιτική Απορρήτου</a>
+          <a href="cookie-policy.html">Πολιτική Cookies</a>
+          <a href="anakainiseis-athina.html">Ανακαινίσεις Αθήνα</a>
+        </nav>
+        <p class="footer-copy">© <span id="year"></span> FM Renovation • <a href="https://anakainisou.gr/">anakainisou.gr</a></p>
+      </div>
+      <div class="footer-social">
+        <h3 class="footer-heading">Ακολουθήστε μας</h3>
+        <div class="social">
+          <a href="https://www.facebook.com/share/1CJUXM8xkk/" aria-label="Facebook" class="icon fb" target="_blank" rel="noopener noreferrer"></a>
+          <a href="https://www.instagram.com/fm.renovation21/" aria-label="Instagram" class="icon ig" target="_blank" rel="noopener noreferrer"></a>
+        </div>
+        <p class="footer-hours">Δευ–Παρ: 08:00–16:00<br>Σάβ: 09:00–15:00<br>Κυρ: Κλειστά</p>
+      </div>
+    </div>
+  </footer>
+
+  <button id="backToTop" class="back-to-top" type="button" aria-label="Επιστροφή στην αρχή" title="Προς τα πάνω">
+    <span class="back-to-top__icon" aria-hidden="true"></span>
+  </button>
+
+  <div class="contact-widget" aria-label="Γρήγορη επικοινωνία">
+    <div id="contactWidgetPanel" class="contact-widget__panel" aria-hidden="true">
+      <a class="contact-widget__link" href="mailto:fmren2021@gmail.com">
+        <span class="contact-widget__icon" aria-hidden="true">
+          <img src="images/icons/email.svg" width="36" height="36" alt="" loading="lazy">
+        </span>
+        <span>Email</span>
+      </a>
+      <a class="contact-widget__link" href="viber://chat?number=+306939500950">
+        <span class="contact-widget__icon" aria-hidden="true">
+          <img src="images/icons/viber.svg" width="36" height="36" alt="" loading="lazy">
+        </span>
+        <span>Viber</span>
+      </a>
+    </div>
+    <button class="contact-widget__toggle" type="button" aria-expanded="false" aria-controls="contactWidgetPanel" aria-label="Άνοιγμα επιλογών επικοινωνίας">
+      <svg aria-hidden="true" width="28" height="28" viewBox="0 0 24 24" fill="none">
+        <path d="M12 3C7.03 3 3 6.58 3 11c0 2.35 1.16 4.47 3 5.96V21l3.07-1.64c.96.27 1.99.42 3.08.42 4.97 0 9-3.58 9-8s-4.03-8-9-8Zm-.14 11.91h-.02c-.31 0-.6-.03-.88-.08-.76.52-1.6.95-2.49 1.26.47-.69.76-1.32.88-1.94-1.11-.74-1.81-1.82-1.81-3.05 0-2.22 2.09-4.02 4.67-4.02s4.67 1.8 4.67 4.02-2.09 4.03-4.66 4.03Z" fill="currentColor"/>
+      </svg>
+      <span class="visually-hidden">Contact</span>
+    </button>
+  </div>
+
+  <div class="cookie-banner" id="cookieBanner">
+    <div class="cookie-banner__inner">
+      <p class="cookie-banner__text">
+        Χρησιμοποιούμε cookies για να βελτιώσουμε την εμπειρία σας.
+        Συνεχίζοντας αποδέχεστε τη χρήση τους.
+        <a href="/cookie-policy.html" class="cookie-banner__link">Μάθετε περισσότερα</a>.
+      </p>
+      <div class="cookie-banner__actions">
+        <button type="button" class="cookie-banner__btn cookie-banner__btn--secondary" id="cookieReject">Μόνο τα απαραίτητα</button>
+        <button type="button" class="cookie-banner__btn cookie-banner__btn--primary" id="cookieAccept">Αποδοχή</button>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    (function(){
+      const banner=document.getElementById('cookieBanner');
+      const accept=document.getElementById('cookieAccept');
+      const reject=document.getElementById('cookieReject');
+      if(!banner||!accept||!reject) return;
+      if(!localStorage.getItem('cookieConsent')) banner.style.display='block';
+      accept.addEventListener('click',()=>{
+        localStorage.setItem('cookieConsent','accepted');
+        banner.style.display='none';
+      });
+      reject.addEventListener('click',()=>{
+        localStorage.setItem('cookieConsent','minimal');
+        banner.style.display='none';
+      });
+    })();
+  </script>
+  <script src="assets/app.js" defer></script>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Provide a dedicated, SEO-friendly contact page that reuses the existing site header, footer and styles to keep visual consistency without modifying global assets. 
- Surface clickable phone/email, a Formspree-ready contact form and an embedded responsive Google Map so visitors can easily reach FM Renovation or find the office. 
- Improve search visibility with page-level SEO (title, meta description, canonical) and add structured data for local business discovery. 

### Description
- Added a new standalone page `contact.html` that reuses the site header, mobile nav, contact widget, cookie banner and the shared stylesheet `assets/style.css`. 
- Implemented a small hero banner with dark overlay and a single `H1` ("Επικοινωνία"), a two-column contact area with left-side contact details and right-side Formspree form that posts to `https://formspree.io/f/mkgqykrp`. 
- Embedded a responsive Google Map iframe centered on `Doiranis 180, Kallithea`, added a CTA section with a `tel:` button, and ensured images use `loading="lazy"` plus width/height attributes. 
- Added SEO metadata (title, meta description, canonical, OpenGraph/Twitter) and `LocalBusiness` JSON-LD including name, address, phone, email and `areaServed`, and included an internal footer link to `contact.html` inside the new page footer without changing other pages. 

### Testing
- Parsed `contact.html` with Python's `html.parser` which completed successfully. 
- Verified presence of canonical URL, meta description, single `H1`, `LocalBusiness` JSON-LD and Google Maps iframe via quick Python content checks, all returned true. 
- Reviewed output `git diff` and performed `git commit` for `contact.html` to record the change successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bffe193df48320b06bb92b0c9e976a)