### PR TITLE
Add premium hero CTA buttons to main landing pages

### DIFF
--- a/anakainiseis-athina.html
+++ b/anakainiseis-athina.html
@@ -298,6 +298,14 @@
       <div class="athens-hero__inner container">
         <span class="athens-hero__eyebrow">FM Renovation • Ανακαινίσεις Αθήνα &amp; Αττική</span>
         <h1 id="athens-hero-title">Ανακαινίσεις στην Αθήνα με συνέπεια, ασφάλεια και ποιοτικά υλικά</h1>
+        <div class="hero-cta">
+          <a href="/contact.html" class="btn btn-primary">
+            Ζητήστε Δωρεάν Εκτίμηση
+          </a>
+          <a href="/contact.html" class="btn btn-secondary">
+            Επικοινωνήστε μαζί μας
+          </a>
+        </div>
         <p>Αναλαμβάνουμε ανακαίνιση σπιτιού στην Αθήνα, ολικές και μερικές παρεμβάσεις, με σωστό συντονισμό συνεργείων, καθαρή κοστολόγηση και αποτέλεσμα που αναβαθμίζει ουσιαστικά την αξία και τη λειτουργικότητα του χώρου σας.</p>
         <div class="athens-hero__actions">
           <a href="index.html#contact" class="btn btn--primary">Ζητήστε Προσφορά</a>

--- a/anakainisi-kouzinas-athina.html
+++ b/anakainisi-kouzinas-athina.html
@@ -301,6 +301,14 @@
         <div class="container kitchen-hero__inner">
           <span class="kitchen-kicker">FM Renovation • Ανακαίνιση κουζίνας Αθήνα &amp; Αττική</span>
           <h1 id="kitchen-hero-title">Ανακαίνιση Κουζίνας στην Αθήνα</h1>
+          <div class="hero-cta">
+            <a href="/contact.html" class="btn btn-primary">
+              Ζητήστε Δωρεάν Εκτίμηση
+            </a>
+            <a href="/contact.html" class="btn btn-secondary">
+              Επικοινωνήστε μαζί μας
+            </a>
+          </div>
           <p>Δημιουργούμε κουζίνες που συνδυάζουν εργονομία, σύγχρονη αισθητική και υλικά υψηλής αντοχής, με ολοκληρωμένη οργάνωση έργου από τη μελέτη μέχρι την τελική παράδοση. Αν αναζητάτε κουζίνα ανακαίνιση Αθήνα ή μοντέρνα ανακαίνιση κουζίνας Αττική, σχεδιάζουμε λύσεις προσαρμοσμένες στις πραγματικές ανάγκες του χώρου σας.</p>
           <div class="kitchen-actions">
             <a href="contact.html" class="btn btn--primary">Ζητήστε Προσφορά</a>

--- a/anakainisi-spitiou-athina.html
+++ b/anakainisi-spitiou-athina.html
@@ -638,6 +638,14 @@
         <div class="service-hero__content reveal">
           <span class="service-eyebrow">Premium service page • Αθήνα &amp; Αττική</span>
           <h1>Ολική Ανακαίνιση Κατοικίας στην Αθήνα</h1>
+          <div class="hero-cta">
+            <a href="/contact.html" class="btn btn-primary">
+              Ζητήστε Δωρεάν Εκτίμηση
+            </a>
+            <a href="/contact.html" class="btn btn-secondary">
+              Επικοινωνήστε μαζί μας
+            </a>
+          </div>
           <p>Η FM Renovation αναλαμβάνει πλήρεις ανακαινίσεις κατοικιών στην Αθήνα και όλη την Αττική, με οργανωμένη διαχείριση έργου, εξειδικευμένα συνεργεία και υλικά που αναβαθμίζουν την αισθητική, τη λειτουργικότητα και την αξία του ακινήτου σας.</p>
           <div class="service-hero__actions">
             <a href="contact.html" class="btn btn--primary">Ζητήστε Προσφορά</a>

