### PR TITLE
Update CTA links to point to /contact.html

### DIFF
--- a/anakainiseis-athina.html
+++ b/anakainiseis-athina.html
@@ -237,7 +237,7 @@
           </li>
           <li class="nav__item nav__item--projects"><a href="erga.html" class="nav__link">Έργα μας</a></li>
           <li class="nav__item"><a href="contact.html" class="nav__link">Επικοινωνία</a></li>
-          <li class="nav__item nav__item--cta"><a href="index.html#contact" class="btn btn--sm nav-cta">Ζητήστε Προσφορά</a></li>
+          <li class="nav__item nav__item--cta"><a href="/contact.html" class="btn btn--sm nav-cta">Ζητήστε Προσφορά</a></li>
         </ul>
       </nav>
       <div class="social">
@@ -273,7 +273,7 @@
           </li>
           <li class="nav-mobile__item nav-mobile__item--projects"><a href="erga.html" class="nav-mobile__link">Έργα μας</a></li>
           <li class="nav-mobile__item"><a href="contact.html" class="nav-mobile__link">Επικοινωνία</a></li>
-          <li class="nav-mobile__item nav-mobile__item--cta"><a href="index.html#contact" class="btn btn--primary nav-mobile__cta">Ζητήστε Προσφορά</a></li>
+          <li class="nav-mobile__item nav-mobile__item--cta"><a href="/contact.html" class="btn btn--primary nav-mobile__cta">Ζητήστε Προσφορά</a></li>
         </ul>
       </nav>
       <div class="nav-overlay__social">
@@ -300,7 +300,7 @@
         <h1 id="athens-hero-title">Ανακαινίσεις στην Αθήνα με συνέπεια, ασφάλεια και ποιοτικά υλικά</h1>
         <p>Αναλαμβάνουμε ανακαίνιση σπιτιού στην Αθήνα, ολικές και μερικές παρεμβάσεις, με σωστό συντονισμό συνεργείων, καθαρή κοστολόγηση και αποτέλεσμα που αναβαθμίζει ουσιαστικά την αξία και τη λειτουργικότητα του χώρου σας.</p>
         <div class="athens-hero__actions">
-          <a href="index.html#contact" class="btn btn--primary">Ζητήστε Προσφορά</a>
+          <a href="/contact.html" class="btn btn--primary">Ζητήστε Προσφορά</a>
           <a href="erga.html" class="btn btn--ghost">Δείτε τα έργα μας</a>
         </div>
       </div>
@@ -480,7 +480,7 @@
           <h2>Συζητήστε το έργο σας με μια ομάδα που γνωρίζει τις ανακαινίσεις στην Αθήνα</h2>
           <p>Αν θέλετε σοβαρή προσέγγιση, τεχνική καθοδήγηση και καθαρό πλάνο για το ακίνητό σας, επικοινωνήστε μαζί μας για δωρεάν εκτίμηση. Θα σας προτείνουμε λύσεις που συνδυάζουν αισθητική, πρακτικότητα και σωστή επένδυση.</p>
           <div class="athens-final__actions">
-            <a href="index.html#contact" class="btn btn--primary">Μετάβαση στην επικοινωνία</a>
+            <a href="/contact.html" class="btn btn--primary">Μετάβαση στην επικοινωνία</a>
             <a href="contact.html" class="btn btn--ghost">Επικοινωνήστε μαζί μας</a>
             <a href="tel:+302114044496" class="btn btn--ghost">Καλέστε μας τώρα</a>
           </div>

--- a/anakainisi-kouzinas-athina.html
+++ b/anakainisi-kouzinas-athina.html
@@ -233,7 +233,7 @@
           </li>
           <li class="nav__item nav__item--projects"><a href="erga.html" class="nav__link">Έργα μας</a></li>
           <li class="nav__item"><a href="contact.html" class="nav__link">Επικοινωνία</a></li>
-          <li class="nav__item nav__item--cta"><a href="index.html#contact" class="btn btn--sm nav-cta">Ζητήστε Προσφορά</a></li>
+          <li class="nav__item nav__item--cta"><a href="/contact.html" class="btn btn--sm nav-cta">Ζητήστε Προσφορά</a></li>
         </ul>
       </nav>
       <div class="social">
@@ -269,7 +269,7 @@
           </li>
           <li class="nav-mobile__item nav-mobile__item--projects"><a href="erga.html" class="nav-mobile__link">Έργα μας</a></li>
           <li class="nav-mobile__item"><a href="contact.html" class="nav-mobile__link">Επικοινωνία</a></li>
-          <li class="nav-mobile__item nav-mobile__item--cta"><a href="index.html#contact" class="btn btn--primary nav-mobile__cta">Ζητήστε Προσφορά</a></li>
+          <li class="nav-mobile__item nav-mobile__item--cta"><a href="/contact.html" class="btn btn--primary nav-mobile__cta">Ζητήστε Προσφορά</a></li>
         </ul>
       </nav>
       <div class="nav-overlay__social">

