### PR TITLE
Make "Ανακαινίσεις" a non-link dropdown and point submenu items to `#services`

### DIFF
--- a/anakainiseis-athina.html
+++ b/anakainiseis-athina.html
@@ -223,15 +223,15 @@
         <ul class="nav__list">
           <li class="nav__item"><a href="#" class="nav__link" data-home rel="home">Αρχική</a></li>
           <li class="nav__item nav__item--has-dropdown" data-nav-dropdown>
-            <a href="anakainiseis-athina.html" class="nav__link nav__link--dropdown" aria-haspopup="true" aria-expanded="false">
+            <button type="button" class="nav__link nav__link--dropdown" aria-haspopup="true" aria-expanded="false">
               <span>Ανακαινίσεις</span>
               <span class="nav__chevron" aria-hidden="true"></span>
-            </a>
+            </button>
             <ul class="nav-dropdown" aria-label="Υπηρεσίες ανακαίνισης">
-              <li class="nav-dropdown__item"><a href="anakainisi-spitiou-athina.html" class="nav-dropdown__link">Ολική Ανακαίνιση</a></li>
-              <li class="nav-dropdown__item"><a href="anakainisi-kouzinas-athina.html" class="nav-dropdown__link">Ανακαίνιση Κουζίνας</a></li>
-              <li class="nav-dropdown__item"><a href="anakainisi-mpaniou-athina.html" class="nav-dropdown__link">Ανακαίνιση Μπάνιου</a></li>
-              <li class="nav-dropdown__item"><a href="dapeda-plakakia-athina.html" class="nav-dropdown__link">Δάπεδα & Πλακάκια</a></li>
+              <li class="nav-dropdown__item"><a href="index.html#services" class="nav-dropdown__link">Ολική Ανακαίνιση</a></li>
+              <li class="nav-dropdown__item"><a href="index.html#services" class="nav-dropdown__link">Ανακαίνιση Κουζίνας</a></li>
+              <li class="nav-dropdown__item"><a href="index.html#services" class="nav-dropdown__link">Ανακαίνιση Μπάνιου</a></li>
+              <li class="nav-dropdown__item"><a href="index.html#services" class="nav-dropdown__link">Δάπεδα & Πλακάκια</a></li>
             </ul>
           </li>
           <li class="nav__item nav__item--projects"><a href="erga.html" class="nav__link">Έργα μας</a></li>
@@ -261,16 +261,16 @@
           <li class="nav-mobile__item"><a href="#" class="nav-mobile__link" data-home rel="home">Αρχική</a></li>
           <li class="nav-mobile__item nav-mobile__item--submenu" data-mobile-submenu>
             <div class="nav-mobile__submenu-header">
-              <a href="anakainiseis-athina.html" class="nav-mobile__link nav-mobile__link--parent">Ανακαινίσεις</a>
-              <button class="nav-mobile__submenu-toggle" type="button" aria-expanded="false" aria-label="Άνοιγμα υπομενού Ανακαινίσεις" data-mobile-submenu-toggle>
+              <button class="nav-mobile__link nav-mobile__link--parent nav-mobile__submenu-trigger" type="button" aria-expanded="false" aria-haspopup="true" aria-label="Άνοιγμα υπομενού Ανακαινίσεις" data-mobile-submenu-toggle>
+                <span>Ανακαινίσεις</span>
                 <span class="nav-mobile__submenu-icon" aria-hidden="true"></span>
               </button>
             </div>
             <ul class="nav-mobile__submenu" hidden>
