### PR TITLE
Replace homepage contact form with premium CTA

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -197,19 +197,18 @@ body.nav-open{overflow:hidden}
 
 /* Contact section */
 .contact-section{background:#f8f8f8;padding:80px 20px;text-align:center}
-.contact-intro{max-width:640px;margin:0 auto 32px;color:#333}
-.contact-form{max-width:640px;margin:0 auto;display:flex;flex-direction:column;gap:16px;text-align:left;background:#fff;border:1px solid #e8edf4;border-radius:16px;padding:32px;box-shadow:var(--shadow)}
-#contactForm{display:flex;flex-direction:column;gap:16px}
-.contact{display:grid;grid-template-columns:minmax(0,1fr);gap:28px;align-items:start}
-.form-group label{font-weight:600;margin-bottom:6px;display:block}
-.form-group input,.form-group textarea,.form-group select{width:100%;padding:12px 14px;border:1px solid #cfd3d9;border-radius:10px;font:inherit}
-.form-group input:focus,.form-group textarea:focus,.form-group select:focus{outline:none;border-color:var(--accent,#F59E0B);box-shadow:0 0 0 3px rgba(245,158,11,.2)}
-.btn-submit{background:var(--accent,#F59E0B);color:#fff;border:0;padding:14px 20px;border-radius:10px;font-weight:600;cursor:pointer;transition:.25s}
-.btn-submit:hover{background:#e48e0a;transform:translateY(-1px)}
-.form-status{margin-top:8px;font-size:.95rem}
-.gdpr{display:block;font-size:.95rem}
-.gdpr a{color:var(--accent,#F59E0B);text-decoration:underline}
-.map iframe{display:block;width:100%;min-height:360px;border:0;border-radius:14px;box-shadow:var(--shadow)}
+.contact-intro{max-width:720px;margin:0 auto;color:#334155;line-height:1.7}
+.contact-cta-block{max-width:760px;margin:0 auto;padding:40px 32px;background:linear-gradient(145deg,#ffffff 0%,#f8fafc 100%);border:1px solid rgba(15,23,42,.08);border-radius:28px;box-shadow:0 24px 48px rgba(15,23,42,.1);display:grid;gap:20px;justify-items:center}
+.contact-cta-block__eyebrow{display:inline-flex;align-items:center;justify-content:center;padding:8px 14px;border-radius:999px;background:rgba(245,158,11,.12);color:#b45309;font-size:.85rem;font-weight:700;letter-spacing:.08em;text-transform:uppercase}
+.contact-cta-block h2{margin:0;font-size:clamp(1.9rem,3vw,2.5rem);color:var(--accent-2)}
+.contact-cta-block__actions{display:flex;flex-wrap:wrap;gap:14px;justify-content:center}
+.contact-cta-block__actions .btn{animation:none;min-width:min(100%,260px)}
+
+@media (max-width: 640px){
+  .contact-cta-block{padding:32px 20px;border-radius:22px}
+  .contact-cta-block__actions{flex-direction:column;width:100%}
+  .contact-cta-block__actions .btn{width:100%}
+}
 
 /* Footer */
 .site-footer{border-top:1px solid #e8edf4;padding:20px 0;background:#fff}

--- a/index.html
+++ b/index.html
@@ -466,73 +466,17 @@
       </div>
     </section>
 
-    <!-- CONTACT + MAP -->
+    <!-- CONTACT CTA -->
     <section id="contact" class="section contact-section">
-      <div class="container contact">
-        <div class="contact-form">
-          <h2>Επικοινωνία</h2>
-          <p class="contact-intro">Στείλτε μας ένα μήνυμα και θα επικοινωνήσουμε μαζί σας το συντομότερο.</p>
-
-          <form id="contactForm" action="https://formspree.io/f/mkgqykrp" method="POST">
-            <div class="form-group">
-              <label for="name">Ονοματεπώνυμο</label>
-              <input id="name" name="name" type="text" placeholder="Πλήρες όνομα" required>
-            </div>
-
-            <div class="form-group">
-              <label for="email">Email</label>
-              <input id="email" name="email" type="email" placeholder="Το email σας" required>
-            </div>
-
-            <div class="form-group">
-              <label for="phone">Τηλέφωνο</label>
-              <input id="phone" name="phone" type="tel" inputmode="tel" placeholder="Π.χ. 2101234567">
-            </div>
-
-            <div class="form-group">
-              <label for="service">Υπηρεσία</label>
-              <select id="service" name="service">
-                <option value="">Επιλέξτε υπηρεσία (προαιρετικό)</option>
-                <option>Γκρεμίσματα / αποξηλώσεις</option>
-                <option>Χτισίματα – σοβατίσματα – ελαιοχρωματισμοί</option>
-                <option>Υδραυλικές εργασίες</option>
-                <option>Ηλεκτρολογικές εργασίες – Υ.Δ.Ε.</option>
-                <option>Κουφώματα αλουμινίου / PVC</option>
-                <option>Πλακίδια – Δάπεδα</option>
-                <option>Γυψοσανίδες – Ψευδοροφές</option>
-                <option>Μονώσεις</option>
-                <option>Άλλο</option>
-              </select>
-            </div>
-
-            <div class="form-group">
-              <label for="message">Μήνυμα</label>
-              <textarea id="message" name="message" rows="5" placeholder="Πείτε μας λίγα λόγια για το έργο…" required></textarea>
-            </div>
-
-            <!-- GDPR -->
-            <label class="gdpr">
-              <input type="checkbox" name="gdpr" required>
-              Συμφωνώ με την <a href="/privacy-policy.html" target="_blank" rel="noopener">Πολιτική Απορρήτου</a>.
-            </label>
-
-            <!-- Honeypot (spam trap) -->
-            <input type="text" name="_gotcha" style="display:none">
-
-            <!-- Subject & Reply-To -->
-            <input type="hidden" name="_subject" value="Νέο μήνυμα από τη φόρμα – FM Renovation">
-            <input type="hidden" name="_replyto" value="{{email}}">
-
-            <!-- <div class="g-recaptcha" data-sitekey="YOUR_RECAPTCHA_SITE_KEY"></div> -->
-
-            <button type="submit" class="btn-submit">Αποστολή Μηνύματος</button>
-
-            <!-- Inline feedback -->
-            <p id="form-status" class="form-status" aria-live="polite" hidden></p>
-          </form>
-        </div>
-        <div class="map">
-          <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3146.316254805402!2d23.698714476547654!3d37.94640100225389!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x66d032e1e4d0f22b%3A0x2808a708424de056!2zRk0gUmVub3ZhdGlvbiAtIM6Rzr3Osc66zrHOr869zrnPg863IM-Hz47Pgc6_z4U!5e0!3m2!1sel!2sgr!4v1764374951391!5m2!1sel!2sgr" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
+      <div class="container">
+        <div class="contact-cta-block">
+          <span class="contact-cta-block__eyebrow">FM Renovation</span>
+          <h2>Επικοινωνήστε μαζί μας</h2>
+          <p class="contact-intro">Είμαστε στη διάθεσή σας για ολικές και μερικές ανακαινίσεις στην Αθήνα και όλη την Αττική. Ζητήστε δωρεάν εκτίμηση ή μεταβείτε στη σελίδα επικοινωνίας.</p>
+          <div class="contact-cta-block__actions">
+            <a href="/contact.html" class="btn btn--primary">Ζητήστε Δωρεάν Εκτίμηση</a>
+            <a href="/contact.html" class="btn btn--ghost">Μετάβαση στη σελίδα επικοινωνίας</a>
+          </div>
         </div>
       </div>
     </section>


### PR DESCRIPTION
### Motivation
- Replace the heavy contact form + embedded map on the homepage with a cleaner premium CTA that routes users to `/contact.html` while preserving layout, styles and responsiveness. 
- Keep header/navigation/footer and other sections unchanged and reuse existing site button styles to maintain visual consistency. 

### Description
- Removed the full contact form and embedded map from the homepage `index.html` and replaced the homepage contact area with a compact CTA block containing the requested heading `Επικοινωνήστε μαζί μας`, the short descriptive text, a primary button `Ζητήστε Δωρεάν Εκτίμηση` and a secondary button `Μετάβαση στη σελίδα επικοινωνίας`, both linking to `/contact.html` and reusing existing button classes (`btn`, `btn--primary`, `btn--ghost`).
- Added minimal, scoped CSS in `assets/style.css` for `.contact-cta-block`, `.contact-cta-block__eyebrow`, and `.contact-cta-block__actions` plus a small mobile media query to preserve balance and responsiveness. 
- Files changed: `index.html` and `assets/style.css`.
- No named skill from the session's skill list was used; changes were applied directly following the project instructions.

### Testing
- Ran a Python assertion that verified `index.html` no longer contains `#contactForm` or the old Formspree `action` and confirmed both CTA buttons point to `/contact.html` (assertions passed). 
- Reviewed `git diff` for `index.html` and `assets/style.css` to inspect the HTML/CSS changes (diff reviewed and is as intended). 
- Confirmed commit recorded with the updated files (automated `git` status/commit check succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c05a4423cc83208db297f5f6e77a5a)