### PR TITLE
Fix contact page address language

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -311,7 +311,7 @@
             </li>
             <li>
               <strong>Διεύθυνση</strong>
-              <span>Doiranis 180, Kallithea</span>
+              <span>Δοϊράνης 180, Καλλιθέα</span>
             </li>
             <li>
               <span class="hours-title">Ώρες λειτουργίας</span>


### PR DESCRIPTION
### Motivation
- Replace the visible address on the contact page from an English transliteration to the proper Greek spelling while preserving the existing HTML structure, classes, and layout.

### Description
- In `contact.html` replaced `Doiranis 180, Kallithea` with `Δοϊράνης 180, Καλλιθέα` as a single visible text-only change.

### Testing
- Verified the change with a small `python` check, inspected the output of `git diff -- contact.html`, and committed the file with `git commit`, all of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c05c2d336c83208df14a544f3dd573)