### PR TITLE
Unify shared header/nav on service pages and improve desktop “Ανακαινίσεις” dropdown UX

### DIFF
--- a/anakainisi-kouzinas-athina.html
+++ b/anakainisi-kouzinas-athina.html
@@ -219,6 +219,18 @@
         <ul class="nav__list">
           <li class="nav__item"><a href="#" class="nav__link" data-home rel="home">Αρχική</a></li>
           <li class="nav__item"><a href="index.html#services" class="nav__link">Υπηρεσίες</a></li>
+          <li class="nav__item nav__item--dropdown" data-dropdown>
+            <div class="nav__dropdown-trigger" data-dropdown-trigger>
+              <a href="anakainiseis-athina.html" class="nav__link" data-dropdown-link>Ανακαινίσεις</a>
+              <button class="nav__dropdown-toggle" type="button" aria-expanded="false" aria-label="Άνοιγμα υπομενού Ανακαινίσεις" data-dropdown-toggle>
+                <span class="nav__dropdown-caret" aria-hidden="true"></span>
+              </button>
+            </div>
+            <div class="nav__dropdown-panel" data-dropdown-panel>
+              <a href="anakainisi-spitiou-athina.html" class="nav__dropdown-link">Ολική Ανακαίνιση</a>
+              <a href="anakainisi-kouzinas-athina.html" class="nav__dropdown-link">Ανακαίνιση Κουζίνας</a>
+            </div>
+          </li>
           <li class="nav__item nav__item--projects"><a href="erga.html" class="nav__link">Έργα μας</a></li>
           <li class="nav__item"><a href="contact.html" class="nav__link">Επικοινωνία</a></li>
           <li class="nav__item nav__item--cta"><a href="index.html#contact" class="btn btn--sm nav-cta">Ζητήστε Προσφορά</a></li>
@@ -245,6 +257,16 @@
         <ul class="nav-mobile__list">
           <li class="nav-mobile__item"><a href="#" class="nav-mobile__link" data-home rel="home">Αρχική</a></li>
           <li class="nav-mobile__item"><a href="index.html#services" class="nav-mobile__link">Υπηρεσίες</a></li>
+          <li class="nav-mobile__item nav-mobile__item--submenu" data-mobile-submenu>
+            <button class="nav-mobile__link nav-mobile__toggle" type="button" aria-expanded="false" aria-label="Άνοιγμα υπομενού Ανακαινίσεις" data-mobile-submenu-toggle>
+              <span>Ανακαινίσεις</span>
+              <span class="nav-mobile__caret" aria-hidden="true"></span>
+            </button>
+            <div class="nav-mobile__submenu" data-mobile-submenu-panel hidden>
+              <a href="anakainisi-spitiou-athina.html" class="nav-mobile__sublink">Ολική Ανακαίνιση</a>
+              <a href="anakainisi-kouzinas-athina.html" class="nav-mobile__sublink">Ανακαίνιση Κουζίνας</a>
+            </div>
+          </li>
           <li class="nav-mobile__item nav-mobile__item--projects"><a href="erga.html" class="nav-mobile__link">Έργα μας</a></li>
           <li class="nav-mobile__item"><a href="contact.html" class="nav-mobile__link">Επικοινωνία</a></li>
           <li class="nav-mobile__item nav-mobile__item--cta"><a href="index.html#contact" class="btn btn--primary nav-mobile__cta">Ζητήστε Προσφορά</a></li>

--- a/anakainisi-spitiou-athina.html
+++ b/anakainisi-spitiou-athina.html
@@ -571,9 +571,21 @@
         <ul class="nav__list">
           <li class="nav__item"><a href="#" class="nav__link" data-home rel="home">Αρχική</a></li>
           <li class="nav__item"><a href="index.html#services" class="nav__link">Υπηρεσίες</a></li>
+          <li class="nav__item nav__item--dropdown" data-dropdown>
+            <div class="nav__dropdown-trigger" data-dropdown-trigger>
+              <a href="anakainiseis-athina.html" class="nav__link" data-dropdown-link>Ανακαινίσεις</a>
+              <button class="nav__dropdown-toggle" type="button" aria-expanded="false" aria-label="Άνοιγμα υπομενού Ανακαινίσεις" data-dropdown-toggle>
+                <span class="nav__dropdown-caret" aria-hidden="true"></span>
+              </button>
+            </div>
+            <div class="nav__dropdown-panel" data-dropdown-panel>
+              <a href="anakainisi-spitiou-athina.html" class="nav__dropdown-link">Ολική Ανακαίνιση</a>
+              <a href="anakainisi-kouzinas-athina.html" class="nav__dropdown-link">Ανακαίνιση Κουζίνας</a>
+            </div>
+          </li>
           <li class="nav__item nav__item--projects"><a href="erga.html" class="nav__link">Έργα μας</a></li>
           <li class="nav__item"><a href="contact.html" class="nav__link">Επικοινωνία</a></li>
