### PR TITLE
Replace homepage contact form with CTA

### DIFF
--- a/index.html
+++ b/index.html
@@ -469,67 +469,21 @@
     <!-- CONTACT + MAP -->
     <section id="contact" class="section contact-section">
       <div class="container contact">
-        <div class="contact-form">
-          <h2>Επικοινωνία</h2>
-          <p class="contact-intro">Στείλτε μας ένα μήνυμα και θα επικοινωνήσουμε μαζί σας το συντομότερο.</p>
-
-          <form id="contactForm" action="https://formspree.io/f/mkgqykrp" method="POST">
-            <div class="form-group">
-              <label for="name">Ονοματεπώνυμο</label>
-              <input id="name" name="name" type="text" placeholder="Πλήρες όνομα" required>
-            </div>
-
-            <div class="form-group">
-              <label for="email">Email</label>
-              <input id="email" name="email" type="email" placeholder="Το email σας" required>
-            </div>
-
-            <div class="form-group">
-              <label for="phone">Τηλέφωνο</label>
-              <input id="phone" name="phone" type="tel" inputmode="tel" placeholder="Π.χ. 2101234567">
-            </div>
-
-            <div class="form-group">
-              <label for="service">Υπηρεσία</label>
-              <select id="service" name="service">
-                <option value="">Επιλέξτε υπηρεσία (προαιρετικό)</option>
-                <option>Γκρεμίσματα / αποξηλώσεις</option>
-                <option>Χτισίματα – σοβατίσματα – ελαιοχρωματισμοί</option>
-                <option>Υδραυλικές εργασίες</option>
-                <option>Ηλεκτρολογικές εργασίες – Υ.Δ.Ε.</option>
-                <option>Κουφώματα αλουμινίου / PVC</option>
-                <option>Πλακίδια – Δάπεδα</option>
-                <option>Γυψοσανίδες – Ψευδοροφές</option>
-                <option>Μονώσεις</option>
-                <option>Άλλο</option>
-              </select>
-            </div>
-
-            <div class="form-group">
-              <label for="message">Μήνυμα</label>
-              <textarea id="message" name="message" rows="5" placeholder="Πείτε μας λίγα λόγια για το έργο…" required></textarea>
-            </div>
-
-            <!-- GDPR -->
-            <label class="gdpr">
-              <input type="checkbox" name="gdpr" required>
-              Συμφωνώ με την <a href="/privacy-policy.html" target="_blank" rel="noopener">Πολιτική Απορρήτου</a>.
-            </label>
-
-            <!-- Honeypot (spam trap) -->
-            <input type="text" name="_gotcha" style="display:none">
-
-            <!-- Subject & Reply-To -->
-            <input type="hidden" name="_subject" value="Νέο μήνυμα από τη φόρμα – FM Renovation">
-            <input type="hidden" name="_replyto" value="{{email}}">
-
-            <!-- <div class="g-recaptcha" data-sitekey="YOUR_RECAPTCHA_SITE_KEY"></div> -->
-
-            <button type="submit" class="btn-submit">Αποστολή Μηνύματος</button>
-
-            <!-- Inline feedback -->
-            <p id="form-status" class="form-status" aria-live="polite" hidden></p>
-          </form>
+        <div class="contact-form contact-cta__box">
+          <span class="contact-cta__tag">FM RENOVATION</span>
+          <h2>Επικοινωνήστε μαζί μας</h2>
+          <p class="contact-intro">
+            Είμαστε στη διάθεσή σας για ολικές και μερικές ανακαινίσεις στην Αθήνα και όλη την Αττική.
+            Ζητήστε δωρεάν εκτίμηση ή μεταβείτε στη σελίδα επικοινωνίας.
+          </p>
+          <div class="contact-cta__actions">
+            <a href="/contact.html" class="btn btn-primary">
+              Ζητήστε Δωρεάν Εκτίμηση
+            </a>
+            <a href="/contact.html" class="btn btn-secondary">
+              Μετάβαση στη σελίδα επικοινωνίας
+            </a>
+          </div>
         </div>
         <div class="map">
           <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3146.316254805402!2d23.698714476547654!3d37.94640100225389!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x66d032e1e4d0f22b%3A0x2808a708424de056!2zRk0gUmVub3ZhdGlvbiAtIM6Rzr3Osc66zrHOr869zrnPg863IM-Hz47Pgc6_z4U!5e0!3m2!1sel!2sgr!4v1764374951391!5m2!1sel!2sgr" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>


### PR DESCRIPTION
### Motivation
- Replace the homepage-embedded contact form with a simple call-to-action that points users to the full contact page while preserving page layout and spacing.
- Ensure all existing form logic, the dedicated `contact.html` page, header/footer/navigation and other site areas remain unchanged.

### Description
- Remove the inline form markup inside the `<section id="contact" class="section contact-section">` in `index.html` and insert a CTA block using classes `contact-cta__box`, `contact-cta__tag`, and `contact-cta__actions` with the requested Greek copy and two links to `/contact.html`.
- Preserve the surrounding container and the embedded map iframe so layout, spacing and visual balance remain intact.
- Only `index.html` was modified and no JavaScript or server/form logic files were changed.

### Testing
- Ran assertions to confirm `index.html` no longer contains the homepage form identifier `id="contactForm"` and now contains the CTA text `Επικοινωνήστε μαζί μας`.
- Verified the map iframe remains present in `index.html` and that the site structure (header/footer/navigation) was not altered by the change.
- Reviewed the file diff to ensure only `index.html` was affected and the replacement is limited to the form block on the homepage.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c06293e0e08320bb23c4ff421e2b39)