### PR TITLE
Increase hero carousel interval to 6 seconds

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -280,7 +280,7 @@ const y=document.getElementById('year'); if(y) y.textContent=new Date().getFullY
     imgs[i].classList.remove('active');
     i=(i+1)%imgs.length;
     imgs[i].classList.add('active');
-  },4000);
+  },6000);
 })();
 
 // Process interactive description


### PR DESCRIPTION
### Motivation
- Slow down the homepage HERO carousel from 4s to 6s so images change less frequently while keeping layout, animations and other carousels untouched.

### Description
- In `assets/app.js` inside the IIFE that targets `.hero-slider img[data-hero]` I replaced `},4000);` with `},6000);` so the hero autoplay interval is now `6000ms`, without changing HTML, CSS, classes/ids or other carousel logic.

### Testing
- Verified the change and context with `nl -ba assets/app.js | sed -n '274,284p'` and searched for other timing occurrences with `rg -n "setInterval|delay|autoplay|interval" -S assets app.js`, confirming only the hero interval was updated; no browser visual tests were run in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c00d022b28832083a291e5bdc60788)