### PR TITLE
Fix Athens portfolio preview image path

### DIFF
--- a/anakainiseis-athina.html
+++ b/anakainiseis-athina.html
@@ -85,7 +85,7 @@
     .athens-step h3{margin:0;font-size:1.06rem;color:var(--accent-2)}
     .athens-step p{margin:0;color:#475569;line-height:1.7}
     .athens-projects{display:grid;gap:24px;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));align-items:center}
-    .athens-projects__media{min-height:280px;border-radius:26px;background:linear-gradient(135deg,rgba(15,23,42,.12),rgba(245,158,11,.22)),url('erga/renovation2.webp') center/cover no-repeat;box-shadow:0 18px 36px rgba(15,23,42,.12)}
+    .athens-projects__media{min-height:280px;border-radius:26px;background:linear-gradient(135deg,rgba(15,23,42,.12),rgba(245,158,11,.22)),url('erga/renovation-home.webp') center/cover no-repeat;box-shadow:0 18px 36px rgba(15,23,42,.12)}
     .athens-faq{display:grid;gap:14px;max-width:900px;margin:0 auto}
     .athens-faq details{padding:0 22px}
     .athens-faq summary{cursor:pointer;list-style:none;padding:20px 0;font-weight:700;color:var(--accent-2)}


### PR DESCRIPTION
### Motivation
- Correct the background image used for the Athens portfolio/projects preview so the intended image is displayed without changing layout or styles.

### Description
- Replaced the background-image URL in `anakainiseis-athina.html` from `url('erga/renovation2.webp')` to `url('erga/renovation-home.webp')` on line 88 and made no other edits.

### Testing
- Verified with `rg`, a small Python replace script, `git diff`, `nl -ba`, and a commit; the replacement was applied, `erga/renovation-home.webp` exists, and all automated checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0568c96108320bc5ade41e82fc67b)