-          <li class="nav__item nav__item--cta"><a href="contact.html" class="btn btn--sm nav-cta">Ζητήστε Προσφορά</a></li>
+          <li class="nav__item nav__item--cta"><a href="index.html#contact" class="btn btn--sm nav-cta">Ζητήστε Προσφορά</a></li>
         </ul>
       </nav>
       <div class="social">
@@ -597,9 +609,19 @@
         <ul class="nav-mobile__list">
           <li class="nav-mobile__item"><a href="#" class="nav-mobile__link" data-home rel="home">Αρχική</a></li>
           <li class="nav-mobile__item"><a href="index.html#services" class="nav-mobile__link">Υπηρεσίες</a></li>
+          <li class="nav-mobile__item nav-mobile__item--submenu" data-mobile-submenu>
+            <button class="nav-mobile__link nav-mobile__toggle" type="button" aria-expanded="false" aria-label="Άνοιγμα υπομενού Ανακαινίσεις" data-mobile-submenu-toggle>
+              <span>Ανακαινίσεις</span>
+              <span class="nav-mobile__caret" aria-hidden="true"></span>
+            </button>
+            <div class="nav-mobile__submenu" data-mobile-submenu-panel hidden>
+              <a href="anakainisi-spitiou-athina.html" class="nav-mobile__sublink">Ολική Ανακαίνιση</a>
+              <a href="anakainisi-kouzinas-athina.html" class="nav-mobile__sublink">Ανακαίνιση Κουζίνας</a>
+            </div>
+          </li>
           <li class="nav-mobile__item nav-mobile__item--projects"><a href="erga.html" class="nav-mobile__link">Έργα μας</a></li>
           <li class="nav-mobile__item"><a href="contact.html" class="nav-mobile__link">Επικοινωνία</a></li>
-          <li class="nav-mobile__item nav-mobile__item--cta"><a href="contact.html" class="btn btn--primary nav-mobile__cta">Ζητήστε Προσφορά</a></li>
+          <li class="nav-mobile__item nav-mobile__item--cta"><a href="index.html#contact" class="btn btn--primary nav-mobile__cta">Ζητήστε Προσφορά</a></li>
         </ul>
       </nav>
       <div class="nav-overlay__social">

--- a/assets/app.js
+++ b/assets/app.js
@@ -181,16 +181,53 @@ if(navToggle&&navOverlay&&navBackdrop){
   }
 }
 
+function setDesktopDropdownState(dropdown, shouldOpen){
+  if(!dropdown){return;}
+  dropdown.classList.toggle('is-open', shouldOpen);
+  const toggle=dropdown.querySelector('[data-dropdown-toggle]');
+  if(toggle){toggle.setAttribute('aria-expanded',String(shouldOpen));}
+}
+
 desktopDropdowns.forEach(function(dropdown){
   const toggle=dropdown.querySelector('[data-dropdown-toggle]');
+  const trigger=dropdown.querySelector('[data-dropdown-trigger]')||dropdown.querySelector('.nav__dropdown-trigger');
+  const parentLink=dropdown.querySelector('[data-dropdown-link]')||dropdown.querySelector('.nav__dropdown-trigger .nav__link');
   if(!toggle){return;}
+
+  const openDropdown=function(){
+    closeDesktopDropdowns(dropdown);
+    setDesktopDropdownState(dropdown,true);
+  };
+
+  const toggleDropdown=function(){
+    const isOpen=dropdown.classList.contains('is-open');
+    closeDesktopDropdowns(isOpen?null:dropdown);
+    setDesktopDropdownState(dropdown,!isOpen);
+  };
+
+  if(trigger){
+    trigger.addEventListener('mouseenter',function(){
+      if(!desktopMedia.matches){return;}
+      openDropdown();
+    });
+  }
+
+  if(parentLink){
+    parentLink.addEventListener('click',function(event){
+      if(!desktopMedia.matches){return;}
+      const isOpen=dropdown.classList.contains('is-open');
+      if(!isOpen){
+        event.preventDefault();
+        event.stopPropagation();
+        openDropdown();
+      }
+    });
+  }
+
   toggle.addEventListener('click',function(event){
     event.preventDefault();
     event.stopPropagation();
-    const isOpen=dropdown.classList.contains('is-open');
-    closeDesktopDropdowns(isOpen?null:dropdown);
-    dropdown.classList.toggle('is-open',!isOpen);
-    toggle.setAttribute('aria-expanded',String(!isOpen));
+    toggleDropdown();
   });
 });
 

