### PR TITLE
Add Athens home renovation landing page (anakainisi-spitiou-athina.html)

### DIFF
--- a/anakainisi-spitiou-athina.html
+++ b/anakainisi-spitiou-athina.html
@@ -1,0 +1,926 @@
+<!doctype html>
+<html lang="el">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Ολική Ανακαίνιση Κατοικίας Αθήνα | FM Renovation</title>
+  <meta name="description" content="Αναλαμβάνουμε ολική ανακαίνιση κατοικίας στην Αθήνα και όλη την Αττική. Πλήρεις εργασίες με συνέπεια, ποιοτικά υλικά και δωρεάν εκτίμηση.">
+  <link rel="canonical" href="https://www.anakainisou.gr/anakainisi-spitiou-athina.html">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Roboto:wght@700&display=swap" rel="stylesheet">
+  <link rel="preload" as="image" href="images/hero-anakainisi-athina-saloni.webp" fetchpriority="high">
+  <link rel="stylesheet" href="assets/style.css">
+  <link rel="icon" type="image/png" href="favicon-96x96.png" sizes="96x96">
+  <link rel="icon" type="image/svg+xml" href="favicon.svg">
+  <link rel="shortcut icon" href="favicon.ico">
+  <link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png">
+  <link rel="manifest" href="site.webmanifest">
+  <meta name="theme-color" content="#0F172A">
+  <meta property="og:title" content="Ολική Ανακαίνιση Κατοικίας Αθήνα | FM Renovation">
+  <meta property="og:description" content="Αναλαμβάνουμε ολική ανακαίνιση κατοικίας στην Αθήνα και όλη την Αττική. Πλήρεις εργασίες με συνέπεια, ποιοτικά υλικά και δωρεάν εκτίμηση.">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://www.anakainisou.gr/anakainisi-spitiou-athina.html">
+  <meta property="og:image" content="https://www.anakainisou.gr/images/hero-anakainisi-athina-saloni.webp">
+  <meta property="og:locale" content="el_GR">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Ολική Ανακαίνιση Κατοικίας Αθήνα | FM Renovation">
+  <meta name="twitter:description" content="Αναλαμβάνουμε ολική ανακαίνιση κατοικίας στην Αθήνα και όλη την Αττική. Πλήρεις εργασίες με συνέπεια, ποιοτικά υλικά και δωρεάν εκτίμηση.">
+  <meta name="twitter:image" content="https://www.anakainisou.gr/images/hero-anakainisi-athina-saloni.webp">
+  <style>
+    .athina-home-page main {
+      display: block;
+      background: linear-gradient(180deg, #ffffff 0%, #f8fafc 100%);
+    }
+
+    .service-hero {
+      position: relative;
+      min-height: clamp(340px, 50vh, 520px);
+      display: grid;
+      place-items: center;
+      overflow: hidden;
+      isolation: isolate;
+      color: #fff;
+      text-align: left;
+    }
+
+    .service-hero::before {
+      content: "";
+      position: absolute;
+      inset: 0;
+      background: linear-gradient(115deg, rgba(15, 23, 42, 0.84) 0%, rgba(15, 23, 42, 0.56) 52%, rgba(15, 23, 42, 0.72) 100%);
+      z-index: 1;
+    }
+
+    .service-hero__image {
+      position: absolute;
+      inset: 0;
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      z-index: 0;
+    }
+
+    .service-hero__inner {
+      position: relative;
+      z-index: 2;
+      width: min(100%, 1240px);
+      padding: 120px 20px 84px;
+    }
+
+    .service-hero__content {
+      max-width: 720px;
+    }
+
+    .service-eyebrow {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 8px 14px;
+      border-radius: 999px;
+      border: 1px solid rgba(255,255,255,0.2);
+      background: rgba(255,255,255,0.08);
+      backdrop-filter: blur(10px);
+      margin-bottom: 18px;
+      font-size: 0.92rem;
+      font-weight: 700;
+      letter-spacing: 0.03em;
+    }
+
+    .service-hero h1 {
+      margin: 0 0 16px;
+      font-size: clamp(2.2rem, 4.8vw, 3.9rem);
+      line-height: 1.08;
+      color: #fff;
+    }
+
+    .service-hero p {
+      margin: 0;
+      max-width: 640px;
+      font-size: clamp(1rem, 1.9vw, 1.16rem);
+      line-height: 1.78;
+      color: rgba(255,255,255,0.92);
+    }
+
+    .service-hero__actions,
+    .service-final__actions,
+    .service-projects__actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 14px;
+      margin-top: 28px;
+    }
+
+    .btn--ghost-light {
+      background: rgba(255,255,255,0.1);
+      border: 1px solid rgba(255,255,255,0.28);
+      color: #fff;
+    }
+
+    .btn--ghost-light:hover,
+    .btn--ghost-light:focus-visible {
+      background: #fff;
+      color: #0f172a;
+      outline: none;
+    }
+
+    .service-section {
+      padding: 68px 0;
+    }
+
+    .service-section--soft {
+      background: linear-gradient(180deg, #ffffff 0%, #f5f7fb 100%);
+    }
+
+    .service-section__head {
+      max-width: 760px;
+      margin: 0 auto 34px;
+      text-align: center;
+    }
+
+    .service-section__head h2,
+    .service-intro__copy h2,
+    .service-local__copy h2,
+    .service-projects__copy h2,
+    .service-final__box h2 {
+      margin: 0 0 14px;
+      color: #0f172a;
+      font-size: clamp(1.75rem, 3vw, 2.45rem);
+      line-height: 1.15;
+    }
+
+    .service-section__head p,
+    .service-intro__copy p,
+    .service-local__copy p,
+    .service-projects__copy p,
+    .service-final__box p,
+    .service-faq p {
+      margin: 0;
+      color: #475569;
+      line-height: 1.8;
+    }
+
+    .service-kicker {
+      display: inline-block;
+      margin-bottom: 10px;
+      color: #b45309;
+      font-size: 0.84rem;
+      font-weight: 800;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+    }
+
+    .service-intro {
+      padding-top: 34px;
+    }
+
+    .service-intro__grid,
+    .service-local,
+    .service-projects {
+      display: grid;
+      gap: 28px;
+      align-items: center;
+    }
+
+    .service-intro__grid {
+      grid-template-columns: minmax(0, 1.15fr) minmax(280px, 0.85fr);
+    }
+
+    .service-intro__copy,
+    .service-intro__aside,
+    .service-trust__card,
+    .service-include,
+    .service-step,
+    .service-faq details,
+    .service-final__box,
+    .service-local__areas {
+      background: #fff;
+      border: 1px solid rgba(15, 23, 42, 0.08);
+      border-radius: 24px;
+      box-shadow: 0 18px 36px rgba(15, 23, 42, 0.08);
+    }
+
+    .service-intro__copy,
+    .service-intro__aside,
+    .service-final__box,
+    .service-local__areas {
+      padding: clamp(24px, 4vw, 34px);
+    }
+
+    .service-intro__copy p + p,
+    .service-local__copy p + p {
+      margin-top: 16px;
+    }
+
+    .service-stat {
+      padding: 18px 0;
+      border-bottom: 1px solid rgba(15, 23, 42, 0.08);
+    }
+
+    .service-stat:first-child { padding-top: 0; }
+    .service-stat:last-child {
+      padding-bottom: 0;
+      border-bottom: 0;
+    }
+
+    .service-stat strong {
+      display: block;
+      margin-bottom: 6px;
+      color: #0f172a;
+      font-size: 1.02rem;
+    }
+
+    .service-stat span {
+      color: #475569;
+      line-height: 1.7;
+    }
+
+    .service-includes,
+    .service-trust,
+    .service-process {
+      display: grid;
+      gap: 22px;
+      grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    }
+
+    .service-include,
+    .service-trust__card,
+    .service-step {
+      padding: 24px;
+      height: 100%;
+    }
+
+    .service-icon,
+    .service-step__num {
+      width: 48px;
+      height: 48px;
+      border-radius: 16px;
+      display: grid;
+      place-items: center;
+      margin-bottom: 14px;
+      background: linear-gradient(135deg, rgba(245, 158, 11, 0.18), rgba(251, 191, 36, 0.28));
+      color: #b45309;
+      font-size: 1.2rem;
+      font-weight: 800;
+    }
+
+    .service-include h3,
+    .service-trust__card h3,
+    .service-step h3,
+    .service-projects__copy h2,
+    .service-final__box h2,
+    .service-faq summary {
+      margin: 0 0 12px;
+      color: #0f172a;
+    }
+
+    .service-include p,
+    .service-trust__card p,
+    .service-step p {
+      margin: 0;
+      color: #475569;
+      line-height: 1.76;
+    }
+
+    .service-local {
+      grid-template-columns: minmax(0, 1.08fr) minmax(280px, 0.92fr);
+      align-items: start;
+    }
+
+    .service-local__areas {
+      display: grid;
+      gap: 12px;
+      grid-template-columns: repeat(auto-fit, minmax(132px, 1fr));
+    }
+
+    .service-area {
+      padding: 14px 16px;
+      border-radius: 18px;
+      background: linear-gradient(180deg, #fff 0%, #f8fafc 100%);
+      border: 1px solid rgba(15, 23, 42, 0.08);
+      color: #334155;
+      text-align: center;
+      font-weight: 700;
+    }
+
+    .service-projects {
+      grid-template-columns: minmax(0, 1fr) minmax(280px, 0.95fr);
+    }
+
+    .service-projects__media {
+      min-height: 320px;
+      border-radius: 28px;
+      overflow: hidden;
+      box-shadow: 0 20px 40px rgba(15, 23, 42, 0.14);
+      position: relative;
+    }
+
+    .service-projects__media img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      display: block;
+    }
+
+    .service-projects__media::after {
+      content: "FM Renovation";
+      position: absolute;
+      left: 18px;
+      bottom: 18px;
+      padding: 8px 14px;
+      border-radius: 999px;
+      background: rgba(15, 23, 42, 0.82);
+      color: #fff;
+      font-size: 0.85rem;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+    }
+
+    .service-faq {
+      max-width: 920px;
+      margin: 0 auto;
+      display: grid;
+      gap: 14px;
+    }
+
+    .service-faq details {
+      padding: 0 22px;
+    }
+
+    .service-faq summary {
+      list-style: none;
+      cursor: pointer;
+      padding: 20px 0;
+      font-weight: 700;
+      font-size: 1.04rem;
+    }
+
+    .service-faq summary::-webkit-details-marker {
+      display: none;
+    }
+
+    .service-faq p {
+      padding-bottom: 22px;
+    }
+
+    .service-final__box {
+      background: linear-gradient(135deg, #0f172a 0%, #1e293b 62%, #334155 100%);
+      color: #fff;
+      box-shadow: 0 24px 50px rgba(15, 23, 42, 0.24);
+    }
+
+    .service-final__box h2,
+    .service-final__box p {
+      color: #fff;
+    }
+
+    .service-final__box p {
+      max-width: 760px;
+      color: rgba(255,255,255,0.88);
+    }
+
+    .service-final__actions .btn--ghost-light {
+      background: rgba(255,255,255,0.08);
+    }
+
+    .service-link-inline {
+      color: #0f172a;
+      font-weight: 700;
+      text-decoration: underline;
+      text-underline-offset: 3px;
+    }
+
+    .service-link-inline:hover,
+    .service-link-inline:focus-visible {
+      color: var(--accent);
+      outline: none;
+    }
+
+    @media (max-width: 960px) {
+      .service-intro__grid,
+      .service-local,
+      .service-projects {
+        grid-template-columns: 1fr;
+      }
+    }
+
+    @media (max-width: 640px) {
+      .service-section {
+        padding: 54px 0;
+      }
+
+      .service-hero__inner {
+        padding: 108px 18px 72px;
+      }
+
+      .service-hero__actions,
+      .service-final__actions,
+      .service-projects__actions {
+        flex-direction: column;
+      }
+
+      .service-hero__actions .btn,
+      .service-final__actions .btn,
+      .service-projects__actions .btn {
+        width: 100%;
+      }
+
+      .service-intro__copy,
+      .service-intro__aside,
+      .service-trust__card,
+      .service-include,
+      .service-step,
+      .service-faq details,
+      .service-final__box,
+      .service-local__areas {
+        border-radius: 20px;
+      }
+
+      .service-area {
+        text-align: left;
+      }
+    }
+  </style>
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "HomeAndConstructionBusiness",
+      "@id": "https://www.anakainisou.gr/anakainisi-spitiou-athina.html#business",
+      "name": "FM Renovation",
+      "url": "https://www.anakainisou.gr/anakainisi-spitiou-athina.html",
+      "image": "https://www.anakainisou.gr/images/hero-anakainisi-athina-saloni.webp",
+      "logo": "https://www.anakainisou.gr/images/logo.webp",
+      "description": "Η FM Renovation αναλαμβάνει ολική ανακαίνιση κατοικίας στην Αθήνα και όλη την Αττική με πλήρη οργάνωση έργου, ποιοτικά υλικά και εξειδικευμένα συνεργεία.",
+      "telephone": "+30 211 404 4496",
+      "email": "fmren2021@gmail.com",
+      "address": {
+        "@type": "PostalAddress",
+        "streetAddress": "Δοϊράνης 180",
+        "addressLocality": "Καλλιθέα",
+        "postalCode": "17673",
+        "addressCountry": "GR"
+      },
+      "areaServed": [
+        {"@type": "City", "name": "Αθήνα"},
+        {"@type": "City", "name": "Πειραιάς"},
+        {"@type": "City", "name": "Γλυφάδα"},
+        {"@type": "City", "name": "Νέα Σμύρνη"},
+        {"@type": "City", "name": "Κηφισιά"},
+        {"@type": "City", "name": "Μαρούσι"},
+        {"@type": "City", "name": "Χαλάνδρι"},
+        {"@type": "City", "name": "Περιστέρι"},
+        {"@type": "AdministrativeArea", "name": "Αττική"}
+      ],
+      "sameAs": [
+        "https://www.facebook.com/share/1CJUXM8xkk/",
+        "https://www.instagram.com/fm.renovation21/"
+      ]
+    }
+  </script>
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Service",
+      "@id": "https://www.anakainisou.gr/anakainisi-spitiou-athina.html#service",
+      "serviceType": "Ολική Ανακαίνιση Κατοικίας",
+      "name": "Ολική Ανακαίνιση Κατοικίας στην Αθήνα",
+      "url": "https://www.anakainisou.gr/anakainisi-spitiou-athina.html",
+      "description": "Πλήρης ανακαίνιση κατοικίας στην Αθήνα και την Αττική, από αποξηλώσεις και νέες παροχές μέχρι τελικά φινιρίσματα, κουζίνα, μπάνιο και κουφώματα.",
+      "provider": {
+        "@type": "HomeAndConstructionBusiness",
+        "name": "FM Renovation",
+        "url": "https://www.anakainisou.gr/"
+      },
+      "areaServed": [
+        "Αθήνα",
+        "Πειραιάς",
+        "Γλυφάδα",
+        "Νέα Σμύρνη",
+        "Κηφισιά",
+        "Μαρούσι",
+        "Χαλάνδρι",
+        "Περιστέρι",
+        "Αττική"
+      ]
+    }
+  </script>
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "FAQPage",
+      "mainEntity": [
+        {
+          "@type": "Question",
+          "name": "Πόσο διαρκεί μια ολική ανακαίνιση;",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Η διάρκεια μιας ολικής ανακαίνισης εξαρτάται από τα τετραγωνικά, τη διαρρύθμιση και το εύρος των τεχνικών παρεμβάσεων. Μετά την αυτοψία σας δίνουμε ρεαλιστικό χρονοδιάγραμμα για κάθε στάδιο του έργου."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "Πώς βγαίνει η προσφορά;",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Η προσφορά διαμορφώνεται μετά από επικοινωνία, επιτόπια αυτοψία και αναλυτική καταγραφή αναγκών, ώστε να υπολογιστούν με ακρίβεια οι εργασίες, τα υλικά και το συνολικό πλάνο υλοποίησης."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "Αναλαμβάνετε μικρές και μεγάλες κατοικίες;",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Ναι, αναλαμβάνουμε τόσο μικρότερα διαμερίσματα όσο και μεγαλύτερες κατοικίες, οργανώνοντας το έργο ανάλογα με τη χρήση του ακινήτου, τις ανάγκες του ιδιοκτήτη και το επιθυμητό αποτέλεσμα."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "Εξυπηρετείτε όλη την Αττική;",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Ναι, η FM Renovation εξυπηρετεί έργα ολικής ανακαίνισης σε όλη την Αττική, με παρουσία στην Αθήνα, τον Πειραιά, τη Γλυφάδα, τη Νέα Σμύρνη, την Κηφισιά, το Μαρούσι, το Χαλάνδρι και το Περιστέρι."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "Μπορώ να ζητήσω δωρεάν εκτίμηση;",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Βεβαίως. Μπορείτε να επικοινωνήσετε μαζί μας για δωρεάν πρώτη εκτίμηση και να προγραμματίσουμε αυτοψία για το ακίνητό σας."
+          }
+        }
+      ]
+    }
+  </script>
+</head>
+<body class="athina-home-page">
+  <header class="site-header" id="top">
+    <div class="container header-inner">
+      <div class="brand">
+        <a href="index.html" class="logo-link" aria-label="Αρχική σελίδα">
+          <img class="brand-logo" src="images/logo.webp" alt="FM Renovation Ανακαινίσεις Αθήνα" width="180" height="60">
+        </a>
+        <span class="brand-tagline"><strong>Ανακαίνιση χώρου</strong></span>
+      </div>
+      <button class="nav-toggle" type="button" data-nav-toggle aria-expanded="false" aria-controls="mobile-menu" aria-label="Άνοιγμα μενού">
+        <span class="nav-toggle-bar"></span>
+        <span class="nav-toggle-bar"></span>
+        <span class="nav-toggle-bar"></span>
+      </button>
+      <nav id="site-nav" class="nav" aria-label="Κύρια πλοήγηση">
+        <ul class="nav__list">
+          <li class="nav__item"><a href="#" class="nav__link" data-home rel="home">Αρχική</a></li>
+          <li class="nav__item"><a href="index.html#services" class="nav__link">Υπηρεσίες</a></li>
+          <li class="nav__item nav__item--projects"><a href="erga.html" class="nav__link">Έργα μας</a></li>
+          <li class="nav__item"><a href="contact.html" class="nav__link">Επικοινωνία</a></li>
+          <li class="nav__item nav__item--cta"><a href="contact.html" class="btn btn--sm nav-cta">Ζητήστε Προσφορά</a></li>
+        </ul>
+      </nav>
+      <div class="social">
+        <a href="https://www.facebook.com/share/1CJUXM8xkk/" aria-label="Facebook" class="icon fb" target="_blank" rel="noopener noreferrer"></a>
+        <a href="https://www.instagram.com/fm.renovation21/" aria-label="Instagram" class="icon ig" target="_blank" rel="noopener noreferrer"></a>
+      </div>
+    </div>
+  </header>
+
+  <div class="nav-backdrop" data-nav-backdrop hidden></div>
+  <div class="nav-overlay" id="mobile-menu" role="dialog" aria-modal="true" aria-labelledby="mobile-menu-title" hidden>
+    <div class="nav-overlay__inner" data-mobile-overlay>
+      <div class="nav-overlay__top">
+        <h2 id="mobile-menu-title" class="nav-overlay__title">Μενού</h2>
+        <button class="nav-close" type="button" data-nav-close aria-label="Κλείσιμο μενού">
+          <span class="nav-close-bar"></span>
+          <span class="nav-close-bar"></span>
+        </button>
+      </div>
+      <nav class="nav-mobile" aria-label="Κύρια πλοήγηση" data-mobile-nav>
+        <ul class="nav-mobile__list">
+          <li class="nav-mobile__item"><a href="#" class="nav-mobile__link" data-home rel="home">Αρχική</a></li>
+          <li class="nav-mobile__item"><a href="index.html#services" class="nav-mobile__link">Υπηρεσίες</a></li>
+          <li class="nav-mobile__item nav-mobile__item--projects"><a href="erga.html" class="nav-mobile__link">Έργα μας</a></li>
+          <li class="nav-mobile__item"><a href="contact.html" class="nav-mobile__link">Επικοινωνία</a></li>
+          <li class="nav-mobile__item nav-mobile__item--cta"><a href="contact.html" class="btn btn--primary nav-mobile__cta">Ζητήστε Προσφορά</a></li>
+        </ul>
+      </nav>
+      <div class="nav-overlay__social">
+        <a href="https://www.facebook.com/share/1CJUXM8xkk/" aria-label="Facebook" class="icon fb" target="_blank" rel="noopener noreferrer"></a>
+        <a href="https://www.instagram.com/fm.renovation21/" aria-label="Instagram" class="icon ig" target="_blank" rel="noopener noreferrer"></a>
+      </div>
+    </div>
+  </div>
+
+  <main>
+    <section class="service-hero">
+      <img class="service-hero__image" src="images/hero-anakainisi-athina-saloni.webp" width="1600" height="1067" alt="Ολική ανακαίνιση κατοικίας στην Αθήνα με μοντέρνο σαλόνι" fetchpriority="high">
+      <div class="service-hero__inner">
+        <div class="service-hero__content reveal">
+          <span class="service-eyebrow">Premium service page • Αθήνα &amp; Αττική</span>
+          <h1>Ολική Ανακαίνιση Κατοικίας στην Αθήνα</h1>
+          <p>Η FM Renovation αναλαμβάνει πλήρεις ανακαινίσεις κατοικιών στην Αθήνα και όλη την Αττική, με οργανωμένη διαχείριση έργου, εξειδικευμένα συνεργεία και υλικά που αναβαθμίζουν την αισθητική, τη λειτουργικότητα και την αξία του ακινήτου σας.</p>
+          <div class="service-hero__actions">
+            <a href="contact.html" class="btn btn--primary">Ζητήστε Προσφορά</a>
+            <a href="erga.html" class="btn btn--ghost-light">Δείτε τα έργα μας</a>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="service-section service-intro">
+      <div class="container service-intro__grid">
+        <div class="service-intro__copy reveal">
+          <span class="service-kicker">Ολική ανακαίνιση κατοικίας Αθήνα</span>
+          <h2>Πλήρης ανακαίνιση σπιτιού στην Αθήνα με premium οργάνωση και καθαρό αποτέλεσμα</h2>
+          <p>Η <a class="service-link-inline" href="/">FM Renovation</a> αναλαμβάνει την ολική ανακαίνιση κατοικίας στην Αθήνα και σε όλη την Αττική, συνδυάζοντας τεχνική εμπειρία, προσεκτικό προγραμματισμό και ποιοτικά υλικά. Σχεδιάζουμε κάθε έργο ώστε να προχωρά με συνέπεια, σαφή κοστολόγηση και σωστό συντονισμό όλων των εργασιών.</p>
+          <p>Είτε πρόκειται για παλαιό διαμέρισμα στο κέντρο είτε για κατοικία στα νότια ή βόρεια προάστια, οργανώνουμε την ανακαίνιση σπιτιού στην Αθήνα ως μία ολοκληρωμένη διαδικασία, από την πρώτη αποτύπωση έως την τελική παράδοση, χωρίς να αντιμετωπίζουμε τις επιμέρους εργασίες σαν ασύνδετες μικρές παρεμβάσεις.</p>
+        </div>
+        <aside class="service-intro__aside reveal" aria-label="Βασικά πλεονεκτήματα">
+          <div class="service-stat">
+            <strong>Σαφής διαχείριση έργου</strong>
+            <span>Ένα οργανωμένο πλάνο για όλες τις φάσεις της πλήρους ανακαίνισης κατοικίας.</span>
+          </div>
+          <div class="service-stat">
+            <strong>Ποιοτικά υλικά &amp; τελειώματα</strong>
+            <span>Επιλογές που στηρίζουν τόσο την καθημερινή χρήση όσο και τη μακροχρόνια αξία του ακινήτου.</span>
+          </div>
+          <div class="service-stat">
+            <strong>Εξυπηρέτηση σε Αθήνα &amp; Αττική</strong>
+            <span>Άμεση ανταπόκριση για έργα ολικής ανακαίνισης σε όλη την περιοχή.</span>
+          </div>
+        </aside>
+      </div>
+    </section>
+
+    <section id="services" class="service-section service-section--soft" aria-labelledby="included-title">
+      <div class="container">
+        <div class="service-section__head reveal">
+          <span class="service-kicker">Τι περιλαμβάνει</span>
+          <h2 id="included-title">Οι βασικές εργασίες που εντάσσονται σε μια πλήρη ανακαίνιση κατοικίας</h2>
+          <p>Αντιμετωπίζουμε την ολική ανακαίνιση κατοικίας ως ενιαίο έργο, όπου κάθε τεχνική και αισθητική παρέμβαση συνδέεται με το συνολικό αποτέλεσμα του σπιτιού.</p>
+        </div>
+        <div class="service-includes">
+          <article class="service-include reveal">
+            <div class="service-icon">01</div>
+            <h3>Γκρεμίσματα / αποξηλώσεις</h3>
+            <p>Προχωράμε σε ελεγχόμενες αποξηλώσεις και απομακρύνσεις παλαιών υλικών, ώστε να δημιουργηθεί η σωστή βάση για τη νέα διαρρύθμιση και την ασφαλή εξέλιξη της ανακαίνισης.</p>
+          </article>
+          <article class="service-include reveal">
+            <div class="service-icon">02</div>
+            <h3>Υδραυλικές εργασίες</h3>
+            <p>Αναβαθμίζουμε δίκτυα και παροχές σε κουζίνα, μπάνιο και βοηθητικούς χώρους, εντάσσοντας τις υδραυλικές λύσεις στο συνολικό πλάνο της κατοικίας.</p>
+          </article>
+          <article class="service-include reveal">
+            <div class="service-icon">03</div>
+            <h3>Ηλεκτρολογικές εργασίες</h3>
+            <p>Σχεδιάζουμε νέες γραμμές, πίνακες, φωτισμό και σημεία χρήσης, ώστε το σπίτι να εξυπηρετεί σύγχρονες ανάγκες με ασφάλεια και λειτουργικότητα.</p>
+          </article>
+          <article class="service-include reveal">
+            <div class="service-icon">04</div>
+            <h3>Δάπεδα / πλακάκια</h3>
+            <p>Τοποθετούμε νέα δάπεδα και πλακίδια που δένουν αισθητικά με το σύνολο της ανακαίνισης και προσφέρουν αντοχή στην καθημερινή χρήση.</p>
+          </article>
+          <article class="service-include reveal">
+            <div class="service-icon">05</div>
+            <h3>Βαψίματα / φινιρίσματα</h3>
+            <p>Ολοκληρώνουμε το έργο με προσεγμένα φινιρίσματα, σωστή προεργασία και τελικά χρώματα που αναδεικνύουν το νέο ύφος του χώρου.</p>
+          </article>
+          <article class="service-include reveal">
+            <div class="service-icon">06</div>
+            <h3>Κουζίνα / μπάνιο / κουφώματα</h3>
+            <p>Ενσωματώνουμε κομβικές αναβαθμίσεις σε κουζίνα, μπάνιο και κουφώματα ως μέρος της πλήρους μεταμόρφωσης της κατοικίας και όχι σαν μεμονωμένες εργασίες.</p>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section class="service-section" aria-labelledby="why-us-title">
+      <div class="container">
+        <div class="service-section__head reveal">
+          <span class="service-kicker">Γιατί FM Renovation</span>
+          <h2 id="why-us-title">Γιατί να μας επιλέξετε για ολική ανακαίνιση στην Αθήνα</h2>
+          <p>Δίνουμε έμφαση στην ποιότητα, στον συντονισμό των συνεργείων και στη συνέπεια που χρειάζεται μια σοβαρή ανακαίνιση σπιτιού στην Αθήνα.</p>
+        </div>
+        <div class="service-trust">
+          <article class="service-trust__card reveal">
+            <h3>Πιστοποιημένα υλικά</h3>
+            <p>Επιλέγουμε υλικά και συστήματα που ανταποκρίνονται στις απαιτήσεις ενός σύγχρονου έργου, με έμφαση στην αντοχή, την αισθητική και την αξιοπιστία.</p>
+          </article>
+          <article class="service-trust__card reveal">
+            <h3>Εξειδικευμένα συνεργεία</h3>
+            <p>Κάθε στάδιο της ολικής ανακαίνισης υλοποιείται από κατάλληλα συνεργεία που λειτουργούν συντονισμένα μέσα στο ίδιο project plan.</p>
+          </article>
+          <article class="service-trust__card reveal">
+            <h3>Συνέπεια στα χρονοδιαγράμματα</h3>
+            <p>Ορίζουμε σαφή βήματα και παρακολουθούμε την πρόοδο του έργου ώστε να διατηρείται έλεγχος σε χρόνο, ποιότητα και παραδοτέα.</p>
+          </article>
+          <article class="service-trust__card reveal">
+            <h3>Εξυπηρέτηση σε όλη την Αττική</h3>
+            <p>Αναλαμβάνουμε έργα σε κεντρικές και περιφερειακές περιοχές, με προσαρμογή στις πρακτικές ανάγκες κάθε κατοικίας.</p>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section class="service-section service-section--soft" aria-labelledby="areas-title">
+      <div class="container service-local">
+        <div class="service-local__copy reveal">
+          <span class="service-kicker">Local SEO</span>
+          <h2 id="areas-title">Ολική ανακαίνιση κατοικίας σε Αθήνα και σε όλη την Αττική</h2>
+          <p>Η FM Renovation εξυπηρετεί ιδιοκτήτες που αναζητούν ολική ανακαίνιση κατοικίας στην Αθήνα, αλλά και σε όλη την Αττική, με οργανωμένη διαδικασία και αξιόπιστη παρακολούθηση έργου. Καλύπτουμε περιοχές με διαφορετικές κατασκευαστικές απαιτήσεις, από παλαιότερα διαμερίσματα έως πιο σύγχρονες κατοικίες.</p>
+          <p>Αν χρειάζεστε <a class="service-link-inline" href="/anakainiseis-athina.html">ανακαίνιση σπιτιού στην Αθήνα</a> ή πλήρη αναβάθμιση κατοικίας σε γειτονιές της πόλης και των προαστίων, μπορούμε να οργανώσουμε το έργο σας με συνέπεια, σαφή προσφορά και ποιοτικό τελικό αποτέλεσμα.</p>
+        </div>
+        <div class="service-local__areas reveal" aria-label="Περιοχές εξυπηρέτησης στην Αττική">
+          <span class="service-area">Αθήνα</span>
+          <span class="service-area">Πειραιάς</span>
+          <span class="service-area">Γλυφάδα</span>
+          <span class="service-area">Νέα Σμύρνη</span>
+          <span class="service-area">Κηφισιά</span>
+          <span class="service-area">Μαρούσι</span>
+          <span class="service-area">Χαλάνδρι</span>
+          <span class="service-area">Περιστέρι</span>
+        </div>
+      </div>
+    </section>
+
+    <section class="service-section" aria-labelledby="process-title">
+      <div class="container">
+        <div class="service-section__head reveal">
+          <span class="service-kicker">Process</span>
+          <h2 id="process-title">Η διαδικασία συνεργασίας μας από την πρώτη επαφή έως την παράδοση</h2>
+          <p>Κάθε ολική ανακαίνιση ακολουθεί συγκεκριμένα στάδια, ώστε να υπάρχει σαφήνεια, σωστή κοστολόγηση και έλεγχος σε κάθε φάση του έργου.</p>
+        </div>
+        <div class="service-process">
+          <article class="service-step reveal">
+            <div class="service-step__num">1</div>
+            <h3>Επικοινωνία</h3>
+            <p>Λαμβάνουμε το αίτημά σας και συζητάμε τον τύπο κατοικίας, τις ανάγκες σας και τον στόχο της ανακαίνισης.</p>
+          </article>
+          <article class="service-step reveal">
+            <div class="service-step__num">2</div>
+            <h3>Αυτοψία / καταγραφή αναγκών</h3>
+            <p>Επισκεπτόμαστε τον χώρο για πλήρη αποτύπωση, τεχνικό έλεγχο και καταγραφή όλων των απαιτήσεων του έργου.</p>
+          </article>
+          <article class="service-step reveal">
+            <div class="service-step__num">3</div>
+            <h3>Αναλυτική προσφορά</h3>
+            <p>Σας παρουσιάζουμε δομημένη προσφορά με εργασίες, υλικά, στάδια υλοποίησης και εκτιμώμενο χρονοδιάγραμμα.</p>
+          </article>
+          <article class="service-step reveal">
+            <div class="service-step__num">4</div>
+            <h3>Υλοποίηση έργου</h3>
+            <p>Συντονίζουμε όλα τα συνεργεία και επιβλέπουμε την εξέλιξη της ανακαίνισης ώστε να διατηρείται η ποιότητα και η συνέπεια.</p>
+          </article>
+          <article class="service-step reveal">
+            <div class="service-step__num">5</div>
+            <h3>Παράδοση</h3>
+            <p>Παραδίδουμε την κατοικία ολοκληρωμένη, λειτουργική και έτοιμη για άμεση χρήση, με προσοχή στη λεπτομέρεια.</p>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section class="service-section service-section--soft" aria-labelledby="projects-title">
+      <div class="container service-projects">
+        <div class="service-projects__copy reveal">
+          <span class="service-kicker">Έργα μας</span>
+          <h2 id="projects-title">Δείτε πραγματικά έργα που αποτυπώνουν την ποιότητα της FM Renovation</h2>
+          <p>Αν θέλετε να δείτε πώς προσεγγίζουμε στην πράξη μια ανακαίνιση κατοικίας στην Αθήνα και την Αττική, περιηγηθείτε στη σελίδα με τα έργα μας και δείτε εικόνες από ολοκληρωμένες παρεμβάσεις.</p>
+          <div class="service-projects__actions">
+            <a href="/erga.html" class="btn btn--primary">Μετάβαση στο erga.html</a>
+            <a href="/contact.html" class="btn btn--ghost">Συζητήστε το έργο σας</a>
+          </div>
+        </div>
+        <figure class="service-projects__media reveal">
+          <img src="erga/ampelokipoi12.webp" width="1200" height="900" alt="Ολοκληρωμένο έργο ανακαίνισης κατοικίας της FM Renovation στην Αττική" loading="lazy" decoding="async">
+        </figure>
+      </div>
+    </section>
+
+    <section class="service-section" aria-labelledby="faq-title">
+      <div class="container">
+        <div class="service-section__head reveal">
+          <span class="service-kicker">FAQ</span>
+          <h2 id="faq-title">Συχνές ερωτήσεις για ολική ανακαίνιση κατοικίας στην Αθήνα</h2>
+        </div>
+        <div class="service-faq">
+          <details class="reveal" open>
+            <summary>Πόσο διαρκεί μια ολική ανακαίνιση;</summary>
+            <p>Η διάρκεια εξαρτάται από τα τετραγωνικά, την υφιστάμενη κατάσταση του ακινήτου και το εύρος των παρεμβάσεων. Μετά την αυτοψία μπορούμε να δώσουμε σαφές και ρεαλιστικό χρονοδιάγραμμα.</p>
+          </details>
+          <details class="reveal">
+            <summary>Πώς βγαίνει η προσφορά;</summary>
+            <p>Η προσφορά προκύπτει μετά από επικοινωνία, αυτοψία και αναλυτική καταγραφή αναγκών, ώστε να κοστολογηθούν σωστά οι εργασίες, τα υλικά και οι τεχνικές απαιτήσεις του έργου.</p>
+          </details>
+          <details class="reveal">
+            <summary>Αναλαμβάνετε μικρές και μεγάλες κατοικίες;</summary>
+            <p>Ναι, αναλαμβάνουμε τόσο μικρότερα διαμερίσματα όσο και μεγαλύτερες κατοικίες, οργανώνοντας την ολική ανακαίνιση ανάλογα με τη χρήση, τις ανάγκες και τον στόχο κάθε ιδιοκτήτη.</p>
+          </details>
+          <details class="reveal">
+            <summary>Εξυπηρετείτε όλη την Αττική;</summary>
+            <p>Βεβαίως. Εξυπηρετούμε έργα σε Αθήνα, Πειραιά, Γλυφάδα, Νέα Σμύρνη, Κηφισιά, Μαρούσι, Χαλάνδρι, Περιστέρι και σε ακόμη περισσότερες περιοχές της Αττικής.</p>
+          </details>
+          <details class="reveal">
+            <summary>Μπορώ να ζητήσω δωρεάν εκτίμηση;</summary>
+            <p>Ναι, μπορείτε να επικοινωνήσετε μαζί μας μέσω της σελίδας <a class="service-link-inline" href="/contact.html">επικοινωνίας</a> για μια δωρεάν πρώτη εκτίμηση και προγραμματισμό αυτοψίας.</p>
+          </details>
+        </div>
+      </div>
+    </section>
+
+    <section class="service-section">
+      <div class="container">
+        <div class="service-final__box reveal">
+          <span class="service-kicker" style="color:#fbbf24">Τελικό CTA</span>
+          <h2>Ξεκινήστε την ανακαίνιση του σπιτιού σας με σωστή οργάνωση από την πρώτη μέρα</h2>
+          <p>Αν σχεδιάζετε ολική ανακαίνιση κατοικίας στην Αθήνα ή σε οποιαδήποτε περιοχή της Αττικής, η ομάδα της FM Renovation είναι έτοιμη να οργανώσει το έργο σας με επαγγελματισμό, συνέπεια και δωρεάν αρχική εκτίμηση.</p>
+          <div class="service-final__actions">
+            <a href="contact.html" class="btn btn--primary">Μετάβαση στο contact.html</a>
+            <a href="/erga.html" class="btn btn--ghost-light">Δείτε έργα ανακαίνισης</a>
+          </div>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container footer-inner">
+      <div class="footer-contact">
+        <h3 class="footer-heading">Εξυπηρετούμε όλη την Αττική</h3>
+        <ul class="footer-list">
+          <li class="footer-list__item"><span class="footer-list__icon" aria-hidden="true"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M6.62 10.79a15.05 15.05 0 0 0 6.59 6.59l2.2-2.2a1 1 0 0 1 1.01-.24 11.36 11.36 0 0 0 3.56.57 1 1 0 0 1 1 1v3.52a1 1 0 0 1-1 1C10.29 21.03 3 13.74 3 4.02a1 1 0 0 1 1-1h3.52a1 1 0 0 1 1 1c0 1.22.2 2.43.57 3.56a1 1 0 0 1-.25 1.01l-2.2 2.2Z" fill="currentColor"/></svg></span><span><a href="tel:+302114044496">+30 211 404 4496</a></span></li>
+          <li class="footer-list__item"><span class="footer-list__icon" aria-hidden="true"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M6.62 10.79a15.05 15.05 0 0 0 6.59 6.59l2.2-2.2a1 1 0 0 1 1.01-.24 11.36 11.36 0 0 0 3.56.57 1 1 0 0 1 1 1v3.52a1 1 0 0 1-1 1C10.29 21.03 3 13.74 3 4.02a1 1 0 0 1 1-1h3.52a1 1 0 0 1 1 1c0 1.22.2 2.43.57 3.56a1 1 0 0 1-.25 1.01l-2.22 2.2Z" fill="currentColor"/></svg></span><span><a href="tel:+306939500950">+30 693 950 0950</a></span></li>
+          <li class="footer-list__item"><span class="footer-list__icon" aria-hidden="true"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M4 6c-1.1 0-2 .9-2 2v8c0 1.1.9 2 2 2h16a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2H4Zm0 2 8 5 8-5v-.01L12 13 4 7.99V8Z" fill="currentColor"/></svg></span><span><a href="mailto:fmren2021@gmail.com">fmren2021@gmail.com</a></span></li>
+          <li class="footer-list__item"><span class="footer-list__icon" aria-hidden="true"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M12 2a7 7 0 0 0-7 7c0 4.67 4.24 9.87 6.34 12.09a1 1 0 0 0 1.32 0C14.76 18.87 19 13.67 19 9a7 7 0 0 0-7-7Zm0 10a3 3 0 1 1 0-6 3 3 0 0 1 0 6Z" fill="currentColor"/></svg></span><span>Δοϊράνης 180, Καλλιθέα Τ.Κ. 17673</span></li>
+        </ul>
+      </div>
+      <div class="footer-brand">
+        <div class="brand brand--footer">
+          <a href="index.html" class="logo-link" aria-label="Αρχική σελίδα">
+            <img class="brand-logo" src="images/logo.webp" alt="FM Renovation Ανακαινίσεις Αθήνα" width="180" height="60">
+          </a>
+        </div>
+        <nav class="footer-links" aria-label="Χρήσιμες σύνδεσμοι">
+          <a href="terms.html">Όροι &amp; Προϋποθέσεις</a>
+          <a href="privacy-policy.html">Πολιτική Απορρήτου</a>
+          <a href="cookie-policy.html">Πολιτική Cookies</a>
+          <a href="/anakainiseis-athina.html">Ανακαινίσεις Αθήνα</a>
+        </nav>
+        <p class="footer-copy">© <span id="year"></span> FM Renovation • <a href="https://anakainisou.gr/">anakainisou.gr</a></p>
+      </div>
+      <div class="footer-social">
+        <h3 class="footer-heading">Ακολουθήστε μας</h3>
+        <div class="social">
+          <a href="https://www.facebook.com/share/1CJUXM8xkk/" aria-label="Facebook" class="icon fb" target="_blank" rel="noopener noreferrer"></a>
+          <a href="https://www.instagram.com/fm.renovation21/" aria-label="Instagram" class="icon ig" target="_blank" rel="noopener noreferrer"></a>
+        </div>
+        <p class="footer-hours">Δευ–Παρ: 08:00–16:00<br>Σάβ: 09:00–15:00<br>Κυρ: Κλειστά</p>
+      </div>
+    </div>
+  </footer>
+
+  <button id="backToTop" class="back-to-top" type="button" aria-label="Επιστροφή στην αρχή" title="Προς τα πάνω">
+    <span class="back-to-top__icon" aria-hidden="true"></span>
+  </button>
+
+  <div class="contact-widget" aria-label="Γρήγορη επικοινωνία">
+    <div id="contactWidgetPanel" class="contact-widget__panel" aria-hidden="true">
+      <a class="contact-widget__link" href="mailto:fmren2021@gmail.com"><span class="contact-widget__icon" aria-hidden="true"><img src="images/icons/email.svg" width="36" height="36" alt="" loading="lazy"></span><span>Email</span></a>
+      <a class="contact-widget__link" href="viber://chat?number=+306939500950"><span class="contact-widget__icon" aria-hidden="true"><img src="images/icons/viber.svg" width="36" height="36" alt="" loading="lazy"></span><span>Viber</span></a>
+    </div>
+    <button class="contact-widget__toggle" type="button" aria-expanded="false" aria-controls="contactWidgetPanel" aria-label="Άνοιγμα επιλογών επικοινωνίας">
+      <svg aria-hidden="true" width="28" height="28" viewBox="0 0 24 24" fill="none"><path d="M12 3C7.03 3 3 6.58 3 11c0 2.35 1.16 4.47 3 5.96V21l3.07-1.64c.96.27 1.99.42 3.08.42 4.97 0 9-3.58 9-8s-4.03-8-9-8Zm-.14 11.91h-.02c-.31 0-.6-.03-.88-.08-.76.52-1.6.95-2.49 1.26.47-.69.76-1.32.88-1.94-1.11-.74-1.81-1.82-1.81-3.05 0-2.22 2.09-4.02 4.67-4.02s4.67 1.8 4.67 4.02-2.09 4.03-4.66 4.03Z" fill="currentColor"/></svg>
+      <span class="visually-hidden">Contact</span>
+    </button>
+  </div>
+
+  <div class="cookie-banner" id="cookieBanner">
+    <div class="cookie-banner__inner">
+      <p class="cookie-banner__text">Χρησιμοποιούμε cookies για να βελτιώσουμε την εμπειρία σας. Συνεχίζοντας αποδέχεστε τη χρήση τους. <a href="/cookie-policy.html" class="cookie-banner__link">Μάθετε περισσότερα</a>.</p>
+      <div class="cookie-banner__actions">
+        <button type="button" class="cookie-banner__btn cookie-banner__btn--secondary" id="cookieReject">Μόνο τα απαραίτητα</button>
+        <button type="button" class="cookie-banner__btn cookie-banner__btn--primary" id="cookieAccept">Αποδοχή</button>
+      </div>
+    </div>
+  </div>
+
+  <script>
+  (function(){
+    const banner = document.getElementById('cookieBanner');
+    const accept = document.getElementById('cookieAccept');
+    const reject = document.getElementById('cookieReject');
+    if (!banner || !accept || !reject) return;
+    if (!localStorage.getItem('cookieConsent')) {
+      banner.style.display = 'block';
+    }
+    accept.addEventListener('click', () => {
+      localStorage.setItem('cookieConsent', 'accepted');
+      banner.style.display = 'none';
+    });
+    reject.addEventListener('click', () => {
+      localStorage.setItem('cookieConsent', 'minimal');
+      banner.style.display = 'none';
+    });
+  })();
+  </script>
+  <script src="assets/app.js" defer></script>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Provide a new standalone, conversion-focused service landing page targeting “ολική ανακαίνιση κατοικίας Αθήνα”, “ανακαίνιση σπιτιού Αθήνα” and “ολική ανακαίνιση Αττική”.
- Keep visual and functional parity with the existing site by reusing shared header, mobile menu, footer, cookie banner and contact widget without changing global assets or other pages.
- Improve local SEO and SERP visibility with dedicated metadata, Open Graph/Twitter tags and structured data for the service and business area.

