### PR TITLE
Update contact navigation links to contact page

### DIFF
--- a/anakainiseis-athina.html
+++ b/anakainiseis-athina.html
@@ -224,7 +224,7 @@
           <li class="nav__item"><a href="#" class="nav__link" data-home rel="home">Αρχική</a></li>
           <li class="nav__item"><a href="#services" class="nav__link">Υπηρεσίες</a></li>
           <li class="nav__item nav__item--projects"><a href="erga.html" class="nav__link">Έργα μας</a></li>
-          <li class="nav__item"><a href="index.html#contact" class="nav__link">Επικοινωνία</a></li>
+          <li class="nav__item"><a href="contact.html" class="nav__link">Επικοινωνία</a></li>
           <li class="nav__item nav__item--cta"><a href="index.html#contact" class="btn btn--sm nav-cta">Ζητήστε Προσφορά</a></li>
         </ul>
       </nav>
@@ -250,7 +250,7 @@
           <li class="nav-mobile__item"><a href="#" class="nav-mobile__link" data-home rel="home">Αρχική</a></li>
           <li class="nav-mobile__item"><a href="#services" class="nav-mobile__link">Υπηρεσίες</a></li>
           <li class="nav-mobile__item nav-mobile__item--projects"><a href="erga.html" class="nav-mobile__link">Έργα μας</a></li>
-          <li class="nav-mobile__item"><a href="index.html#contact" class="nav-mobile__link">Επικοινωνία</a></li>
+          <li class="nav-mobile__item"><a href="contact.html" class="nav-mobile__link">Επικοινωνία</a></li>
           <li class="nav-mobile__item nav-mobile__item--cta"><a href="index.html#contact" class="btn btn--primary nav-mobile__cta">Ζητήστε Προσφορά</a></li>
         </ul>
       </nav>

--- a/contact.html
+++ b/contact.html
@@ -223,7 +223,7 @@
           <li class="nav__item"><a href="index.html" class="nav__link" rel="home">Αρχική</a></li>
           <li class="nav__item"><a href="index.html#services" class="nav__link">Υπηρεσίες</a></li>
           <li class="nav__item nav__item--projects"><a href="erga.html" class="nav__link">Έργα μας</a></li>
-          <li class="nav__item"><a href="index.html#contact" class="nav__link">Επικοινωνία</a></li>
+          <li class="nav__item"><a href="contact.html" class="nav__link">Επικοινωνία</a></li>
           <li class="nav__item nav__item--cta"><a href="index.html#contact" class="btn btn--sm nav-cta">Ζητήστε Προσφορά</a></li>
         </ul>
       </nav>
@@ -249,7 +249,7 @@
           <li class="nav-mobile__item"><a href="index.html" class="nav-mobile__link" rel="home">Αρχική</a></li>
           <li class="nav-mobile__item"><a href="index.html#services" class="nav-mobile__link">Υπηρεσίες</a></li>
           <li class="nav-mobile__item nav-mobile__item--projects"><a href="erga.html" class="nav-mobile__link">Έργα μας</a></li>
-          <li class="nav-mobile__item"><a href="index.html#contact" class="nav-mobile__link">Επικοινωνία</a></li>
+          <li class="nav-mobile__item"><a href="contact.html" class="nav-mobile__link">Επικοινωνία</a></li>
           <li class="nav-mobile__item nav-mobile__item--cta"><a href="index.html#contact" class="btn btn--primary nav-mobile__cta">Ζητήστε Προσφορά</a></li>
         </ul>
       </nav>

--- a/cookie-policy.html
+++ b/cookie-policy.html
@@ -72,7 +72,7 @@
           <li><a class="nav-mobile__link" href="erga.html"><span>Έργα</span><span aria-hidden="true">→</span></a></li>
           <li><a class="nav-mobile__link" href="/index.html#gallery"><span>Gallery</span><span aria-hidden="true">→</span></a></li>
           <li><a class="nav-mobile__link" href="/index.html#faq"><span>FAQ</span><span aria-hidden="true">→</span></a></li>
-          <li><a class="nav-mobile__link" href="/index.html#contact"><span>Επικοινωνία</span><span aria-hidden="true">→</span></a></li>
+          <li><a class="nav-mobile__link" href="contact.html"><span>Επικοινωνία</span><span aria-hidden="true">→</span></a></li>
         </ul>
       </nav>
       <div class="nav-overlay__social">

--- a/erga.html
+++ b/erga.html
@@ -42,7 +42,7 @@
           <li class="nav__item"><a href="#" class="nav__link" data-home rel="home">Αρχική</a></li>
           <li class="nav__item"><a href="index.html#services" class="nav__link">Υπηρεσίες</a></li>
           <li class="nav__item nav__item--projects"><a href="erga.html" class="nav__link">Έργα μας</a></li>