--- a/assets/style.css
+++ b/assets/style.css
@@ -45,11 +45,12 @@ img{max-width:100%;height:auto;display:block}
 .nav__link:focus-visible{opacity:1;color:var(--accent);outline:none}
 .nav__item--cta{margin-left:6px}
 .nav__item--dropdown{position:relative}
-.nav__dropdown-trigger{display:flex;align-items:center;gap:4px}
-.nav__dropdown-toggle{display:inline-flex;align-items:center;justify-content:center;width:30px;height:30px;padding:0;border:0;border-radius:999px;background:transparent;color:var(--text);cursor:pointer;transition:color .2s ease,background .2s ease,transform .2s ease}
+.nav__dropdown-trigger{position:relative;display:flex;align-items:center;gap:4px;padding:4px 8px 12px;margin:-4px -8px -12px;border-radius:999px}
+.nav__dropdown-trigger::after{content:"";position:absolute;left:0;right:0;top:100%;height:18px}
+.nav__dropdown-toggle{display:inline-flex;align-items:center;justify-content:center;width:34px;height:34px;padding:0;border:0;border-radius:999px;background:transparent;color:var(--text);cursor:pointer;transition:color .2s ease,background .2s ease,transform .2s ease}
 .nav__dropdown-toggle:hover,.nav__dropdown-toggle:focus-visible{background:rgba(15,23,42,.06);color:var(--accent);outline:none}
 .nav__dropdown-caret,.nav-mobile__caret{display:inline-block;width:9px;height:9px;border-right:1.8px solid currentColor;border-bottom:1.8px solid currentColor;transform:rotate(45deg);transform-origin:center;transition:transform .2s ease}
-.nav__dropdown-panel{position:absolute;top:calc(100% + 14px);left:0;min-width:240px;padding:10px;background:rgba(255,255,255,.98);border:1px solid rgba(15,23,42,.08);border-radius:18px;box-shadow:0 20px 40px rgba(15,23,42,.14);display:grid;gap:4px;opacity:0;visibility:hidden;pointer-events:none;transform:translateY(8px);transition:opacity .2s ease,transform .2s ease,visibility .2s ease}
+.nav__dropdown-panel{position:absolute;top:calc(100% + 8px);left:0;min-width:240px;padding:10px;background:rgba(255,255,255,.98);border:1px solid rgba(15,23,42,.08);border-radius:18px;box-shadow:0 20px 40px rgba(15,23,42,.14);display:grid;gap:4px;opacity:0;visibility:hidden;pointer-events:none;transform:translateY(8px);transition:opacity .2s ease,transform .2s ease,visibility .2s ease}
 .nav__dropdown-panel::before{content:"";position:absolute;left:24px;top:-8px;width:16px;height:16px;background:inherit;border-left:1px solid rgba(15,23,42,.08);border-top:1px solid rgba(15,23,42,.08);transform:rotate(45deg)}
 .nav__dropdown-link{display:block;padding:12px 14px;border-radius:12px;text-decoration:none;font-weight:500;color:var(--text);transition:background .2s ease,color .2s ease}
 .nav__dropdown-link:hover,.nav__dropdown-link:focus-visible{background:rgba(15,23,42,.05);color:var(--accent);outline:none}


### PR DESCRIPTION
### Motivation
- Ensure the two new service pages use the same shared header/nav/dropdown markup and mobile submenu behavior as the rest of the site so navigation is consistent.
- Improve desktop usability of the "Ανακαινίσεις" dropdown so users can open the submenu from the parent label/area (hover or click) instead of having to click only the small caret.

### Description
- Added the shared desktop dropdown markup and mobile submenu block to `anakainisi-spitiou-athina.html` and `anakainisi-kouzinas-athina.html`, and normalized the CTA target in their headers to `index.html#contact` so the header matches other pages.
- Enhanced desktop dropdown JS in `assets/app.js` by introducing `setDesktopDropdownState`, expanding the trigger area, wiring the parent label/link to open the dropdown on desktop (hover on the trigger and click on the parent label when the menu is closed), and centralizing toggle logic to avoid racey states.
- Tweaked `assets/style.css` to slightly increase the dropdown trigger hit area, add a small hover bridge under the trigger, and reduce the vertical gap before the dropdown panel to make the submenu less likely to collapse when moving the pointer to submenu links.
- Kept mobile toggle behavior and visual styling intact; changes are targeted to interaction areas and small spacing adjustments only.

### Testing
- Ran `node --check assets/app.js` to validate JS syntax and it completed successfully.
- Ran automated presence checks that confirmed each updated service page contains the desktop dropdown block, mobile submenu block, and the normalized CTA href (`index.html#contact`), and those checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c03c4066648320886e834ebe0f4b53)