### Description
- Added a new standalone file `anakainisi-spitiou-athina.html` containing a premium responsive layout with a small/medium hero (local image preload, no lazy loading for above-the-fold image), intro, “what is included” cards, trust points, local SEO areas, process steps, projects CTA, FAQ (5 Q/A) and final conversion CTA. 
- Integrated SEO elements including `title`, `meta description`, `canonical`, Open Graph tags, Twitter card, a single `H1`, and JSON-LD for `HomeAndConstructionBusiness`, `Service` and `FAQPage` with `areaServed` for Athens/Attica. 
- Kept site conventions by reusing the shared header, mobile menu, footer, contact widget and cookie banner, and added internal links to `/`, `/anakainiseis-athina.html`, `/erga.html` and `/contact.html` in CTAs and body copy. 
- Only page-scoped CSS was added inside the file for layout/styling specific to this landing page and no global CSS or other pages were modified.

### Testing
- Ran a Python check that confirmed a single `H1` and the presence of required SEO markers (`canonical`, `og:title`, `og:description`, `og:type`, `og:url`, `og:image`, `twitter:card`, `application/ld+json`) and the internal links, and the check succeeded. 
- Performed a content/structure inspection of the generated HTML to ensure all sections (hero, includes, trust, local areas, process, projects CTA, FAQ, final CTA) were present and used shared components successfully. 
- No browser/screenshot tool was available in the environment, so visual QA via rendered screenshots was not performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c030e338a483208243c268f0f1b030)