### PR TITLE
Add unified MasterEat footer credit across all HTML pages

### DIFF
--- a/anakainiseis-athina.html
+++ b/anakainiseis-athina.html
@@ -517,6 +517,10 @@
           <a href="/anakainiseis-athina.html">Ανακαινίσεις Αθήνα</a>
         </nav>
         <p class="footer-copy">© <span id="year"></span> FM Renovation • <a href="https://anakainisou.gr/">anakainisou.gr</a></p>
+        <p class="me-credit">
+          Crafted by <a href="https://mastereat.gr" target="_blank" rel="noopener noreferrer">MasterEat</a><br>
+          Digital Growth & Web Solutions
+        </p>
       </div>
       <div class="footer-social">
         <h3 class="footer-heading">Ακολουθήστε μας</h3>

--- a/anakainisi-kouzinas-athina.html
+++ b/anakainisi-kouzinas-athina.html
@@ -527,6 +527,10 @@
           <a href="/anakainiseis-athina.html">Ανακαινίσεις Αθήνα</a>
         </nav>
         <p class="footer-copy">© <span id="year"></span> FM Renovation • <a href="https://anakainisou.gr/">anakainisou.gr</a></p>
+        <p class="me-credit">
+          Crafted by <a href="https://mastereat.gr" target="_blank" rel="noopener noreferrer">MasterEat</a><br>
+          Digital Growth & Web Solutions
+        </p>
       </div>
       <div class="footer-social">
         <h3 class="footer-heading">Ακολουθήστε μας</h3>

--- a/anakainisi-spitiou-athina.html
+++ b/anakainisi-spitiou-athina.html
@@ -891,6 +891,10 @@
           <a href="/anakainiseis-athina.html">Ανακαινίσεις Αθήνα</a>
         </nav>
         <p class="footer-copy">© <span id="year"></span> FM Renovation • <a href="https://anakainisou.gr/">anakainisou.gr</a></p>
+        <p class="me-credit">
+          Crafted by <a href="https://mastereat.gr" target="_blank" rel="noopener noreferrer">MasterEat</a><br>
+          Digital Growth & Web Solutions
+        </p>
       </div>
       <div class="footer-social">
         <h3 class="footer-heading">Ακολουθήστε μας</h3>

--- a/assets/style.css
+++ b/assets/style.css
@@ -237,6 +237,7 @@ body.nav-open{overflow:hidden}
 .footer-links a:hover::after,.footer-links a:focus-visible::after{opacity:1;transform:scaleX(1)}
 .footer-links a:focus-visible{outline:0;box-shadow:0 0 0 3px var(--ring)}
 .footer-copy{margin:0;font-size:.95rem}
+.me-credit{text-align:center;font-size:12px;margin-top:10px;opacity:.7}
 .brand--footer{margin:0}
 .brand--footer .brand-logo{height:56px}
 .site-footer .social{margin-left:0}

--- a/contact.html
+++ b/contact.html
@@ -427,6 +427,10 @@
           <a href="anakainiseis-athina.html">Ανακαινίσεις Αθήνα</a>
         </nav>
         <p class="footer-copy">© <span id="year"></span> FM Renovation • <a href="https://anakainisou.gr/">anakainisou.gr</a></p>
+        <p class="me-credit">
+          Crafted by <a href="https://mastereat.gr" target="_blank" rel="noopener noreferrer">MasterEat</a><br>
+          Digital Growth & Web Solutions
+        </p>
       </div>
       <div class="footer-social">
         <h3 class="footer-heading">Ακολουθήστε μας</h3>

--- a/cookie-policy.html
+++ b/cookie-policy.html
@@ -147,6 +147,10 @@
         </a>
       </div>
       <p>© <span id="year"></span> FM Renovation • <a href="https://anakainisou.gr/">anakainisou.gr</a> • <a href="/anakainiseis-athina.html">Ανακαινίσεις Αθήνα</a></p>
+      <p class="me-credit">
+        Crafted by <a href="https://mastereat.gr" target="_blank" rel="noopener noreferrer">MasterEat</a><br>
+        Digital Growth & Web Solutions
+      </p>
       <div class="social">
         <a href="https://www.facebook.com/share/1CJUXM8xkk/" aria-label="Facebook" class="icon fb" target="_blank" rel="noopener noreferrer"></a>
         <a href="https://www.instagram.com/fm.renovation21/" aria-label="Instagram" class="icon ig"></a>

