### PR TITLE
Fix third hero image path

### DIFF
--- a/index.html
+++ b/index.html
@@ -178,7 +178,7 @@
       <figure class="hero-slider" aria-label="Προβολή έργων">
         <img data-hero src="images/hero-anakainisi-athina-exoteriko.webp" width="1600" height="1067" alt="Εξωτερική ανακαίνιση κατοικίας στην Αθήνα με σύγχρονο σχεδιασμό" fetchpriority="high">
         <img data-hero src="images/hero-anakainisi-athina-saloni.webp" width="1600" height="1067" loading="lazy" decoding="async" alt="Ανακαίνιση σαλονιού σύγχρονου διαμερίσματος στην Αθήνα">
-        <img data-hero src="images/hero-anakainisi-athina-kouzina.webp" width="1600" height="1067" loading="lazy" decoding="async" alt="Μοντέρνα ανακαίνιση κουζίνας σε διαμέρισμα στην Αθήνα">
+        <img data-hero src="images/hero-anakainisi-kouzinas-athina.webp" width="1600" height="1067" loading="lazy" decoding="async" alt="Μοντέρνα ανακαίνιση κουζίνας σε διαμέρισμα στην Αθήνα">
         <img data-hero src="images/hero-anakainisi-athina-modern-chair.webp" width="1600" height="1067" loading="lazy" decoding="async" alt="Μοντέρνα πολυθρόνα σε ανακαινισμένο διαμέρισμα στην Αθήνα">
       </figure>
       <div class="container hero-inner">


### PR DESCRIPTION
### Motivation
- Η τρίτη εικόνα του hero έδειχνε σε λάθος filename και επέστρεφε 404, οπότε πρέπει να διορθωθεί το `src` ώστε να ταιριάζει με το υπάρχον αρχείο `images/hero-anakainisi-kouzinas-athina.webp`.

### Description
- Αντικατέστησα μόνο το `src` της τρίτης εικόνας μέσα στο `.hero-slider` στο `index.html` από `images/hero-anakainisi-athina-kouzina.webp` σε `images/hero-anakainisi-kouzinas-athina.webp`, χωρίς να αλλάξω άλλα attributes, τη σειρά των εικόνων, ή οποιοδήποτε CSS/JS.

### Testing
- Εκτέλεσα `git diff -- index.html`, `test -f images/hero-anakainisi-kouzinas-athina.webp`, έλεγχο πλήθους `hero_count` μέσω `sed`/`rg`, και το `git commit`, και όλα τα αυτοματοποιημένα checks ολοκληρώθηκαν επιτυχώς.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c02ab3839c8320a558f17a87495027)