### PR TITLE
Ensure hero slider contains exactly 4 images in requested order

### DIFF
--- a/index.html
+++ b/index.html
@@ -152,11 +152,10 @@
     <!-- HERO: slider 5 εικόνες + CTA -->
     <section class="hero">
       <figure class="hero-slider" aria-label="Προβολή έργων">
-        <!-- Χρησιμοποιούμε καθαρές εικόνες από Unsplash για άμεση προεπισκόπηση -->
         <img data-hero src="images/hero-anakainisi-athina-exoteriko.webp" width="1600" height="1067" alt="Εξωτερική ανακαίνιση κατοικίας στην Αθήνα με σύγχρονο σχεδιασμό" fetchpriority="high">
         <img data-hero src="images/hero-anakainisi-athina-saloni.webp" width="1600" height="1067" loading="lazy" decoding="async" alt="Ανακαίνιση σαλονιού σύγχρονου διαμερίσματος στην Αθήνα">
-        <img data-hero src="images/hero-anakainisi-athina-modern-chair.webp" width="1600" height="1067" loading="lazy" decoding="async" alt="Μοντέρνα πολυθρόνα σε ανακαινισμένο διαμέρισμα στην Αθήνα">
         <img data-hero src="images/hero-anakainisi-athina-kouzina.webp" width="1600" height="1067" loading="lazy" decoding="async" alt="Μοντέρνα ανακαίνιση κουζίνας σε διαμέρισμα στην Αθήνα">
+        <img data-hero src="images/hero-anakainisi-athina-modern-chair.webp" width="1600" height="1067" loading="lazy" decoding="async" alt="Μοντέρνα πολυθρόνα σε ανακαινισμένο διαμέρισμα στην Αθήνα">
       </figure>
       <div class="container hero-inner">
         <div class="hero-copy">


### PR DESCRIPTION
### Motivation
- Clean up the hero slider so it contains only the four specified LCP + lazy images in the exact order required and remove any broken/extra hero slides.
- Prevent hidden/duplicate `<img data-hero>` entries that could break the slider or affect LCP and accessibility.

### Description
- Replaced the contents of the `.hero-slider` `figure` so it contains exactly the four provided `<img data-hero>` elements in this order: `images/hero-anakainisi-athina-exoteriko.webp`, `images/hero-anakainisi-athina-saloni.webp`, `images/hero-anakainisi-athina-kouzina.webp`, `images/hero-anakainisi-athina-modern-chair.webp` while preserving the surrounding `section` and `figure` structure.
- Removed an obsolete inline hero comment and any out-of-order image entries without changing CSS, JS, classes, or slider logic.
- Preserved the LCP `fetchpriority="high"` on the first image and `loading="lazy" decoding="async"` on the remaining images as requested.

### Testing
- Ran a Python validation that extracts all `src` values from `<img data-hero>` and verifies `hero_count == 4`, `unique_count == 4`, `empty_src == False`, and `order_ok == True`, and the script returned success for all checks.
- Ran `rg -c 'data-hero' index.html` and `rg -n 'data-hero' index.html` to confirm there are exactly 4 `data-hero` occurrences and their positions, both succeeded.
- Inspected the file diff to confirm only the hero block content was changed and automated checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c025243e948320ad45962d7849a9ec)