--- a/erga.html
+++ b/erga.html
@@ -177,6 +177,10 @@
           <a href="/anakainiseis-athina.html">Ανακαινίσεις Αθήνα</a>
         </nav>
         <p class="footer-copy">© <span id="year"></span> FM Renovation • <a href="https://anakainisou.gr/">anakainisou.gr</a></p>
+        <p class="me-credit">
+          Crafted by <a href="https://mastereat.gr" target="_blank" rel="noopener noreferrer">MasterEat</a><br>
+          Digital Growth & Web Solutions
+        </p>
       </div>
       <div class="footer-social">
         <h3 class="footer-heading">Ακολουθήστε μας</h3>

--- a/index.html
+++ b/index.html
@@ -561,6 +561,10 @@
           <a href="/anakainiseis-athina.html">Ανακαινίσεις Αθήνα</a>
         </nav>
         <p class="footer-copy">© <span id="year"></span> FM Renovation • <a href="https://anakainisou.gr/">anakainisou.gr</a></p>
+        <p class="me-credit">
+          Crafted by <a href="https://mastereat.gr" target="_blank" rel="noopener noreferrer">MasterEat</a><br>
+          Digital Growth & Web Solutions
+        </p>
       </div>
       <div class="footer-social">
         <h3 class="footer-heading">Ακολουθήστε μας</h3>

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -114,6 +114,10 @@
         </a>
       </div>
       <p>© <span id="year"></span> FM Renovation • <a href="https://anakainisou.gr/">anakainisou.gr</a> • <a href="/anakainiseis-athina.html">Ανακαινίσεις Αθήνα</a></p>
+      <p class="me-credit">
+        Crafted by <a href="https://mastereat.gr" target="_blank" rel="noopener noreferrer">MasterEat</a><br>
+        Digital Growth & Web Solutions
+      </p>
       <div class="social">
         <a href="https://www.facebook.com/share/1CJUXM8xkk/" aria-label="Facebook" class="icon fb" target="_blank" rel="noopener noreferrer"></a>
         <a href="https://www.instagram.com/fm.renovation21/" aria-label="Instagram" class="icon ig"></a>

--- a/terms.html
+++ b/terms.html
@@ -113,6 +113,10 @@
         </a>
       </div>
       <p>© <span id="year"></span> FM Renovation • <a href="https://anakainisou.gr/">anakainisou.gr</a> • <a href="/anakainiseis-athina.html">Ανακαινίσεις Αθήνα</a></p>
+      <p class="me-credit">
+        Crafted by <a href="https://mastereat.gr" target="_blank" rel="noopener noreferrer">MasterEat</a><br>
+        Digital Growth & Web Solutions
+      </p>
       <div class="social">
         <a href="https://www.facebook.com/share/1CJUXM8xkk/" aria-label="Facebook" class="icon fb" target="_blank" rel="noopener noreferrer"></a>
         <a href="https://www.instagram.com/fm.renovation21/" aria-label="Instagram" class="icon ig"></a>


### PR DESCRIPTION
### Motivation
- Add a single, premium footer credit block for MasterEat across every page to present a consistent digital partner credit for a construction/renovation business. 
- Keep placement and visual hierarchy unchanged and avoid modifying existing branding, layout, colors or spacing.

### Description
- Inserted the provided `.me-credit` HTML block immediately after the copyright paragraph inside each page's `<footer>`, replacing any existing `.me-credit` blocks and ensuring only one instance per page. 
- Added a minimal, safe CSS rule for `.me-credit` in `assets/style.css` to maintain consistent, mobile-friendly rendering: `text-align:center;font-size:12px;margin-top:10px;opacity:.7`.
- Changes apply to the site root, service pages and legal pages: `index.html`, `contact.html`, `anakainiseis-athina.html`, `anakainisi-kouzinas-athina.html`, `anakainisi-spitiou-athina.html`, `erga.html`, `privacy-policy.html`, `terms.html`, `cookie-policy.html`, and `assets/style.css`.

### Testing
- Located and inspected HTML files with `rg` (ripgrep) to find footers and occurrences of `©` and `class="me-credit"`, and the checks reported one `me-credit` per file. 
- Ran a validation Python script (`python - <<'PY' ...`) that confirmed each HTML file contains exactly one `class="me-credit"` and that the block resides inside the `<footer>`, which succeeded. 
- Performed spot checks with `sed`/`nl` to verify the credit lines are immediately after the copyright paragraphs, and those checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c312a7f2888320b0d4b0b5daa89788)