### PR TITLE
Scoped override for homepage contact CTA button colors

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -210,11 +210,11 @@ body.nav-open{overflow:hidden}
 .gdpr{display:block;font-size:.95rem}
 .gdpr a{color:var(--accent,#F59E0B);text-decoration:underline}
 .map iframe{display:block;width:100%;min-height:360px;border:0;border-radius:14px;box-shadow:var(--shadow)}
-.contact-cta__box .contact-cta__actions .btn{animation:none}
-.contact-cta__box .contact-cta__actions .btn-primary{background:#C2A85D;color:#ffffff;border:none;box-shadow:none}
-.contact-cta__box .contact-cta__actions .btn-primary:hover,.contact-cta__box .contact-cta__actions .btn-primary:focus-visible{background:#a68d4a;color:#ffffff;border:none;box-shadow:none;outline:none}
-.contact-cta__box .contact-cta__actions .btn-secondary{background:transparent;color:#C2A85D;border:1px solid #C2A85D;box-shadow:none}
-.contact-cta__box .contact-cta__actions .btn-secondary:hover,.contact-cta__box .contact-cta__actions .btn-secondary:focus-visible{background:#C2A85D;color:#ffffff;border-color:#C2A85D;outline:none}
+.contact-section .contact-cta__box .contact-cta__actions > .btn{animation:none}
+.contact-section .contact-cta__box .contact-cta__actions > .btn.btn-primary{background:#C2A85D !important;color:#ffffff !important;border:none !important;box-shadow:none !important}
+.contact-section .contact-cta__box .contact-cta__actions > .btn.btn-primary:hover,.contact-section .contact-cta__box .contact-cta__actions > .btn.btn-primary:focus-visible{background:#a68d4a !important;color:#ffffff !important;border:none !important;box-shadow:none !important;outline:none}
+.contact-section .contact-cta__box .contact-cta__actions > .btn.btn-secondary{background:transparent !important;color:#C2A85D !important;border:1px solid #C2A85D !important;box-shadow:none !important}
+.contact-section .contact-cta__box .contact-cta__actions > .btn.btn-secondary:hover,.contact-section .contact-cta__box .contact-cta__actions > .btn.btn-secondary:focus-visible{background:#C2A85D !important;color:#ffffff !important;border-color:#C2A85D !important;box-shadow:none !important;outline:none}
 
 /* Footer */
 .site-footer{border-top:1px solid #e8edf4;padding:20px 0;background:#fff}


### PR DESCRIPTION
### Motivation
- Ensure the two CTA buttons inside the homepage "Επικοινωνήστε μαζί μας" block use the exact brand colors and hover states regardless of broader or conflicting button rules. 
- Keep the fix strictly scoped to the homepage contact CTA block and avoid changing hero buttons, contact page, layout, spacing, text, hrefs, or button structure.

### Description
- Modified `assets/style.css` to add a stronger, scoped selector targeting the homepage CTA actions: `.contact-section .contact-cta__box .contact-cta__actions > .btn.btn-primary` and `.contact-section .contact-cta__box .contact-cta__actions > .btn.btn-secondary` including their `:hover` and `:focus-visible` variants. 
- Applied the requested styles inside that scope and used `!important` only within this scope to ensure the rules win over less-specific/global button styles while leaving global `.btn-primary` and `.btn-secondary` definitions untouched. 
- The scoped rules force Primary to `background: #C2A85D; color: #ffffff; border: none` with hover `background: #a68d4a; color: #ffffff`, and Secondary to `background: transparent; color: #C2A85D; border: 1px solid #C2A85D` with hover `background: #C2A85D; color: #ffffff`, overriding generic `.btn`/shared button color behavior. 
- Only `assets/style.css` was changed and `index.html`/`contact.html` markup and layout were left intact, so hero buttons and contact page remain unaffected. 

### Testing
- Ran `git diff -- assets/style.css index.html` to confirm the CSS change is scoped and present, and the check succeeded. 
- Inspected the updated CSS snippet with `nl -ba assets/style.css | sed -n '206,223p'` to verify the exact selectors and rules were written, and the inspection succeeded. 
- Ran `git status --short` to confirm a single file was modified, and the check succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c06b03309c8320993cdc81dae2ac58)