-                <li class="nav-mobile__subitem"><a href="anakainisi-spitiou-athina.html" class="nav-mobile__sublink">Ολική Ανακαίνιση</a></li>
-                <li class="nav-mobile__subitem"><a href="anakainisi-kouzinas-athina.html" class="nav-mobile__sublink">Ανακαίνιση Κουζίνας</a></li>
-                <li class="nav-mobile__subitem"><a href="anakainisi-mpaniou-athina.html" class="nav-mobile__sublink">Ανακαίνιση Μπάνιου</a></li>
-                <li class="nav-mobile__subitem"><a href="dapeda-plakakia-athina.html" class="nav-mobile__sublink">Δάπεδα & Πλακάκια</a></li>
+                <li class="nav-mobile__subitem"><a href="index.html#services" class="nav-mobile__sublink">Ολική Ανακαίνιση</a></li>
+                <li class="nav-mobile__subitem"><a href="index.html#services" class="nav-mobile__sublink">Ανακαίνιση Κουζίνας</a></li>
+                <li class="nav-mobile__subitem"><a href="index.html#services" class="nav-mobile__sublink">Ανακαίνιση Μπάνιου</a></li>
+                <li class="nav-mobile__subitem"><a href="index.html#services" class="nav-mobile__sublink">Δάπεδα & Πλακάκια</a></li>
             </ul>
           </li>
           <li class="nav-mobile__item nav-mobile__item--projects"><a href="erga.html" class="nav-mobile__link">Έργα μας</a></li>