--- a/assets/style.css
+++ b/assets/style.css
@@ -148,6 +148,14 @@ body.nav-open{overflow:hidden}
 .cta-group .btn{width:100%;justify-content:center}
 .hero .btn{border-color:rgba(255,255,255,.35)}
 .hero .btn--ghost{background:rgba(255,255,255,.12);color:#fff}
+.hero-cta{display:flex;gap:16px;margin-top:24px;flex-wrap:wrap}
+.hero-cta .btn{animation:none}
+.hero-cta .btn-primary{background:var(--accent);color:#fff;border-color:var(--accent);box-shadow:0 6px 16px rgba(245,158,11,.35);font-weight:700}
+.hero-cta .btn-primary:hover,
+.hero-cta .btn-primary:focus-visible{background:var(--bg);color:var(--text);border-color:var(--accent-2);transform:translateY(-1px);box-shadow:var(--shadow);outline:none}
+.hero-cta .btn-secondary{background:rgba(255,255,255,.12);color:#fff;border-color:rgba(255,255,255,.35)}
+.hero-cta .btn-secondary:hover,
+.hero-cta .btn-secondary:focus-visible{background:#fff;color:var(--text);border-color:#fff;outline:none}
 
 /* About */
 .about-grid{display:grid;gap:20px}
@@ -248,6 +256,10 @@ body.nav-open{overflow:hidden}
 .contact-widget__link:focus-visible{outline:0;box-shadow:0 0 0 3px var(--ring)}
 .contact-widget__icon{display:inline-flex;align-items:center;justify-content:center;width:32px;height:32px;line-height:1}
 .contact-widget__icon img{width:100%;height:100%}
+
+@media (max-width: 768px) {
+  .hero-cta{flex-direction:column;align-items:flex-start}
+}
 
 @media (prefers-reduced-motion: reduce){
   .back-to-top{transition:none !important;transform:none !important}

--- a/index.html
+++ b/index.html
@@ -182,6 +182,14 @@
       <div class="container hero-inner">
         <div class="hero-copy">
           <h2 class="hero-title">Ολική ή μερική ανακαίνιση οικίας και επαγγελματικού χώρου</h2>
+          <div class="hero-cta">
+            <a href="/contact.html" class="btn btn-primary">
+              Ζητήστε Δωρεάν Εκτίμηση
+            </a>
+            <a href="/contact.html" class="btn btn-secondary">
+              Επικοινωνήστε μαζί μας
+            </a>
+          </div>
           <p class="tagline">Με τεχνική ακρίβεια, συνέπεια και διαφάνεια.</p>
         </div>
       </div>


### PR DESCRIPTION
### Motivation
- Improve conversions by adding a clear two-button CTA under the hero title on all main pages while preserving the premium minimal design and existing layout.

### Description
- Inserted the requested CTA block (`<div class="hero-cta">…</div>`) directly below the main hero heading in `index.html`, `anakainiseis-athina.html`, `anakainisi-spitiou-athina.html`, and `anakainisi-kouzinas-athina.html` so both buttons link to `/contact.html`.
- Added minimal, scoped styles to `assets/style.css` for `.hero-cta`, `.btn-primary`, and `.btn-secondary` so buttons are side-by-side on desktop with a `gap:16px` and stack vertically on mobile via `@media (max-width: 768px)`.
- Kept all existing hero structure, header, navigation, and page-specific action groups unchanged and avoided global CSS modifications by scoping rules to `.hero-cta`.

### Testing
- Ran content/regex checks with `rg` to verify the new `div.hero-cta` block and both `href="/contact.html"` occurrences in the four updated pages, and the checks succeeded.
- Used `git diff` to confirm only the intended files changed and reviewed the diff, which matched the expected insertions, and the check succeeded.
- Verified repository state with `git status --short` and committed the changes with the message `Add hero CTA buttons to main pages`, and the commit succeeded.
- Visual screenshot/browser render tests were not executed in this environment (no browser tool available).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0425567008320a25601f00bc5fc1f)