### PR TITLE
Center Athens hero CTA buttons

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -149,6 +149,8 @@ body.nav-open{overflow:hidden}
 .hero .btn{border-color:rgba(255,255,255,.35)}
 .hero .btn--ghost{background:rgba(255,255,255,.12);color:#fff}
 .hero-cta{display:flex;gap:16px;margin-top:24px;flex-wrap:wrap}
+.athens-hero .hero-cta{justify-content:center;align-items:center;text-align:center}
+.athens-hero .hero-cta a{text-align:center}
 .hero-cta .btn{animation:none}
 .hero-cta .btn-primary{background:var(--accent);color:#fff;border-color:var(--accent);box-shadow:0 6px 16px rgba(245,158,11,.35);font-weight:700}
 .hero-cta .btn-primary:hover,


### PR DESCRIPTION
### Motivation
- Center the hero CTA buttons only on the Athens landing page (`anakainiseis-athina.html`) so they align visually under the hero text without changing global styles, HTML structure, or mobile behavior.

### Description
- Added scoped CSS in `assets/style.css`: `.athens-hero .hero-cta { justify-content: center; align-items: center; text-align: center; }` and `.athens-hero .hero-cta a { text-align: center; }` to center the CTA row exclusively for the `.athens-hero` section.

### Testing
- Located selectors with `rg`, applied the CSS change, and verified the edit and commit with `git diff -- assets/style.css`, `git status --short`, and `git show --stat --oneline --decorate=short HEAD`, all commands succeeded and the existing mobile `@media` stacking remains unchanged.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0493e66c48320be7e38e66af27924)