### PR TITLE
Update HERO slider to use 4 local images with SEO alt texts

### DIFF
--- a/index.html
+++ b/index.html
@@ -153,11 +153,10 @@
     <section class="hero">
       <figure class="hero-slider" aria-label="Προβολή έργων">
         <!-- Χρησιμοποιούμε καθαρές εικόνες από Unsplash για άμεση προεπισκόπηση -->
-        <img data-hero src="https://images.unsplash.com/photo-1505691938895-1758d7feb511?q=80&w=1600&auto=format&fit=crop" width="1600" height="1067" fetchpriority="high" decoding="async" alt="Ανακαίνιση σαλονιού στην Αθήνα από FM Renovation με νέα διάταξη επίπλων και φωτισμό που αναδεικνύει τον χώρο της κατοικίας.">
-        <img data-hero src="https://images.unsplash.com/photo-1501045661006-fcebe0257c3f?q=80&w=1600&auto=format&fit=crop" width="1600" height="1067" loading="lazy" decoding="async" fetchpriority="low" alt="Ανακαίνιση κουζίνας στην Αθήνα από FM Renovation με εργονομικές λύσεις και φωτεινά υλικά για σύγχρονη καθημερινότητα.">
-        <img data-hero src="https://images.unsplash.com/photo-1505691723518-36a5ac3b2d55?q=80&w=1600&auto=format&fit=crop" width="1600" height="1067" loading="lazy" decoding="async" fetchpriority="low" alt="Ανακαίνιση επαγγελματικού χώρου στην Αττική από FM Renovation με προσεγμένο φωτισμό και καθαρές γραμμές για λειτουργική εργασία.">
-        <img data-hero src="https://images.unsplash.com/photo-1484154218962-a197022b5858?q=80&w=1600&auto=format&fit=crop" width="1600" height="1067" loading="lazy" decoding="async" fetchpriority="low" alt="Ανακαίνιση μπάνιου στην Αθήνα από FM Renovation με μινιμαλιστική αισθητική και ανθεκτικά υλικά για καθημερινή άνεση.">
-        <img data-hero src="https://images.unsplash.com/photo-1494526585095-c41746248156?q=80&w=1600&auto=format&fit=crop" width="1600" height="1067" loading="lazy" decoding="async" fetchpriority="low" alt="Ανακαίνιση υπνοδωματίου στην Αττική από FM Renovation με γήινους τόνους και φωτισμό που προσφέρει ζεστή ατμόσφαιρα χαλάρωσης.">
+        <img data-hero src="images/hero-anakainisi-athina-exoteriko.webp" width="1600" height="1067" alt="Εξωτερική ανακαίνιση κατοικίας στην Αθήνα με σύγχρονο σχεδιασμό" fetchpriority="high">
+        <img data-hero src="images/hero-anakainisi-athina-saloni.webp" width="1600" height="1067" loading="lazy" decoding="async" alt="Ανακαίνιση σαλονιού σύγχρονου διαμερίσματος στην Αθήνα">
+        <img data-hero src="images/hero-anakainisi-athina-modern-chair.webp" width="1600" height="1067" loading="lazy" decoding="async" alt="Μοντέρνα πολυθρόνα σε ανακαινισμένο διαμέρισμα στην Αθήνα">
+        <img data-hero src="images/hero-anakainisi-athina-kouzina.webp" width="1600" height="1067" loading="lazy" decoding="async" alt="Μοντέρνα ανακαίνιση κουζίνας σε διαμέρισμα στην Αθήνα">
       </figure>
       <div class="container hero-inner">
         <div class="hero-copy">


### PR DESCRIPTION
### Motivation
- Replace remote placeholder images in the HERO slider with the provided local `/images` assets to improve loading reliability and SEO.
- Ensure the page LCP behavior is preserved by keeping the first image eager and the rest lazy-loaded.

### Description
- Replaced the five existing `<img data-hero>` elements inside the `figure.hero-slider` block in `index.html` with the four specified local images in the exact order requested.
- Preserved `width` and `height` attributes and the slider structure, classes, IDs, and wrappers, and did not modify any JS or CSS behavior.
- Ensured only the first image is eager with `fetchpriority="high"` and no `loading="lazy"`, and the remaining three images use `loading="lazy"` and `decoding="async"` where applicable.
- Updated all four images with the provided SEO-friendly Greek `alt` texts.

### Testing
- Verified changes with `git diff -- index.html`, which showed the updated HERO image block and succeeded.
- Inspected the updated lines with `nl -ba index.html | sed -n '153,160p'` to confirm the new image tags and attributes and it matched the requested output.
- Committed the change with `git commit -m "Update hero slider images"`, and the commit completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c01d424b448320b37c2e64678ad4b5)