### PR TITLE
Add “Ανακαινίσεις” dropdown and mobile submenu with 4 service links

### DIFF
--- a/anakainiseis-athina.html
+++ b/anakainiseis-athina.html
@@ -222,7 +222,18 @@
       <nav id="site-nav" class="nav" aria-label="Κύρια πλοήγηση">
         <ul class="nav__list">
           <li class="nav__item"><a href="#" class="nav__link" data-home rel="home">Αρχική</a></li>
-          <li class="nav__item"><a href="#services" class="nav__link">Υπηρεσίες</a></li>
+          <li class="nav__item nav__item--has-dropdown" data-nav-dropdown>
+            <a href="anakainiseis-athina.html" class="nav__link nav__link--dropdown" aria-haspopup="true" aria-expanded="false">
+              <span>Ανακαινίσεις</span>
+              <span class="nav__chevron" aria-hidden="true"></span>
+            </a>
+            <ul class="nav-dropdown" aria-label="Υπηρεσίες ανακαίνισης">
+              <li class="nav-dropdown__item"><a href="anakainisi-spitiou-athina.html" class="nav-dropdown__link">Ολική Ανακαίνιση</a></li>
+              <li class="nav-dropdown__item"><a href="anakainisi-kouzinas-athina.html" class="nav-dropdown__link">Ανακαίνιση Κουζίνας</a></li>
+              <li class="nav-dropdown__item"><a href="anakainisi-mpaniou-athina.html" class="nav-dropdown__link">Ανακαίνιση Μπάνιου</a></li>
+              <li class="nav-dropdown__item"><a href="dapeda-plakakia-athina.html" class="nav-dropdown__link">Δάπεδα & Πλακάκια</a></li>
+            </ul>
+          </li>
           <li class="nav__item nav__item--projects"><a href="erga.html" class="nav__link">Έργα μας</a></li>
           <li class="nav__item"><a href="contact.html" class="nav__link">Επικοινωνία</a></li>
           <li class="nav__item nav__item--cta"><a href="index.html#contact" class="btn btn--sm nav-cta">Ζητήστε Προσφορά</a></li>
@@ -248,7 +259,20 @@
       <nav class="nav-mobile" aria-label="Κύρια πλοήγηση" data-mobile-nav>
         <ul class="nav-mobile__list">
           <li class="nav-mobile__item"><a href="#" class="nav-mobile__link" data-home rel="home">Αρχική</a></li>
-          <li class="nav-mobile__item"><a href="#services" class="nav-mobile__link">Υπηρεσίες</a></li>
+          <li class="nav-mobile__item nav-mobile__item--submenu" data-mobile-submenu>
+            <div class="nav-mobile__submenu-header">
+              <a href="anakainiseis-athina.html" class="nav-mobile__link nav-mobile__link--parent">Ανακαινίσεις</a>
+              <button class="nav-mobile__submenu-toggle" type="button" aria-expanded="false" aria-label="Άνοιγμα υπομενού Ανακαινίσεις" data-mobile-submenu-toggle>
+                <span class="nav-mobile__submenu-icon" aria-hidden="true"></span>
+              </button>
+            </div>
+            <ul class="nav-mobile__submenu" hidden>
+                <li class="nav-mobile__subitem"><a href="anakainisi-spitiou-athina.html" class="nav-mobile__sublink">Ολική Ανακαίνιση</a></li>
+                <li class="nav-mobile__subitem"><a href="anakainisi-kouzinas-athina.html" class="nav-mobile__sublink">Ανακαίνιση Κουζίνας</a></li>
+                <li class="nav-mobile__subitem"><a href="anakainisi-mpaniou-athina.html" class="nav-mobile__sublink">Ανακαίνιση Μπάνιου</a></li>
+                <li class="nav-mobile__subitem"><a href="dapeda-plakakia-athina.html" class="nav-mobile__sublink">Δάπεδα & Πλακάκια</a></li>
+            </ul>
+          </li>
           <li class="nav-mobile__item nav-mobile__item--projects"><a href="erga.html" class="nav-mobile__link">Έργα μας</a></li>
           <li class="nav-mobile__item"><a href="contact.html" class="nav-mobile__link">Επικοινωνία</a></li>
           <li class="nav-mobile__item nav-mobile__item--cta"><a href="index.html#contact" class="btn btn--primary nav-mobile__cta">Ζητήστε Προσφορά</a></li>