--- a/assets/app.js
+++ b/assets/app.js
@@ -209,10 +209,10 @@ desktopDropdownItems.forEach(function(item){
     if(desktopMedia.matches&&!item.contains(event.relatedTarget)){setExpanded(false);}
   });
   trigger.addEventListener('click',function(event){
-    if(!desktopMedia.matches){return;}
     const isOpen=item.classList.contains('is-open');
+    event.preventDefault();
+    if(!desktopMedia.matches){return;}
     if(!isOpen){
-      event.preventDefault();
       desktopDropdownItems.forEach(function(other){
         if(other!==item){
           other.classList.remove('is-open');
@@ -247,7 +247,8 @@ mobileSubmenuItems.forEach(function(item){
   const toggle=item.querySelector('[data-mobile-submenu-toggle]');
   const submenu=item.querySelector('.nav-mobile__submenu');
   if(!toggle||!submenu){return;}
-  toggle.addEventListener('click',function(){
+  toggle.addEventListener('click',function(event){
+    event.preventDefault();
     const isOpen=item.classList.toggle('is-open');
     toggle.setAttribute('aria-expanded',String(isOpen));
     toggle.setAttribute('aria-label',isOpen?'Κλείσιμο υπομενού Ανακαινίσεις':'Άνοιγμα υπομενού Ανακαινίσεις');

--- a/assets/style.css
+++ b/assets/style.css
@@ -40,14 +40,14 @@ img{max-width:100%;height:auto;display:block}
 .nav-toggle.is-active .nav-toggle-bar:nth-child(3){transform:translateY(-7px) rotate(-45deg)}
 .nav{display:none;margin-left:auto}
 .nav__list{list-style:none;display:flex;align-items:center;gap:18px;margin:0;padding:0}
-.nav__link{display:inline-flex;align-items:center;gap:6px;text-decoration:none;font-weight:500;color:var(--text);opacity:.88;transition:color .2s ease,opacity .2s ease}
+.nav__link{display:inline-flex;align-items:center;gap:6px;padding:0;border:0;background:none;text-decoration:none;font:inherit;font-weight:500;color:var(--text);opacity:.88;cursor:pointer;transition:color .2s ease,opacity .2s ease}
 .nav__link:hover,
 .nav__link:focus-visible{opacity:1;color:var(--accent);outline:none}
 .nav__item--has-dropdown{position:relative}
-.nav__link--dropdown{gap:8px}
+.nav__link--dropdown{gap:8px;position:relative;padding-block:10px}
 .nav__chevron{display:inline-flex;width:8px;height:8px;border-right:1.5px solid currentColor;border-bottom:1.5px solid currentColor;transform:translateY(-1px) rotate(45deg);transition:transform .2s ease}
-.nav-dropdown{position:absolute;top:calc(100% + 14px);left:50%;min-width:240px;margin:0;padding:10px 0;list-style:none;background:rgba(255,255,255,.98);border:1px solid rgba(15,23,42,.08);border-radius:18px;box-shadow:0 18px 36px rgba(15,23,42,.12);opacity:0;visibility:hidden;pointer-events:none;transform:translate(-50%,8px);transition:opacity .2s ease,transform .2s ease,visibility .2s ease;z-index:120}
-.nav-dropdown::before{content:"";position:absolute;left:0;right:0;top:-14px;height:14px}
+.nav-dropdown{position:absolute;top:calc(100% + 10px);left:50%;min-width:240px;margin:0;padding:10px 0;list-style:none;background:rgba(255,255,255,.98);border:1px solid rgba(15,23,42,.08);border-radius:18px;box-shadow:0 18px 36px rgba(15,23,42,.12);opacity:0;visibility:hidden;pointer-events:none;transform:translate(-50%,8px);transition:opacity .2s ease,transform .2s ease,visibility .2s ease;z-index:120}
+.nav-dropdown::before{content:"";position:absolute;left:0;right:0;top:-10px;height:10px}
 .nav-dropdown__link{display:block;padding:11px 18px;color:var(--text);text-decoration:none;font-weight:500;white-space:nowrap;transition:background .2s ease,color .2s ease}
 .nav-dropdown__link:hover,.nav-dropdown__link:focus-visible{background:rgba(245,158,11,.08);color:var(--accent);outline:none}
 .nav__item--has-dropdown:hover .nav-dropdown,
@@ -100,11 +100,11 @@ img{max-width:100%;height:auto;display:block}
 .nav-mobile__link:hover,
 .nav-mobile__link:focus-visible{color:var(--accent);outline:none}
 .nav-mobile__item--submenu{padding-bottom:6px}
-.nav-mobile__submenu-header{display:flex;align-items:center;gap:12px}
+.nav-mobile__submenu-header{display:flex;align-items:center}
 .nav-mobile__link--parent{flex:1 1 auto;padding-right:0}
-.nav-mobile__submenu-toggle{flex:0 0 auto;display:inline-flex;align-items:center;justify-content:center;width:42px;height:42px;margin-right:-2px;border:1px solid transparent;border-radius:12px;background:none;color:var(--text);cursor:pointer;transition:background .2s ease,border-color .2s ease,color .2s ease}
-.nav-mobile__submenu-toggle:hover,.nav-mobile__submenu-toggle:focus-visible{background:rgba(245,158,11,.08);border-color:rgba(245,158,11,.18);color:var(--accent);outline:none}
-.nav-mobile__submenu-icon{display:inline-flex;width:10px;height:10px;border-right:1.5px solid currentColor;border-bottom:1.5px solid currentColor;transform:rotate(45deg);transition:transform .2s ease}
+.nav-mobile__submenu-trigger{padding-right:2px;border:1px solid transparent;border-radius:14px;transition:background .2s ease,border-color .2s ease,color .2s ease}
+.nav-mobile__submenu-trigger:hover,.nav-mobile__submenu-trigger:focus-visible{background:rgba(245,158,11,.08);border-color:rgba(245,158,11,.18);color:var(--accent);outline:none}
+.nav-mobile__submenu-icon{display:inline-flex;flex:0 0 auto;width:10px;height:10px;border-right:1.5px solid currentColor;border-bottom:1.5px solid currentColor;transform:rotate(45deg);transition:transform .2s ease}
 .nav-mobile__item--submenu.is-open .nav-mobile__submenu-icon{transform:rotate(225deg)}
 .nav-mobile__submenu{list-style:none;margin:0;padding:0 0 6px 16px;display:grid;gap:2px}
 .nav-mobile__subitem{border-top:1px solid rgba(15,23,42,.06)}

--- a/contact.html
+++ b/contact.html
@@ -225,15 +225,15 @@
         <ul class="nav__list">
           <li class="nav__item"><a href="index.html" class="nav__link" rel="home">Αρχική</a></li>
           <li class="nav__item nav__item--has-dropdown" data-nav-dropdown>
-            <a href="anakainiseis-athina.html" class="nav__link nav__link--dropdown" aria-haspopup="true" aria-expanded="false">
+            <button type="button" class="nav__link nav__link--dropdown" aria-haspopup="true" aria-expanded="false">
               <span>Ανακαινίσεις</span>
               <span class="nav__chevron" aria-hidden="true"></span>
-            </a>
+            </button>
             <ul class="nav-dropdown" aria-label="Υπηρεσίες ανακαίνισης">
-              <li class="nav-dropdown__item"><a href="anakainisi-spitiou-athina.html" class="nav-dropdown__link">Ολική Ανακαίνιση</a></li>
-              <li class="nav-dropdown__item"><a href="anakainisi-kouzinas-athina.html" class="nav-dropdown__link">Ανακαίνιση Κουζίνας</a></li>
-              <li class="nav-dropdown__item"><a href="anakainisi-mpaniou-athina.html" class="nav-dropdown__link">Ανακαίνιση Μπάνιου</a></li>
-              <li class="nav-dropdown__item"><a href="dapeda-plakakia-athina.html" class="nav-dropdown__link">Δάπεδα & Πλακάκια</a></li>
+              <li class="nav-dropdown__item"><a href="index.html#services" class="nav-dropdown__link">Ολική Ανακαίνιση</a></li>
+              <li class="nav-dropdown__item"><a href="index.html#services" class="nav-dropdown__link">Ανακαίνιση Κουζίνας</a></li>
+              <li class="nav-dropdown__item"><a href="index.html#services" class="nav-dropdown__link">Ανακαίνιση Μπάνιου</a></li>
+              <li class="nav-dropdown__item"><a href="index.html#services" class="nav-dropdown__link">Δάπεδα & Πλακάκια</a></li>
             </ul>
           </li>
           <li class="nav__item nav__item--projects"><a href="erga.html" class="nav__link">Έργα μας</a></li>
@@ -263,16 +263,16 @@
           <li class="nav-mobile__item"><a href="index.html" class="nav-mobile__link" rel="home">Αρχική</a></li>
           <li class="nav-mobile__item nav-mobile__item--submenu" data-mobile-submenu>
             <div class="nav-mobile__submenu-header">
-              <a href="anakainiseis-athina.html" class="nav-mobile__link nav-mobile__link--parent">Ανακαινίσεις</a>
-              <button class="nav-mobile__submenu-toggle" type="button" aria-expanded="false" aria-label="Άνοιγμα υπομενού Ανακαινίσεις" data-mobile-submenu-toggle>
+              <button class="nav-mobile__link nav-mobile__link--parent nav-mobile__submenu-trigger" type="button" aria-expanded="false" aria-haspopup="true" aria-label="Άνοιγμα υπομενού Ανακαινίσεις" data-mobile-submenu-toggle>
+                <span>Ανακαινίσεις</span>
                 <span class="nav-mobile__submenu-icon" aria-hidden="true"></span>
               </button>
             </div>
             <ul class="nav-mobile__submenu" hidden>
-                <li class="nav-mobile__subitem"><a href="anakainisi-spitiou-athina.html" class="nav-mobile__sublink">Ολική Ανακαίνιση</a></li>
-                <li class="nav-mobile__subitem"><a href="anakainisi-kouzinas-athina.html" class="nav-mobile__sublink">Ανακαίνιση Κουζίνας</a></li>
-                <li class="nav-mobile__subitem"><a href="anakainisi-mpaniou-athina.html" class="nav-mobile__sublink">Ανακαίνιση Μπάνιου</a></li>
-                <li class="nav-mobile__subitem"><a href="dapeda-plakakia-athina.html" class="nav-mobile__sublink">Δάπεδα & Πλακάκια</a></li>
+                <li class="nav-mobile__subitem"><a href="index.html#services" class="nav-mobile__sublink">Ολική Ανακαίνιση</a></li>
+                <li class="nav-mobile__subitem"><a href="index.html#services" class="nav-mobile__sublink">Ανακαίνιση Κουζίνας</a></li>
+                <li class="nav-mobile__subitem"><a href="index.html#services" class="nav-mobile__sublink">Ανακαίνιση Μπάνιου</a></li>
+                <li class="nav-mobile__subitem"><a href="index.html#services" class="nav-mobile__sublink">Δάπεδα & Πλακάκια</a></li>
             </ul>
           </li>
           <li class="nav-mobile__item nav-mobile__item--projects"><a href="erga.html" class="nav-mobile__link">Έργα μας</a></li>

--- a/cookie-policy.html
+++ b/cookie-policy.html
@@ -70,16 +70,16 @@
           <li><a class="nav-mobile__link" href="/index.html#process"><span>Πώς Λειτουργούμε</span><span aria-hidden="true">→</span></a></li>
           <li class="nav-mobile__item nav-mobile__item--submenu" data-mobile-submenu>
             <div class="nav-mobile__submenu-header">
-              <a href="anakainiseis-athina.html" class="nav-mobile__link nav-mobile__link--parent">Ανακαινίσεις</a>
-              <button class="nav-mobile__submenu-toggle" type="button" aria-expanded="false" aria-label="Άνοιγμα υπομενού Ανακαινίσεις" data-mobile-submenu-toggle>
+              <button class="nav-mobile__link nav-mobile__link--parent nav-mobile__submenu-trigger" type="button" aria-expanded="false" aria-haspopup="true" aria-label="Άνοιγμα υπομενού Ανακαινίσεις" data-mobile-submenu-toggle>
+                <span>Ανακαινίσεις</span>
                 <span class="nav-mobile__submenu-icon" aria-hidden="true"></span>
               </button>
             </div>
             <ul class="nav-mobile__submenu" hidden>
-              <li class="nav-mobile__subitem"><a href="anakainisi-spitiou-athina.html" class="nav-mobile__sublink">Ολική Ανακαίνιση</a></li>
-              <li class="nav-mobile__subitem"><a href="anakainisi-kouzinas-athina.html" class="nav-mobile__sublink">Ανακαίνιση Κουζίνας</a></li>
-              <li class="nav-mobile__subitem"><a href="anakainisi-mpaniou-athina.html" class="nav-mobile__sublink">Ανακαίνιση Μπάνιου</a></li>
-              <li class="nav-mobile__subitem"><a href="dapeda-plakakia-athina.html" class="nav-mobile__sublink">Δάπεδα & Πλακάκια</a></li>
+              <li class="nav-mobile__subitem"><a href="index.html#services" class="nav-mobile__sublink">Ολική Ανακαίνιση</a></li>
+              <li class="nav-mobile__subitem"><a href="index.html#services" class="nav-mobile__sublink">Ανακαίνιση Κουζίνας</a></li>
+              <li class="nav-mobile__subitem"><a href="index.html#services" class="nav-mobile__sublink">Ανακαίνιση Μπάνιου</a></li>
+              <li class="nav-mobile__subitem"><a href="index.html#services" class="nav-mobile__sublink">Δάπεδα & Πλακάκια</a></li>
             </ul>
           </li>
           <li><a class="nav-mobile__link" href="erga.html"><span>Έργα</span><span aria-hidden="true">→</span></a></li>

--- a/erga.html
+++ b/erga.html
@@ -44,15 +44,15 @@
         <ul class="nav__list">
           <li class="nav__item"><a href="#" class="nav__link" data-home rel="home">Αρχική</a></li>
           <li class="nav__item nav__item--has-dropdown" data-nav-dropdown>
-            <a href="anakainiseis-athina.html" class="nav__link nav__link--dropdown" aria-haspopup="true" aria-expanded="false">
+            <button type="button" class="nav__link nav__link--dropdown" aria-haspopup="true" aria-expanded="false">
               <span>Ανακαινίσεις</span>
               <span class="nav__chevron" aria-hidden="true"></span>
-            </a>
+            </button>
             <ul class="nav-dropdown" aria-label="Υπηρεσίες ανακαίνισης">
-              <li class="nav-dropdown__item"><a href="anakainisi-spitiou-athina.html" class="nav-dropdown__link">Ολική Ανακαίνιση</a></li>
-              <li class="nav-dropdown__item"><a href="anakainisi-kouzinas-athina.html" class="nav-dropdown__link">Ανακαίνιση Κουζίνας</a></li>
-              <li class="nav-dropdown__item"><a href="anakainisi-mpaniou-athina.html" class="nav-dropdown__link">Ανακαίνιση Μπάνιου</a></li>
-              <li class="nav-dropdown__item"><a href="dapeda-plakakia-athina.html" class="nav-dropdown__link">Δάπεδα & Πλακάκια</a></li>
+              <li class="nav-dropdown__item"><a href="index.html#services" class="nav-dropdown__link">Ολική Ανακαίνιση</a></li>
+              <li class="nav-dropdown__item"><a href="index.html#services" class="nav-dropdown__link">Ανακαίνιση Κουζίνας</a></li>
+              <li class="nav-dropdown__item"><a href="index.html#services" class="nav-dropdown__link">Ανακαίνιση Μπάνιου</a></li>
+              <li class="nav-dropdown__item"><a href="index.html#services" class="nav-dropdown__link">Δάπεδα & Πλακάκια</a></li>
             </ul>
           </li>
           <li class="nav__item nav__item--projects"><a href="erga.html" class="nav__link">Έργα μας</a></li>
@@ -82,16 +82,16 @@
           <li class="nav-mobile__item"><a href="#" class="nav-mobile__link" data-home rel="home">Αρχική</a></li>
           <li class="nav-mobile__item nav-mobile__item--submenu" data-mobile-submenu>
             <div class="nav-mobile__submenu-header">
-              <a href="anakainiseis-athina.html" class="nav-mobile__link nav-mobile__link--parent">Ανακαινίσεις</a>
-              <button class="nav-mobile__submenu-toggle" type="button" aria-expanded="false" aria-label="Άνοιγμα υπομενού Ανακαινίσεις" data-mobile-submenu-toggle>
+              <button class="nav-mobile__link nav-mobile__link--parent nav-mobile__submenu-trigger" type="button" aria-expanded="false" aria-haspopup="true" aria-label="Άνοιγμα υπομενού Ανακαινίσεις" data-mobile-submenu-toggle>
+                <span>Ανακαινίσεις</span>
                 <span class="nav-mobile__submenu-icon" aria-hidden="true"></span>
               </button>
             </div>
             <ul class="nav-mobile__submenu" hidden>
-                <li class="nav-mobile__subitem"><a href="anakainisi-spitiou-athina.html" class="nav-mobile__sublink">Ολική Ανακαίνιση</a></li>
-                <li class="nav-mobile__subitem"><a href="anakainisi-kouzinas-athina.html" class="nav-mobile__sublink">Ανακαίνιση Κουζίνας</a></li>
-                <li class="nav-mobile__subitem"><a href="anakainisi-mpaniou-athina.html" class="nav-mobile__sublink">Ανακαίνιση Μπάνιου</a></li>
-                <li class="nav-mobile__subitem"><a href="dapeda-plakakia-athina.html" class="nav-mobile__sublink">Δάπεδα & Πλακάκια</a></li>
+                <li class="nav-mobile__subitem"><a href="index.html#services" class="nav-mobile__sublink">Ολική Ανακαίνιση</a></li>
+                <li class="nav-mobile__subitem"><a href="index.html#services" class="nav-mobile__sublink">Ανακαίνιση Κουζίνας</a></li>
+                <li class="nav-mobile__subitem"><a href="index.html#services" class="nav-mobile__sublink">Ανακαίνιση Μπάνιου</a></li>
+                <li class="nav-mobile__subitem"><a href="index.html#services" class="nav-mobile__sublink">Δάπεδα & Πλακάκια</a></li>
             </ul>
           </li>
           <li class="nav-mobile__item nav-mobile__item--projects"><a href="erga.html" class="nav-mobile__link">Έργα μας</a></li>

--- a/index.html
+++ b/index.html
@@ -107,15 +107,15 @@
         <ul class="nav__list">
           <li class="nav__item"><a href="#" class="nav__link" data-home rel="home">Αρχική</a></li>
           <li class="nav__item nav__item--has-dropdown" data-nav-dropdown>
-            <a href="anakainiseis-athina.html" class="nav__link nav__link--dropdown" aria-haspopup="true" aria-expanded="false">
+            <button type="button" class="nav__link nav__link--dropdown" aria-haspopup="true" aria-expanded="false">
               <span>Ανακαινίσεις</span>
               <span class="nav__chevron" aria-hidden="true"></span>
-            </a>
+            </button>
             <ul class="nav-dropdown" aria-label="Υπηρεσίες ανακαίνισης">
-              <li class="nav-dropdown__item"><a href="anakainisi-spitiou-athina.html" class="nav-dropdown__link">Ολική Ανακαίνιση</a></li>
-              <li class="nav-dropdown__item"><a href="anakainisi-kouzinas-athina.html" class="nav-dropdown__link">Ανακαίνιση Κουζίνας</a></li>
-              <li class="nav-dropdown__item"><a href="anakainisi-mpaniou-athina.html" class="nav-dropdown__link">Ανακαίνιση Μπάνιου</a></li>
-              <li class="nav-dropdown__item"><a href="dapeda-plakakia-athina.html" class="nav-dropdown__link">Δάπεδα & Πλακάκια</a></li>
+              <li class="nav-dropdown__item"><a href="index.html#services" class="nav-dropdown__link">Ολική Ανακαίνιση</a></li>
+              <li class="nav-dropdown__item"><a href="index.html#services" class="nav-dropdown__link">Ανακαίνιση Κουζίνας</a></li>
+              <li class="nav-dropdown__item"><a href="index.html#services" class="nav-dropdown__link">Ανακαίνιση Μπάνιου</a></li>
+              <li class="nav-dropdown__item"><a href="index.html#services" class="nav-dropdown__link">Δάπεδα & Πλακάκια</a></li>
             </ul>
           </li>
           <li class="nav__item nav__item--projects"><a href="erga.html" class="nav__link">Έργα μας</a></li>
@@ -145,16 +145,16 @@
           <li class="nav-mobile__item"><a href="#" class="nav-mobile__link" data-home rel="home">Αρχική</a></li>
           <li class="nav-mobile__item nav-mobile__item--submenu" data-mobile-submenu>
             <div class="nav-mobile__submenu-header">
-              <a href="anakainiseis-athina.html" class="nav-mobile__link nav-mobile__link--parent">Ανακαινίσεις</a>
-              <button class="nav-mobile__submenu-toggle" type="button" aria-expanded="false" aria-label="Άνοιγμα υπομενού Ανακαινίσεις" data-mobile-submenu-toggle>
+              <button class="nav-mobile__link nav-mobile__link--parent nav-mobile__submenu-trigger" type="button" aria-expanded="false" aria-haspopup="true" aria-label="Άνοιγμα υπομενού Ανακαινίσεις" data-mobile-submenu-toggle>
+                <span>Ανακαινίσεις</span>
                 <span class="nav-mobile__submenu-icon" aria-hidden="true"></span>
               </button>
             </div>
             <ul class="nav-mobile__submenu" hidden>
-                <li class="nav-mobile__subitem"><a href="anakainisi-spitiou-athina.html" class="nav-mobile__sublink">Ολική Ανακαίνιση</a></li>
-                <li class="nav-mobile__subitem"><a href="anakainisi-kouzinas-athina.html" class="nav-mobile__sublink">Ανακαίνιση Κουζίνας</a></li>
-                <li class="nav-mobile__subitem"><a href="anakainisi-mpaniou-athina.html" class="nav-mobile__sublink">Ανακαίνιση Μπάνιου</a></li>
-                <li class="nav-mobile__subitem"><a href="dapeda-plakakia-athina.html" class="nav-mobile__sublink">Δάπεδα & Πλακάκια</a></li>
+                <li class="nav-mobile__subitem"><a href="index.html#services" class="nav-mobile__sublink">Ολική Ανακαίνιση</a></li>
+                <li class="nav-mobile__subitem"><a href="index.html#services" class="nav-mobile__sublink">Ανακαίνιση Κουζίνας</a></li>
+                <li class="nav-mobile__subitem"><a href="index.html#services" class="nav-mobile__sublink">Ανακαίνιση Μπάνιου</a></li>
+                <li class="nav-mobile__subitem"><a href="index.html#services" class="nav-mobile__sublink">Δάπεδα & Πλακάκια</a></li>
             </ul>
           </li>
           <li class="nav-mobile__item nav-mobile__item--projects"><a href="erga.html" class="nav-mobile__link">Έργα μας</a></li>


### PR DESCRIPTION
### Motivation
- Fix the navigation issues where the parent item "Ανακαινίσεις" acted as a normal link, submenu links produced 404s and the dropdown visually broke the navbar layout.
- Keep header/CTA/footer intact while providing accessible, touch-friendly dropdown behavior on desktop and mobile.

### Description
- Converted the desktop parent from an anchor to an accessible button trigger with `aria-haspopup` and `aria-expanded`, and prevented navigation when the trigger is clicked; updated the toggle behavior in `assets/app.js` to open/close on hover/focus/click without redirecting. Files changed: `index.html`, `erga.html`, `anakainiseis-athina.html`, `contact.html`.
- Reworked the mobile submenu to use a button-like parent trigger (touch-friendly) with proper `aria-expanded`/`aria-haspopup` semantics and kept the collapsible behavior; applied the same mobile change to `cookie-policy.html` so the shared pattern is consistent.
- Replaced the four submenu targets that returned 404 with temporary anchors pointing to the existing homepage services section (`index.html#services`). The four items (Ολική Ανακαίνιση, Ανακαίνιση Κουζίνας, Ανακαίνιση Μπάνιου, Δάπεδα & Πλακάκια) now link to `index.html#services` in both desktop and mobile menus.
- Adjusted styling in `assets/style.css` to keep the premium look while ensuring the dropdown panel positions and spacing do not push or break the navbar layout; additions include small spacing/timing tweaks and consistent button-like visual behavior.
- JS changes are in `assets/app.js` to: prevent default navigation on triggers, manage `aria-expanded`, support clicking the desktop trigger to toggle the floating panel, and `preventDefault()` on mobile toggle for reliable touch behavior.
- Files modified: `index.html`, `erga.html`, `anakainiseis-athina.html`, `contact.html`, `cookie-policy.html`, `assets/style.css`, `assets/app.js`.

### Testing
- Ran a Python-based structural/regex navigation check across updated HTML files to verify triggers are `button`, `aria-*` attributes exist, and submenu links point to `index.html#services`; result: passed.
- Ran `node --check assets/app.js` to ensure the modified JS is syntactically valid; result: passed.
- Performed local smoke verification of DOM snippets (no browser screenshot tool available in environment); result: checks passed and no unintended changes to other menu items, CTA or footer were detected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c02afc854c8320b40fb93abeb5e685)