--- a/anakainisi-spitiou-athina.html
+++ b/anakainisi-spitiou-athina.html
@@ -585,7 +585,7 @@
           </li>
           <li class="nav__item nav__item--projects"><a href="erga.html" class="nav__link">Έργα μας</a></li>
           <li class="nav__item"><a href="contact.html" class="nav__link">Επικοινωνία</a></li>
-          <li class="nav__item nav__item--cta"><a href="index.html#contact" class="btn btn--sm nav-cta">Ζητήστε Προσφορά</a></li>
+          <li class="nav__item nav__item--cta"><a href="/contact.html" class="btn btn--sm nav-cta">Ζητήστε Προσφορά</a></li>
         </ul>
       </nav>
       <div class="social">
@@ -621,7 +621,7 @@
           </li>
           <li class="nav-mobile__item nav-mobile__item--projects"><a href="erga.html" class="nav-mobile__link">Έργα μας</a></li>
           <li class="nav-mobile__item"><a href="contact.html" class="nav-mobile__link">Επικοινωνία</a></li>
-          <li class="nav-mobile__item nav-mobile__item--cta"><a href="index.html#contact" class="btn btn--primary nav-mobile__cta">Ζητήστε Προσφορά</a></li>
+          <li class="nav-mobile__item nav-mobile__item--cta"><a href="/contact.html" class="btn btn--primary nav-mobile__cta">Ζητήστε Προσφορά</a></li>
         </ul>
       </nav>
       <div class="nav-overlay__social">

--- a/contact.html
+++ b/contact.html
@@ -239,7 +239,7 @@
           </li>
           <li class="nav__item nav__item--projects"><a href="erga.html" class="nav__link">Έργα μας</a></li>
           <li class="nav__item"><a href="contact.html" class="nav__link">Επικοινωνία</a></li>
-          <li class="nav__item nav__item--cta"><a href="index.html#contact" class="btn btn--sm nav-cta">Ζητήστε Προσφορά</a></li>
+          <li class="nav__item nav__item--cta"><a href="/contact.html" class="btn btn--sm nav-cta">Ζητήστε Προσφορά</a></li>
         </ul>
       </nav>
       <div class="social">
@@ -275,7 +275,7 @@
           </li>
           <li class="nav-mobile__item nav-mobile__item--projects"><a href="erga.html" class="nav-mobile__link">Έργα μας</a></li>
           <li class="nav-mobile__item"><a href="contact.html" class="nav-mobile__link">Επικοινωνία</a></li>
-          <li class="nav-mobile__item nav-mobile__item--cta"><a href="index.html#contact" class="btn btn--primary nav-mobile__cta">Ζητήστε Προσφορά</a></li>
+          <li class="nav-mobile__item nav-mobile__item--cta"><a href="/contact.html" class="btn btn--primary nav-mobile__cta">Ζητήστε Προσφορά</a></li>
         </ul>
       </nav>
       <div class="nav-overlay__social">

--- a/cookie-policy.html
+++ b/cookie-policy.html
@@ -55,7 +55,7 @@
           </li>
           <li class="nav__item nav__item--projects"><a href="erga.html" class="nav__link">Έργα</a></li>
           <li class="nav__item"><a href="/index.html#gallery" class="nav__link">Gallery</a></li>
-          <li class="nav__item nav__item--cta"><a href="/index.html#contact" class="btn btn--sm nav-cta">Ζητήστε Προσφορά</a></li>
+          <li class="nav__item nav__item--cta"><a href="/contact.html" class="btn btn--sm nav-cta">Ζητήστε Προσφορά</a></li>
         </ul>
       </nav>
       <div class="social">

--- a/erga.html
+++ b/erga.html
@@ -58,7 +58,7 @@
           </li>
           <li class="nav__item nav__item--projects"><a href="erga.html" class="nav__link">Έργα μας</a></li>
           <li class="nav__item"><a href="contact.html" class="nav__link">Επικοινωνία</a></li>
-          <li class="nav__item nav__item--cta"><a href="index.html#contact" class="btn btn--sm nav-cta">Ζητήστε Προσφορά</a></li>
+          <li class="nav__item nav__item--cta"><a href="/contact.html" class="btn btn--sm nav-cta">Ζητήστε Προσφορά</a></li>
         </ul>
       </nav>
       <div class="social">
@@ -94,7 +94,7 @@
           </li>
           <li class="nav-mobile__item nav-mobile__item--projects"><a href="erga.html" class="nav-mobile__link">Έργα μας</a></li>
           <li class="nav-mobile__item"><a href="contact.html" class="nav-mobile__link">Επικοινωνία</a></li>
