### PR TITLE
Replace portfolio preview images on Athens landing pages

### DIFF
--- a/anakainiseis-athina.html
+++ b/anakainiseis-athina.html
@@ -85,7 +85,7 @@
     .athens-step h3{margin:0;font-size:1.06rem;color:var(--accent-2)}
     .athens-step p{margin:0;color:#475569;line-height:1.7}
     .athens-projects{display:grid;gap:24px;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));align-items:center}
-    .athens-projects__media{min-height:280px;border-radius:26px;background:linear-gradient(135deg,rgba(15,23,42,.12),rgba(245,158,11,.22)),url('erga/ampelokipoi12.webp') center/cover no-repeat;box-shadow:0 18px 36px rgba(15,23,42,.12)}
+    .athens-projects__media{min-height:280px;border-radius:26px;background:linear-gradient(135deg,rgba(15,23,42,.12),rgba(245,158,11,.22)),url('erga/renovation2.webp') center/cover no-repeat;box-shadow:0 18px 36px rgba(15,23,42,.12)}
     .athens-faq{display:grid;gap:14px;max-width:900px;margin:0 auto}
     .athens-faq details{padding:0 22px}
     .athens-faq summary{cursor:pointer;list-style:none;padding:20px 0;font-weight:700;color:var(--accent-2)}

--- a/anakainisi-kouzinas-athina.html
+++ b/anakainisi-kouzinas-athina.html
@@ -452,7 +452,7 @@
           </div>
         </div>
         <div class="kitchen-projects__media reveal" aria-hidden="true">
-          <img src="erga/ampelokipoi12.webp" alt="" loading="lazy">
+          <img src="photos/fm3.webp" alt="" loading="lazy">
         </div>
       </div>
     </section>

--- a/anakainisi-spitiou-athina.html
+++ b/anakainisi-spitiou-athina.html
@@ -816,7 +816,7 @@
           </div>
         </div>
         <figure class="service-projects__media reveal">
-          <img src="erga/ampelokipoi12.webp" width="1200" height="900" alt="Ολοκληρωμένο έργο ανακαίνισης κατοικίας της FM Renovation στην Αττική" loading="lazy" decoding="async">
+          <img src="erga/floor1.webp" width="1200" height="900" alt="Ολοκληρωμένο έργο ανακαίνισης κατοικίας της FM Renovation στην Αττική" loading="lazy" decoding="async">
         </figure>
       </div>
     </section>


### PR DESCRIPTION
### Motivation
- Update only the specific portfolio/projects preview images on three Athens landing pages to use the requested existing assets while keeping layout, classes, ids and texts unchanged.

### Description
- In `anakainiseis-athina.html` updated the background image used by `.athens-projects__media` from `erga/ampelokipoi12.webp` to `erga/renovation2.webp` and left all CSS rules intact. 
- In `anakainisi-spitiou-athina.html` replaced the single `<img>` in the preview `figure.service-projects__media` from `erga/ampelokipoi12.webp` to `erga/floor1.webp` while preserving `width`, `height`, `alt`, `loading` and `decoding` attributes. 
- In `anakainisi-kouzinas-athina.html` replaced the single `<img>` in `.kitchen-projects__media` from `erga/ampelokipoi12.webp` to `photos/fm3.webp` while preserving `loading="lazy"` and existing styling. 
- Only one preview image reference was changed per page and no other markup, classes, ids, dimensions or text were modified. 

### Testing
- Verified the requested asset files exist via `rg --files` and found `erga/renovation2.webp`, `erga/floor1.webp` and `photos/fm3.webp` successfully. 
- Confirmed the targeted elements and single occurrences using `rg -n` and inspected the exact lines with `nl -ba`/`sed`, and the checks matched the intended replacements. 
- Validated the change scope with `git diff -- anakainiseis-athina.html anakainisi-spitiou-athina.html anakainisi-kouzinas-athina.html` and `rg -n` for the new/old image paths, all of which showed only the three intended substitutions and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0511614608320a0292f534bbb1c1b)