-          <li class="nav__item"><a href="index.html#contact" class="nav__link">Επικοινωνία</a></li>
+          <li class="nav__item"><a href="contact.html" class="nav__link">Επικοινωνία</a></li>
           <li class="nav__item nav__item--cta"><a href="index.html#contact" class="btn btn--sm nav-cta">Ζητήστε Προσφορά</a></li>
         </ul>
       </nav>
@@ -68,7 +68,7 @@
           <li class="nav-mobile__item"><a href="#" class="nav-mobile__link" data-home rel="home">Αρχική</a></li>
           <li class="nav-mobile__item"><a href="index.html#services" class="nav-mobile__link">Υπηρεσίες</a></li>
           <li class="nav-mobile__item nav-mobile__item--projects"><a href="erga.html" class="nav-mobile__link">Έργα μας</a></li>
-          <li class="nav-mobile__item"><a href="index.html#contact" class="nav-mobile__link">Επικοινωνία</a></li>
+          <li class="nav-mobile__item"><a href="contact.html" class="nav-mobile__link">Επικοινωνία</a></li>
           <li class="nav-mobile__item nav-mobile__item--cta"><a href="index.html#contact" class="btn btn--primary nav-mobile__cta">Ζητήστε Προσφορά</a></li>
         </ul>
       </nav>

--- a/index.html
+++ b/index.html
@@ -103,7 +103,7 @@
           <li class="nav__item"><a href="#" class="nav__link" data-home rel="home">Αρχική</a></li>
           <li class="nav__item"><a href="#services" class="nav__link">Υπηρεσίες</a></li>
           <li class="nav__item nav__item--projects"><a href="erga.html" class="nav__link">Έργα μας</a></li>
-          <li class="nav__item"><a href="#contact" class="nav__link">Επικοινωνία</a></li>
+          <li class="nav__item"><a href="contact.html" class="nav__link">Επικοινωνία</a></li>
           <li class="nav__item nav__item--cta"><a href="#contact" class="btn btn--sm nav-cta">Ζητήστε Προσφορά</a></li>
         </ul>
       </nav>
@@ -129,7 +129,7 @@
           <li class="nav-mobile__item"><a href="#" class="nav-mobile__link" data-home rel="home">Αρχική</a></li>
           <li class="nav-mobile__item"><a href="#services" class="nav-mobile__link">Υπηρεσίες</a></li>
           <li class="nav-mobile__item nav-mobile__item--projects"><a href="erga.html" class="nav-mobile__link">Έργα μας</a></li>
-          <li class="nav-mobile__item"><a href="#contact" class="nav-mobile__link">Επικοινωνία</a></li>
+          <li class="nav-mobile__item"><a href="contact.html" class="nav-mobile__link">Επικοινωνία</a></li>
           <li class="nav-mobile__item nav-mobile__item--cta"><a href="#contact" class="btn btn--primary nav-mobile__cta">Ζητήστε Προσφορά</a></li>
         </ul>
       </nav>


### PR DESCRIPTION
### Motivation
- Η ιστοσελίδα έχει πλέον ξεχωριστή σελίδα `contact.html` και οι navigation links «Επικοινωνία» πρέπει να οδηγούν εκεί αντί για στο section της homepage για σωστή πλοήγηση και SEO.

### Description
- Αντικατέστησα μόνο τα header / desktop navigation links με label «Επικοινωνία» ώστε να δείχνουν σε `contact.html` στα αρχεία `index.html`, `erga.html`, `anakainiseis-athina.html`, `contact.html` και `cookie-policy.html`.
- Αντικατέστησα μόνο τα αντίστοιχα mobile / nav-overlay links με label «Επικοινωνία» ώστε να δείχνουν σε `contact.html` στις ίδιες σελίδες.
- Δεν έπιασα ούτε άλλαξα τα CTA κουμπιά `Ζητήστε Προσφορά`, τα footer links, form anchors ή οποιοδήποτε CSS/JS/IDs/classes/layout behavior.
- Αρχεία τροποποιημένα: `index.html`, `erga.html`, `anakainiseis-athina.html`, `contact.html`, `cookie-policy.html`.

### Testing
- Έτρεξα `rg -n '<a[^\n>]*class="(?:nav__link|nav-mobile__link)"[^\n>]*>\s*(?:<span>)?Επικοινωνία' index.html erga.html anakainiseis-athina.html contact.html cookie-policy.html` και επιβεβαίωσα ότι οι nav links δείχνουν σε `contact.html` (επιτυχία).
- Έτρεξα `rg -n 'index\.html#contact|#contact|/index\.html#contact' index.html erga.html anakainiseis-athina.html contact.html cookie-policy.html` για να επιβεβαιώσω ότι τα μη-navigation anchors (CTA / content) έμειναν ως είχαν (επιτυχία).
- Έλεγξα το diff με `git diff -- index.html erga.html anakainiseis-athina.html contact.html cookie-policy.html` και κατόπιν έκανα `git commit` με μήνυμα "Update contact nav links to contact page" (επιτυχής commit).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c009204e7483208cfcb8001d8b9772)