--- a/assets/app.js
+++ b/assets/app.js
@@ -41,6 +41,17 @@ const desktopMedia=window.matchMedia('(min-width: 768px)');
 const prefersReducedMotion=window.matchMedia('(prefers-reduced-motion: reduce)');
 const focusableSelectors="a[href]:not([tabindex='-1']), button:not([disabled]):not([tabindex='-1']), [tabindex]:not([tabindex='-1'])";
 let menuOpen=false;
+const desktopDropdownItems=Array.from(document.querySelectorAll('[data-nav-dropdown]'));
+const mobileSubmenuItems=Array.from(document.querySelectorAll('[data-mobile-submenu]'));
+
+function normalizeNavPath(path){
+  const normalized=(path||'/').replace(/\/+$/,'');
+  if(normalized.toLowerCase().endsWith('/index.html')){
+    return normalized.slice(0,-11).replace(/\/+$/,'')||'/';
+  }
+  return normalized||'/';
+}
+
 
 function getFocusableElements(){
   if(!navOverlay){return[];}
@@ -102,6 +113,16 @@ function closeMenu(returnFocus){
   if(navOverlay.hidden&&!menuOpen){
     return;
   }
+  mobileSubmenuItems.forEach(function(item){
+    item.classList.remove('is-open');
+    var toggle=item.querySelector('[data-mobile-submenu-toggle]');
+    var submenu=item.querySelector('.nav-mobile__submenu');
+    if(toggle){
+      toggle.setAttribute('aria-expanded','false');
+      toggle.setAttribute('aria-label','Άνοιγμα υπομενού Ανακαινίσεις');
+    }
+    if(submenu){submenu.hidden=true;}
+  });
   menuOpen=false;
   navOverlay.classList.remove('is-active');
   navBackdrop.classList.remove('is-active');
@@ -138,7 +159,7 @@ if(navToggle&&navOverlay&&navBackdrop){
   if(navClose){navClose.addEventListener('click',function(){closeMenu();});}
   navBackdrop.addEventListener('click',function(){closeMenu();});
   if(navOverlay){
-    var overlayLinks=navOverlay.querySelectorAll('a.nav-mobile__link, a.nav-mobile__cta');
+    var overlayLinks=navOverlay.querySelectorAll('a.nav-mobile__link, a.nav-mobile__sublink, a.nav-mobile__cta');
     overlayLinks.forEach(function(link){
       link.addEventListener('click',function(){closeMenu();});
     });
@@ -166,22 +187,90 @@ if(siteHeader){
   window.addEventListener('scroll',updateHeaderShadow,{passive:true});
 }
 
-// Active nav state for services
-const servicesSection=document.getElementById('services');
-const servicesNavLinks=Array.from(document.querySelectorAll('a.nav__link[href="#services"], a.nav-mobile__link[href="#services"]'));
-if('IntersectionObserver'in window&&servicesSection&&servicesNavLinks.length){
-  const toggleActive=function(isActive){
-    servicesNavLinks.forEach(function(link){
-      link.classList.toggle('nav__link--active',isActive);
-    });
+desktopDropdownItems.forEach(function(item){
+  const trigger=item.querySelector('.nav__link--dropdown');
+  if(!trigger){return;}
+
+  const setExpanded=function(isOpen){
+    item.classList.toggle('is-open',isOpen);
+    trigger.setAttribute('aria-expanded',String(isOpen));
   };
-  const observer=new IntersectionObserver(function(entries){
-    entries.forEach(function(entry){
-      toggleActive(entry.isIntersecting&&entry.intersectionRatio>=0.4);
-    });
-  },{threshold:0.4});
-  observer.observe(servicesSection);
-}
+
+  item.addEventListener('mouseenter',function(){
+    if(desktopMedia.matches){setExpanded(true);}
+  });
+  item.addEventListener('mouseleave',function(){
+    if(desktopMedia.matches){setExpanded(false);}
+  });
+  item.addEventListener('focusin',function(){
+    if(desktopMedia.matches){setExpanded(true);}
+  });
+  item.addEventListener('focusout',function(event){
+    if(desktopMedia.matches&&!item.contains(event.relatedTarget)){setExpanded(false);}
+  });
+  trigger.addEventListener('click',function(event){
+    if(!desktopMedia.matches){return;}
+    const isOpen=item.classList.contains('is-open');
+    if(!isOpen){
+      event.preventDefault();
+      desktopDropdownItems.forEach(function(other){
+        if(other!==item){
+          other.classList.remove('is-open');
+          const otherTrigger=other.querySelector('.nav__link--dropdown');
+          if(otherTrigger){otherTrigger.setAttribute('aria-expanded','false');}
+        }
+      });
+    }
+    setExpanded(!isOpen);
+  });
+});
+
+document.addEventListener('click',function(event){
+  desktopDropdownItems.forEach(function(item){
+    if(item.contains(event.target)){return;}
+    item.classList.remove('is-open');
+    const trigger=item.querySelector('.nav__link--dropdown');
+    if(trigger){trigger.setAttribute('aria-expanded','false');}
+  });
+});
+
+document.addEventListener('keydown',function(event){
+  if(event.key!=='Escape'){return;}
+  desktopDropdownItems.forEach(function(item){
+    item.classList.remove('is-open');
+    const trigger=item.querySelector('.nav__link--dropdown');
+    if(trigger){trigger.setAttribute('aria-expanded','false');}
+  });
+});
+
+mobileSubmenuItems.forEach(function(item){
+  const toggle=item.querySelector('[data-mobile-submenu-toggle]');
+  const submenu=item.querySelector('.nav-mobile__submenu');
+  if(!toggle||!submenu){return;}
+  toggle.addEventListener('click',function(){
+    const isOpen=item.classList.toggle('is-open');
+    toggle.setAttribute('aria-expanded',String(isOpen));
+    toggle.setAttribute('aria-label',isOpen?'Κλείσιμο υπομενού Ανακαινίσεις':'Άνοιγμα υπομενού Ανακαινίσεις');
+    submenu.hidden=!isOpen;
+  });
+});
+
+const currentPath=normalizeNavPath(location.pathname||'/');
+document.querySelectorAll('.nav__link[href], .nav-dropdown__link[href], .nav-mobile__link[href], .nav-mobile__sublink[href]').forEach(function(link){
+  const href=link.getAttribute('href');
+  if(!href||href.charAt(0)==='#'||href.startsWith('mailto:')||href.startsWith('tel:')||href.startsWith('viber:')){return;}
+  const linkUrl=new URL(href,location.href);
+  if(normalizeNavPath(linkUrl.pathname)===currentPath){
+    link.classList.add('nav__link--active');
+    link.setAttribute('aria-current','page');
+    const dropdownItem=link.closest('[data-nav-dropdown]');
+    const desktopTrigger=dropdownItem?dropdownItem.querySelector('.nav__link--dropdown'):null;
+    if(desktopTrigger){desktopTrigger.classList.add('nav__link--active');}
+    const mobileItem=link.closest('[data-mobile-submenu]');
+    const mobileParent=mobileItem?mobileItem.querySelector('.nav-mobile__link--parent'):null;
+    if(mobileParent){mobileParent.classList.add('nav-mobile__link--active');}
+  }
+});
 
 // Accordion toggle + aria
 document.querySelectorAll('.service-card .service-header').forEach(btn=>{

--- a/assets/style.css
+++ b/assets/style.css
@@ -43,6 +43,19 @@ img{max-width:100%;height:auto;display:block}
 .nav__link{display:inline-flex;align-items:center;gap:6px;text-decoration:none;font-weight:500;color:var(--text);opacity:.88;transition:color .2s ease,opacity .2s ease}
 .nav__link:hover,
 .nav__link:focus-visible{opacity:1;color:var(--accent);outline:none}
+.nav__item--has-dropdown{position:relative}
+.nav__link--dropdown{gap:8px}
+.nav__chevron{display:inline-flex;width:8px;height:8px;border-right:1.5px solid currentColor;border-bottom:1.5px solid currentColor;transform:translateY(-1px) rotate(45deg);transition:transform .2s ease}
+.nav-dropdown{position:absolute;top:calc(100% + 14px);left:50%;min-width:240px;margin:0;padding:10px 0;list-style:none;background:rgba(255,255,255,.98);border:1px solid rgba(15,23,42,.08);border-radius:18px;box-shadow:0 18px 36px rgba(15,23,42,.12);opacity:0;visibility:hidden;pointer-events:none;transform:translate(-50%,8px);transition:opacity .2s ease,transform .2s ease,visibility .2s ease;z-index:120}
+.nav-dropdown::before{content:"";position:absolute;left:0;right:0;top:-14px;height:14px}
+.nav-dropdown__link{display:block;padding:11px 18px;color:var(--text);text-decoration:none;font-weight:500;white-space:nowrap;transition:background .2s ease,color .2s ease}
+.nav-dropdown__link:hover,.nav-dropdown__link:focus-visible{background:rgba(245,158,11,.08);color:var(--accent);outline:none}
+.nav__item--has-dropdown:hover .nav-dropdown,
+.nav__item--has-dropdown:focus-within .nav-dropdown,
+.nav__item--has-dropdown.is-open .nav-dropdown{opacity:1;visibility:visible;pointer-events:auto;transform:translate(-50%,0)}
+.nav__item--has-dropdown:hover .nav__chevron,
+.nav__item--has-dropdown:focus-within .nav__chevron,
+.nav__item--has-dropdown.is-open .nav__chevron{transform:translateY(1px) rotate(225deg)}
 .nav__item--cta{margin-left:6px}
 .nav__item--cta .btn{border-width:2px;border-color:var(--accent);color:#0F172A}
 .nav__item--cta .btn:hover,
@@ -86,6 +99,18 @@ img{max-width:100%;height:auto;display:block}
 .nav-mobile__link{width:100%;display:flex;align-items:center;justify-content:space-between;gap:12px;padding:14px 0;font-size:1.08rem;font-weight:600;text-decoration:none;color:var(--text);background:none;border:none;cursor:pointer}
 .nav-mobile__link:hover,
 .nav-mobile__link:focus-visible{color:var(--accent);outline:none}
+.nav-mobile__item--submenu{padding-bottom:6px}
+.nav-mobile__submenu-header{display:flex;align-items:center;gap:12px}
+.nav-mobile__link--parent{flex:1 1 auto;padding-right:0}
+.nav-mobile__submenu-toggle{flex:0 0 auto;display:inline-flex;align-items:center;justify-content:center;width:42px;height:42px;margin-right:-2px;border:1px solid transparent;border-radius:12px;background:none;color:var(--text);cursor:pointer;transition:background .2s ease,border-color .2s ease,color .2s ease}
+.nav-mobile__submenu-toggle:hover,.nav-mobile__submenu-toggle:focus-visible{background:rgba(245,158,11,.08);border-color:rgba(245,158,11,.18);color:var(--accent);outline:none}
+.nav-mobile__submenu-icon{display:inline-flex;width:10px;height:10px;border-right:1.5px solid currentColor;border-bottom:1.5px solid currentColor;transform:rotate(45deg);transition:transform .2s ease}
+.nav-mobile__item--submenu.is-open .nav-mobile__submenu-icon{transform:rotate(225deg)}
+.nav-mobile__submenu{list-style:none;margin:0;padding:0 0 6px 16px;display:grid;gap:2px}
+.nav-mobile__subitem{border-top:1px solid rgba(15,23,42,.06)}
+.nav-mobile__subitem:first-child{border-top:none}
+.nav-mobile__sublink{display:block;padding:12px 0;color:#475569;text-decoration:none;font-weight:500;transition:color .2s ease,transform .2s ease}
+.nav-mobile__sublink:hover,.nav-mobile__sublink:focus-visible{color:var(--accent);outline:none;transform:translateX(2px)}
 .nav-mobile__item--cta{border:none;padding-top:12px}
 .nav-mobile__cta{width:100%;justify-content:center;font-weight:700}
 .nav-overlay__social{margin-top:auto;display:flex;gap:16px;padding-top:20px;border-top:1px solid #e8edf4}
@@ -293,6 +318,7 @@ body.nav-open{overflow:hidden}
   .header-inner{flex-wrap:nowrap}
   .nav{display:block}
   .nav__list{gap:22px}
+  .nav-mobile__item--submenu{padding-bottom:0}
   .nav-toggle{display:none}
   .nav-backdrop,.nav-overlay{display:none !important}
   .cta-group{width:auto}

--- a/contact.html
+++ b/contact.html
@@ -224,7 +224,18 @@
       <nav id="site-nav" class="nav" aria-label="Κύρια πλοήγηση">
         <ul class="nav__list">
           <li class="nav__item"><a href="index.html" class="nav__link" rel="home">Αρχική</a></li>
-          <li class="nav__item"><a href="index.html#services" class="nav__link">Υπηρεσίες</a></li>
+          <li class="nav__item nav__item--has-dropdown" data-nav-dropdown>
+            <a href="anakainiseis-athina.html" class="nav__link nav__link--dropdown" aria-haspopup="true" aria-expanded="false">
+              <span>Ανακαινίσεις</span>
+              <span class="nav__chevron" aria-hidden="true"></span>
+            </a>
+            <ul class="nav-dropdown" aria-label="Υπηρεσίες ανακαίνισης">
+              <li class="nav-dropdown__item"><a href="anakainisi-spitiou-athina.html" class="nav-dropdown__link">Ολική Ανακαίνιση</a></li>
+              <li class="nav-dropdown__item"><a href="anakainisi-kouzinas-athina.html" class="nav-dropdown__link">Ανακαίνιση Κουζίνας</a></li>
+              <li class="nav-dropdown__item"><a href="anakainisi-mpaniou-athina.html" class="nav-dropdown__link">Ανακαίνιση Μπάνιου</a></li>
+              <li class="nav-dropdown__item"><a href="dapeda-plakakia-athina.html" class="nav-dropdown__link">Δάπεδα & Πλακάκια</a></li>
+            </ul>
+          </li>
           <li class="nav__item nav__item--projects"><a href="erga.html" class="nav__link">Έργα μας</a></li>
           <li class="nav__item"><a href="contact.html" class="nav__link">Επικοινωνία</a></li>
           <li class="nav__item nav__item--cta"><a href="index.html#contact" class="btn btn--sm nav-cta">Ζητήστε Προσφορά</a></li>
@@ -250,7 +261,20 @@
       <nav class="nav-mobile" aria-label="Κύρια πλοήγηση" data-mobile-nav>
         <ul class="nav-mobile__list">
           <li class="nav-mobile__item"><a href="index.html" class="nav-mobile__link" rel="home">Αρχική</a></li>
-          <li class="nav-mobile__item"><a href="index.html#services" class="nav-mobile__link">Υπηρεσίες</a></li>
+          <li class="nav-mobile__item nav-mobile__item--submenu" data-mobile-submenu>
+            <div class="nav-mobile__submenu-header">
+              <a href="anakainiseis-athina.html" class="nav-mobile__link nav-mobile__link--parent">Ανακαινίσεις</a>
+              <button class="nav-mobile__submenu-toggle" type="button" aria-expanded="false" aria-label="Άνοιγμα υπομενού Ανακαινίσεις" data-mobile-submenu-toggle>
+                <span class="nav-mobile__submenu-icon" aria-hidden="true"></span>
+              </button>
+            </div>
+            <ul class="nav-mobile__submenu" hidden>
+                <li class="nav-mobile__subitem"><a href="anakainisi-spitiou-athina.html" class="nav-mobile__sublink">Ολική Ανακαίνιση</a></li>
+                <li class="nav-mobile__subitem"><a href="anakainisi-kouzinas-athina.html" class="nav-mobile__sublink">Ανακαίνιση Κουζίνας</a></li>
+                <li class="nav-mobile__subitem"><a href="anakainisi-mpaniou-athina.html" class="nav-mobile__sublink">Ανακαίνιση Μπάνιου</a></li>
+                <li class="nav-mobile__subitem"><a href="dapeda-plakakia-athina.html" class="nav-mobile__sublink">Δάπεδα & Πλακάκια</a></li>
+            </ul>
+          </li>
           <li class="nav-mobile__item nav-mobile__item--projects"><a href="erga.html" class="nav-mobile__link">Έργα μας</a></li>
           <li class="nav-mobile__item"><a href="contact.html" class="nav-mobile__link">Επικοινωνία</a></li>
           <li class="nav-mobile__item nav-mobile__item--cta"><a href="index.html#contact" class="btn btn--primary nav-mobile__cta">Ζητήστε Προσφορά</a></li>

--- a/cookie-policy.html
+++ b/cookie-policy.html
@@ -68,7 +68,20 @@
           <li><a class="nav-mobile__link" href="/index.html#hero"><span>Αρχική</span><span aria-hidden="true">→</span></a></li>
           <li><a class="nav-mobile__link" href="/index.html#about"><span>Σχετικά</span><span aria-hidden="true">→</span></a></li>
           <li><a class="nav-mobile__link" href="/index.html#process"><span>Πώς Λειτουργούμε</span><span aria-hidden="true">→</span></a></li>
-          <li><a class="nav-mobile__link" href="/index.html#services"><span>Υπηρεσίες</span><span aria-hidden="true">→</span></a></li>
+          <li class="nav-mobile__item nav-mobile__item--submenu" data-mobile-submenu>
+            <div class="nav-mobile__submenu-header">
+              <a href="anakainiseis-athina.html" class="nav-mobile__link nav-mobile__link--parent">Ανακαινίσεις</a>
+              <button class="nav-mobile__submenu-toggle" type="button" aria-expanded="false" aria-label="Άνοιγμα υπομενού Ανακαινίσεις" data-mobile-submenu-toggle>
+                <span class="nav-mobile__submenu-icon" aria-hidden="true"></span>
+              </button>
+            </div>
+            <ul class="nav-mobile__submenu" hidden>
+              <li class="nav-mobile__subitem"><a href="anakainisi-spitiou-athina.html" class="nav-mobile__sublink">Ολική Ανακαίνιση</a></li>
+              <li class="nav-mobile__subitem"><a href="anakainisi-kouzinas-athina.html" class="nav-mobile__sublink">Ανακαίνιση Κουζίνας</a></li>
+              <li class="nav-mobile__subitem"><a href="anakainisi-mpaniou-athina.html" class="nav-mobile__sublink">Ανακαίνιση Μπάνιου</a></li>
+              <li class="nav-mobile__subitem"><a href="dapeda-plakakia-athina.html" class="nav-mobile__sublink">Δάπεδα & Πλακάκια</a></li>
+            </ul>
+          </li>
           <li><a class="nav-mobile__link" href="erga.html"><span>Έργα</span><span aria-hidden="true">→</span></a></li>
           <li><a class="nav-mobile__link" href="/index.html#gallery"><span>Gallery</span><span aria-hidden="true">→</span></a></li>
           <li><a class="nav-mobile__link" href="/index.html#faq"><span>FAQ</span><span aria-hidden="true">→</span></a></li>

--- a/erga.html
+++ b/erga.html
@@ -43,7 +43,18 @@
       <nav id="site-nav" class="nav" aria-label="Κύρια πλοήγηση">
         <ul class="nav__list">
           <li class="nav__item"><a href="#" class="nav__link" data-home rel="home">Αρχική</a></li>
-          <li class="nav__item"><a href="index.html#services" class="nav__link">Υπηρεσίες</a></li>
+          <li class="nav__item nav__item--has-dropdown" data-nav-dropdown>
+            <a href="anakainiseis-athina.html" class="nav__link nav__link--dropdown" aria-haspopup="true" aria-expanded="false">
+              <span>Ανακαινίσεις</span>
+              <span class="nav__chevron" aria-hidden="true"></span>
+            </a>
+            <ul class="nav-dropdown" aria-label="Υπηρεσίες ανακαίνισης">
+              <li class="nav-dropdown__item"><a href="anakainisi-spitiou-athina.html" class="nav-dropdown__link">Ολική Ανακαίνιση</a></li>
+              <li class="nav-dropdown__item"><a href="anakainisi-kouzinas-athina.html" class="nav-dropdown__link">Ανακαίνιση Κουζίνας</a></li>
+              <li class="nav-dropdown__item"><a href="anakainisi-mpaniou-athina.html" class="nav-dropdown__link">Ανακαίνιση Μπάνιου</a></li>
+              <li class="nav-dropdown__item"><a href="dapeda-plakakia-athina.html" class="nav-dropdown__link">Δάπεδα & Πλακάκια</a></li>
+            </ul>
+          </li>
           <li class="nav__item nav__item--projects"><a href="erga.html" class="nav__link">Έργα μας</a></li>
           <li class="nav__item"><a href="contact.html" class="nav__link">Επικοινωνία</a></li>
           <li class="nav__item nav__item--cta"><a href="index.html#contact" class="btn btn--sm nav-cta">Ζητήστε Προσφορά</a></li>
@@ -69,7 +80,20 @@
       <nav class="nav-mobile" aria-label="Κύρια πλοήγηση" data-mobile-nav>
         <ul class="nav-mobile__list">
           <li class="nav-mobile__item"><a href="#" class="nav-mobile__link" data-home rel="home">Αρχική</a></li>
-          <li class="nav-mobile__item"><a href="index.html#services" class="nav-mobile__link">Υπηρεσίες</a></li>
+          <li class="nav-mobile__item nav-mobile__item--submenu" data-mobile-submenu>
+            <div class="nav-mobile__submenu-header">
+              <a href="anakainiseis-athina.html" class="nav-mobile__link nav-mobile__link--parent">Ανακαινίσεις</a>
+              <button class="nav-mobile__submenu-toggle" type="button" aria-expanded="false" aria-label="Άνοιγμα υπομενού Ανακαινίσεις" data-mobile-submenu-toggle>
+                <span class="nav-mobile__submenu-icon" aria-hidden="true"></span>
+              </button>
+            </div>
+            <ul class="nav-mobile__submenu" hidden>
+                <li class="nav-mobile__subitem"><a href="anakainisi-spitiou-athina.html" class="nav-mobile__sublink">Ολική Ανακαίνιση</a></li>
+                <li class="nav-mobile__subitem"><a href="anakainisi-kouzinas-athina.html" class="nav-mobile__sublink">Ανακαίνιση Κουζίνας</a></li>
+                <li class="nav-mobile__subitem"><a href="anakainisi-mpaniou-athina.html" class="nav-mobile__sublink">Ανακαίνιση Μπάνιου</a></li>
+                <li class="nav-mobile__subitem"><a href="dapeda-plakakia-athina.html" class="nav-mobile__sublink">Δάπεδα & Πλακάκια</a></li>
+            </ul>
+          </li>
           <li class="nav-mobile__item nav-mobile__item--projects"><a href="erga.html" class="nav-mobile__link">Έργα μας</a></li>
           <li class="nav-mobile__item"><a href="contact.html" class="nav-mobile__link">Επικοινωνία</a></li>
           <li class="nav-mobile__item nav-mobile__item--cta"><a href="index.html#contact" class="btn btn--primary nav-mobile__cta">Ζητήστε Προσφορά</a></li>

--- a/index.html
+++ b/index.html
@@ -106,7 +106,18 @@
       <nav id="site-nav" class="nav" aria-label="Κύρια πλοήγηση">
         <ul class="nav__list">
           <li class="nav__item"><a href="#" class="nav__link" data-home rel="home">Αρχική</a></li>
-          <li class="nav__item"><a href="#services" class="nav__link">Υπηρεσίες</a></li>
+          <li class="nav__item nav__item--has-dropdown" data-nav-dropdown>
+            <a href="anakainiseis-athina.html" class="nav__link nav__link--dropdown" aria-haspopup="true" aria-expanded="false">
+              <span>Ανακαινίσεις</span>
+              <span class="nav__chevron" aria-hidden="true"></span>
+            </a>
+            <ul class="nav-dropdown" aria-label="Υπηρεσίες ανακαίνισης">
+              <li class="nav-dropdown__item"><a href="anakainisi-spitiou-athina.html" class="nav-dropdown__link">Ολική Ανακαίνιση</a></li>
+              <li class="nav-dropdown__item"><a href="anakainisi-kouzinas-athina.html" class="nav-dropdown__link">Ανακαίνιση Κουζίνας</a></li>
+              <li class="nav-dropdown__item"><a href="anakainisi-mpaniou-athina.html" class="nav-dropdown__link">Ανακαίνιση Μπάνιου</a></li>
+              <li class="nav-dropdown__item"><a href="dapeda-plakakia-athina.html" class="nav-dropdown__link">Δάπεδα & Πλακάκια</a></li>
+            </ul>
+          </li>
           <li class="nav__item nav__item--projects"><a href="erga.html" class="nav__link">Έργα μας</a></li>
           <li class="nav__item"><a href="contact.html" class="nav__link">Επικοινωνία</a></li>
           <li class="nav__item nav__item--cta"><a href="#contact" class="btn btn--sm nav-cta">Ζητήστε Προσφορά</a></li>
@@ -132,7 +143,20 @@
       <nav class="nav-mobile" aria-label="Κύρια πλοήγηση" data-mobile-nav>
         <ul class="nav-mobile__list">
           <li class="nav-mobile__item"><a href="#" class="nav-mobile__link" data-home rel="home">Αρχική</a></li>
-          <li class="nav-mobile__item"><a href="#services" class="nav-mobile__link">Υπηρεσίες</a></li>
+          <li class="nav-mobile__item nav-mobile__item--submenu" data-mobile-submenu>
+            <div class="nav-mobile__submenu-header">
+              <a href="anakainiseis-athina.html" class="nav-mobile__link nav-mobile__link--parent">Ανακαινίσεις</a>
+              <button class="nav-mobile__submenu-toggle" type="button" aria-expanded="false" aria-label="Άνοιγμα υπομενού Ανακαινίσεις" data-mobile-submenu-toggle>
+                <span class="nav-mobile__submenu-icon" aria-hidden="true"></span>
+              </button>
+            </div>
+            <ul class="nav-mobile__submenu" hidden>
+                <li class="nav-mobile__subitem"><a href="anakainisi-spitiou-athina.html" class="nav-mobile__sublink">Ολική Ανακαίνιση</a></li>
+                <li class="nav-mobile__subitem"><a href="anakainisi-kouzinas-athina.html" class="nav-mobile__sublink">Ανακαίνιση Κουζίνας</a></li>
+                <li class="nav-mobile__subitem"><a href="anakainisi-mpaniou-athina.html" class="nav-mobile__sublink">Ανακαίνιση Μπάνιου</a></li>
+                <li class="nav-mobile__subitem"><a href="dapeda-plakakia-athina.html" class="nav-mobile__sublink">Δάπεδα & Πλακάκια</a></li>
+            </ul>
+          </li>
           <li class="nav-mobile__item nav-mobile__item--projects"><a href="erga.html" class="nav-mobile__link">Έργα μας</a></li>
           <li class="nav-mobile__item"><a href="contact.html" class="nav-mobile__link">Επικοινωνία</a></li>
           <li class="nav-mobile__item nav-mobile__item--cta"><a href="#contact" class="btn btn--primary nav-mobile__cta">Ζητήστε Προσφορά</a></li>


### PR DESCRIPTION
### Motivation
- Replace the single "Υπηρεσίες" nav item with a clear parent item "Ανακαινίσεις" that exposes the four focused services in a minimal, SEO-friendly submenu so the site navigation maps to the new service architecture. 
- Keep the existing header layout, spacing, CTA and mobile overlay behavior unchanged while providing a premium, touch-friendly submenu experience. 
- Implement the change with minimal, scoped CSS/JS and preserve accessibility (`aria-expanded`, keyboard/escape behavior) and normal `<a href>` links (no JS-only navigation). 

### Description
- Updated shared header markup across `index.html`, `erga.html`, `anakainiseis-athina.html`, `contact.html` and the mobile overlay in `cookie-policy.html` to replace the old `Υπηρεσίες` item with a parent `Ανακαινίσεις` link and the following nested links: `Ολική Ανακαίνιση` → `anakainisi-spitiou-athina.html`, `Ανακαίνιση Κουζίνας` → `anakainisi-kouzinas-athina.html`, `Ανακαίνιση Μπάνιου` → `anakainisi-mpaniou-athina.html`, `Δάπεδα & Πλακάκια` → `dapeda-plakakia-athina.html`. 
- Added scoped desktop dropdown styles and a small mobile-submenu block to `assets/style.css` that position the dropdown below the parent, preserve header spacing/CTA styling, and provide subtle, clean hover/focus states consistent with the existing visual language. 
- Extended `assets/app.js` to handle desktop dropdown hover/focus and click-to-toggle behavior, outside-click and `Escape` to close, mobile submenu toggles with `aria-expanded` updates, reset of mobile submenu state when the overlay closes, and active-link detection for the new links; the JS is conservative and only targets the new menu structure. 
- Did not create the 4 service pages; only the navigation links were added so the menu architecture is ready for those pages. 

### Testing
- Ran `node --check assets/app.js` to validate the modified script and it succeeded. 
- Executed a small Python validation script that checked each modified HTML file contains the new labels and target hrefs and it reported success for `index.html`, `erga.html`, `anakainiseis-athina.html`, `contact.html` and `cookie-policy.html`. 
- Ran `git diff --check` (linter-style whitespace check) and there were no problems. 
- Note: visual/browser screenshot testing was not available in the environment, so visual QA should be verified in a browser as a final step.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c01fa923308320a06f1cdd9e408c76)