-          <li class="nav-mobile__item nav-mobile__item--cta"><a href="index.html#contact" class="btn btn--primary nav-mobile__cta">Ζητήστε Προσφορά</a></li>
+          <li class="nav-mobile__item nav-mobile__item--cta"><a href="/contact.html" class="btn btn--primary nav-mobile__cta">Ζητήστε Προσφορά</a></li>
         </ul>
       </nav>
       <div class="nav-overlay__social">
@@ -108,7 +108,7 @@
     <h1>Έργα Ανακαινίσεων</h1>
     <p>Ενδεικτικά projects με καθαρές φωτογραφίες, συνοπτικές πληροφορίες και πρόσβαση σε ολόκληρο το φωτογραφικό υλικό.</p>
     <div class="page-hero__actions">
-      <a href="index.html#contact" class="btn btn--primary page-hero__cta">Ζητήστε Προσφορά</a>
+      <a href="/contact.html" class="btn btn--primary page-hero__cta">Ζητήστε Προσφορά</a>
     </div>
   </header>
 

--- a/index.html
+++ b/index.html
@@ -121,7 +121,7 @@
           </li>
           <li class="nav__item nav__item--projects"><a href="erga.html" class="nav__link">Έργα μας</a></li>
           <li class="nav__item"><a href="contact.html" class="nav__link">Επικοινωνία</a></li>
-          <li class="nav__item nav__item--cta"><a href="#contact" class="btn btn--sm nav-cta">Ζητήστε Προσφορά</a></li>
+          <li class="nav__item nav__item--cta"><a href="/contact.html" class="btn btn--sm nav-cta">Ζητήστε Προσφορά</a></li>
         </ul>
       </nav>
       <div class="social">
@@ -157,7 +157,7 @@
           </li>
           <li class="nav-mobile__item nav-mobile__item--projects"><a href="erga.html" class="nav-mobile__link">Έργα μας</a></li>
           <li class="nav-mobile__item"><a href="contact.html" class="nav-mobile__link">Επικοινωνία</a></li>
-          <li class="nav-mobile__item nav-mobile__item--cta"><a href="#contact" class="btn btn--primary nav-mobile__cta">Ζητήστε Προσφορά</a></li>
+          <li class="nav-mobile__item nav-mobile__item--cta"><a href="/contact.html" class="btn btn--primary nav-mobile__cta">Ζητήστε Προσφορά</a></li>
         </ul>
       </nav>
       <div class="nav-overlay__social">
@@ -318,7 +318,7 @@
       </div>
 
       <div class="section-cta">
-        <a href="#contact" class="btn btn--primary">Ζητήστε Προσφορά</a>
+        <a href="/contact.html" class="btn btn--primary">Ζητήστε Προσφορά</a>
         <a href="/anakainiseis-athina.html" class="btn">Ανακαινίσεις στην Αθήνα</a>
         <a href="contact.html" class="btn">Επικοινωνία</a>
       </div>
@@ -380,7 +380,7 @@
         </div>
 
         <div class="section-cta">
-          <a href="#contact" class="btn btn--primary">Ζητήστε Προσφορά</a>
+          <a href="/contact.html" class="btn btn--primary">Ζητήστε Προσφορά</a>
         </div>
       </div>
     </section>
@@ -410,7 +410,7 @@
         </div>
 
         <div class="section-cta">
-          <a href="#contact" class="btn btn--primary">Ζητήστε Προσφορά</a>
+          <a href="/contact.html" class="btn btn--primary">Ζητήστε Προσφορά</a>
         </div>
       </div>
     </section>
@@ -454,7 +454,7 @@
           <article class="t-card"><p>“Ζήτησα προτάσεις για φωτισμό και αποθήκευση σε μικρό διαμέρισμα.<br>Μας έστειλαν 3D σχέδια, προσαρμόστηκαν στις ιδιαιτερότητές μας και το αποτέλεσμα είναι τόσο λειτουργικό όσο όμορφο.”</p><span>— Α. Ν., Παγκράτι</span></article>
           <article class="t-card"><p>“Είχαμε κακή εμπειρία με άλλες συνεργασίες και ήμασταν επιφυλακτικοί.<br>Η FM Renovation τήρησε κάθε υπόσχεση, πρόσεξε τα τελευταία φινιρίσματα και ακόμα μετά την παράδοση ρώτησαν αν όλα λειτουργούν σωστά.”</p><span>— Σ. Φ., Νέα Σμύρνη</span></article>
         </div>
-        <div class="under-cta"><a href="#contact" class="btn btn--primary">Ζητήστε κι εσείς προσφορά</a></div>
+        <div class="under-cta"><a href="/contact.html" class="btn btn--primary">Ζητήστε κι εσείς προσφορά</a></div>
       </div>
     </section>
 

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -43,7 +43,7 @@
           <li class="nav__item"><a href="/index.html#process" class="nav__link">Πώς Λειτουργούμε</a></li>
           <li class="nav__item nav__item--projects"><a href="erga.html" class="nav__link">Έργα</a></li>
           <li class="nav__item"><a href="/index.html#gallery" class="nav__link">Gallery</a></li>
-          <li class="nav__item nav__item--cta"><a href="/index.html#contact" class="btn btn--sm nav-cta">Ζητήστε Προσφορά</a></li>
+          <li class="nav__item nav__item--cta"><a href="/contact.html" class="btn btn--sm nav-cta">Ζητήστε Προσφορά</a></li>
         </ul>
       </nav>
       <div class="social">
@@ -70,7 +70,7 @@
           <li class="nav-mobile__item"><a href="/index.html#process" class="nav-mobile__link">Πώς Λειτουργούμε</a></li>
           <li class="nav-mobile__item nav-mobile__item--projects"><a href="erga.html" class="nav-mobile__link">Έργα</a></li>
           <li class="nav-mobile__item"><a href="/index.html#gallery" class="nav-mobile__link">Gallery</a></li>
-          <li class="nav-mobile__item nav-mobile__item--cta"><a href="/index.html#contact" class="btn btn--primary nav-mobile__cta">Ζητήστε Προσφορά</a></li>
+          <li class="nav-mobile__item nav-mobile__item--cta"><a href="/contact.html" class="btn btn--primary nav-mobile__cta">Ζητήστε Προσφορά</a></li>
         </ul>
       </nav>
       <div class="nav-overlay__social">

--- a/terms.html
+++ b/terms.html
@@ -43,7 +43,7 @@
           <li class="nav__item"><a href="/index.html#process" class="nav__link">Πώς Λειτουργούμε</a></li>
           <li class="nav__item nav__item--projects"><a href="erga.html" class="nav__link">Έργα</a></li>
           <li class="nav__item"><a href="/index.html#gallery" class="nav__link">Gallery</a></li>
-          <li class="nav__item nav__item--cta"><a href="/index.html#contact" class="btn btn--sm nav-cta">Ζητήστε Προσφορά</a></li>
+          <li class="nav__item nav__item--cta"><a href="/contact.html" class="btn btn--sm nav-cta">Ζητήστε Προσφορά</a></li>
         </ul>
       </nav>
       <div class="social">
@@ -70,7 +70,7 @@
           <li class="nav-mobile__item"><a href="/index.html#process" class="nav-mobile__link">Πώς Λειτουργούμε</a></li>
           <li class="nav-mobile__item nav-mobile__item--projects"><a href="erga.html" class="nav-mobile__link">Έργα</a></li>
           <li class="nav-mobile__item"><a href="/index.html#gallery" class="nav-mobile__link">Gallery</a></li>
-          <li class="nav-mobile__item nav-mobile__item--cta"><a href="/index.html#contact" class="btn btn--primary nav-mobile__cta">Ζητήστε Προσφορά</a></li>
+          <li class="nav-mobile__item nav-mobile__item--cta"><a href="/contact.html" class="btn btn--primary nav-mobile__cta">Ζητήστε Προσφορά</a></li>
         </ul>
       </nav>
       <div class="nav-overlay__social">


### PR DESCRIPTION
### Motivation
- Ensure all global CTA buttons that previously targeted `index.html#contact` or `#contact` navigate to the dedicated contact page at `/contact.html` so links are consistent site-wide.

### Description
- Replaced `href="index.html#contact"`, `href="/index.html#contact"` and global CTA `href="#contact"` (on `index.html`) with `href="/contact.html"` across the site, modifying only `href` values and leaving classes, text, layout and JS-related attributes untouched.
- Files updated: `index.html`, `erga.html`, `anakainiseis-athina.html`, `anakainisi-spitiou-athina.html`, `anakainisi-kouzinas-athina.html`, `contact.html`, `cookie-policy.html`, `privacy-policy.html`, and `terms.html`.
- Total links changed: 24.
- Verified that no `href="index.html#contact"`, `href="/index.html#contact"` or `href="#contact"` CTA targets remain after the change and that all CTAs now point to `/contact.html`.

### Testing
- Located original targets with `rg -n 'href="(index\.html#contact|#contact)"' --glob '*.html' .` and `rg -n 'href="/index\.html#contact"' --glob '*.html' .` and confirmed matches before replacement.
- Ran a small Python script to perform the replacements and count occurrences, which reported `TOTAL 24` replacements and updated the listed files.
- Confirmed all new targets with `rg -n 'href="/contact\.html"' --glob '*.html' .` and inspected affected lines with `nl -ba <file>` to ensure only `href` attributes changed.
- All automated checks succeeded and no remaining old CTA targets were found.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0414c08f883209b1e530015e08217)